### PR TITLE
Add GitHub Actions CI via BestieTemplate

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,12 @@
+# Changes here will be overwritten by Copier
+Authors: Yakir Gagnon <12.yakir@gmail.com> and contributors
+JuliaMinVersion: '1.11'
+License: MIT
+LicenseCopyrightHolders: Yakir Gagnon
+PackageName: Fromage
+PackageOwner: yakir12
+PackageUUID: f7d2997e-1be8-4771-a487-05d70e6e0672
+StrategyConfirmIncluded: false
+StrategyLevel: 0
+StrategyReviewExcluded: false
+_src_path: /home/yakir/.julia/packages/BestieTemplate/6QVd6

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,51 @@
+# CompatHelper v3.5.0
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: 0 0 * * * # Every day at 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: Use Julia cache
+        uses: julia-actions/cache@v2
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}

--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -1,0 +1,52 @@
+name: Reusable test
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+        default: "1"
+      os:
+        required: false
+        type: string
+        default: ubuntu-latest
+      arch:
+        required: false
+        type: string
+        default: x64
+      allow_failure:
+        required: false
+        type: boolean
+        default: false
+      run_codecov:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      codecov_token:
+        required: true
+
+jobs:
+  test:
+    name: Julia ${{ inputs.version }} - ${{ inputs.os }} - ${{ inputs.arch }} - ${{ github.event_name }}
+    runs-on: ${{ inputs.os }}
+    continue-on-error: ${{ inputs.allow_failure }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ inputs.version }}
+          arch: ${{ inputs.arch }}
+      - name: Use Julia cache
+        uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+        if: ${{ inputs.run_codecov }}
+      - uses: codecov/codecov-action@v4
+        if: ${{ inputs.run_codecov }}
+        with:
+          file: lcov.info
+          token: ${{ secrets.codecov_token }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,37 @@
+name: TagBot
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        type: number
+        default: 3
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+    tags: ["*"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/ReusableTest.yml
+    with:
+      os: ${{ matrix.os }}
+      version: ${{ matrix.version }}
+      arch: ${{ matrix.arch }}
+      allow_failure: ${{ matrix.allow_failure }}
+      run_codecov: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.11"
+          - "1"
+        os:
+          - ubuntu-latest
+          
+          
+        arch:
+          - x64
+        allow_failure: [false]

--- a/.github/workflows/TestOnPRs.yml
+++ b/.github/workflows/TestOnPRs.yml
@@ -1,0 +1,29 @@
+name: Test on PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "test/**"
+      - "*.toml"
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test:
+    uses: ./.github/workflows/ReusableTest.yml
+    with:
+      os: ubuntu-latest
+      version: "1"
+      arch: x64
+      allow_failure: false
+      run_codecov: true
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/TestOnPRs.yml
+++ b/.github/workflows/TestOnPRs.yml
@@ -8,6 +8,7 @@ on:
       - "src/**"
       - "test/**"
       - "*.toml"
+      - ".github/workflows/**"
     types: [opened, synchronize, reopened]
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@
 /docs/build/
 /deps/downloads/
 /deps/src/
+
+# added by BestieTemplate
+*.rej
+.DS_Store
+.benchmarkci
+benchmark/*.json
+coverage
+env
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Fromage 🧀
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://yakir12.github.io/Fromage.jl/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://yakir12.github.io/Fromage.jl/dev/)
-[![Build Status](https://github.com/yakir12/Fromage.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/yakir12/Fromage.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://coveralls.io/repos/github/yakir12/Fromage.jl/badge.svg?branch=main)](https://coveralls.io/github/yakir12/Fromage.jl?branch=main)
+[![Test workflow status](https://github.com/yakir12/Fromage.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/yakir12/Fromage.jl/actions/workflows/Test.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/yakir12/Fromage.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/yakir12/Fromage.jl)
+[![BestieTemplate](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/JuliaBesties/BestieTemplate.jl/main/docs/src/assets/badge.json)](https://github.com/JuliaBesties/BestieTemplate.jl)
 
 This is the main package used to organise, calibrate, and track video files in the Dacke lab.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+# See https://docs.codecov.com/docs/codecovyml-reference for details
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        target: 90%
+  range: "80...90" # Yellow within this range


### PR DESCRIPTION
Applies BestieTemplate (Tiny strategy) to give Fromage a functioning CI, without touching source, README content, tests, `Project.toml`, or `LICENSE`.

**Adopted**
- `Test.yml` / `TestOnPRs.yml` / `ReusableTest.yml` — run the suite on Julia **1.11** and **1** (ubuntu-latest), on push to `main` and on PRs, with codecov upload.
- `CompatHelper.yml` — PRs to bump `[compat]`.
- `TagBot.yml` — release tagging once registered.
- `dependabot.yml` — weekly updates of the GitHub Actions.

**Skipped** (per preference): Runic formatting / pre-commit / format-check, the Documenter docs site, and the template's test scaffolding (the consolidated `test/runtests.jl` + `quality.jl` Aqua/ExplicitImports checks are kept).

This PR exists so the CI runs and is validated before it lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
