### PR TITLE
Save the failing extrinsic frame to results_dir/issues on detection failure

### DIFF
--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -59,6 +59,10 @@ function get_corners(file, t, vf, w, h, n_corners)
     _detect_corners(reshape(img, 1, h, w), n_corners)
 end
 
+# The frame at `t` as a `Gray` image — the same deinterlaced/blurred frame corner detection sees.
+# Used to save a failing calibration's extrinsic frame to the issues folder for inspection.
+extrinsic_gray_frame(file, t, vf, w, h) = colorview(Gray, normedview(_frame_at(file, t, vf, w, h)))
+
 function extract_intrinsics(file, start, stop, temporal_step, vf, w, h, n_corners)
     ts = start:temporal_step:stop
     corners = tmap(t -> get_corners(file, t, vf, w, h, n_corners), ts)

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -1,9 +1,10 @@
 module VerifyRectifications
 
 using CSV: CSV
-using ..Rectifications: get_corners, _vf
+using ..Rectifications: get_corners, _vf, extrinsic_gray_frame
 import ..Rectifications: Rectification
 using ..PawsomeTracker: PawsomeTracker, ApriltagRectification
+using FileIO: FileIO
 using Chain: Chain, @chain
 using DataFramesMeta: DataFramesMeta, @groupby, @rtransform!, @transform!, AbstractDataFrame,
     ByRow, Cols, DataFrame, Not, allowmissing!, completecases, dropmissing, groupby,
@@ -24,14 +25,16 @@ include("types.jl")
 include("parsers.jl")
 include("verifications.jl")
 
-function load_rectifications(file; strict = true, defaults = (;))
+# `issues_dir` is where the extrinsic frame of a calibration that fails checkerboard/AprilTag
+# detection is dumped for inspection (see `verifications!`); it is emptied at the start of every run.
+function load_rectifications(file; strict = true, defaults = (;), issues_dir = joinpath("results_dir", "issues"))
     data_path = dirname(file)
-    load_rectifications(data_path, file; strict, defaults)
+    load_rectifications(data_path, file; strict, defaults, issues_dir)
 end
 
 # `defaults` globally replaces the hardcoded fallbacks of the whitelisted rectification parameters
 # (see DEFAULTS in parsers.jl); the hierarchy is csv cell → `defaults` → hardcoded/probed value.
-function load_rectifications(data_path, file; strict = true, defaults = (;))
+function load_rectifications(data_path, file; strict = true, defaults = (;), issues_dir = joinpath("results_dir", "issues"))
     defaults = resolve_defaults(defaults)   # fail fast on unknown keys / unconvertible values
     # verify csv file exists
     if !isfile(file)
@@ -57,7 +60,7 @@ function load_rectifications(data_path, file; strict = true, defaults = (;))
     df = DataFrame(Tables.dictrowtable(cs))
     allowmissing!(df)
 
-    verifications!(df, data_path)
+    verifications!(df, data_path, issues_dir)
 
     if any(!isempty, df.issues)
         msg = join([string("row $i: ", join(issues, ", ")) for (i, issues) in enumerate(df.issues) if !isempty(issues)], '\n')

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -248,7 +248,29 @@ function extrinsic_issue(file, extrinsic, yadif, blur, width, height, n_corners)
     end
 end
 
-function verify_extrinsics!(df::AbstractDataFrame)
+# Save the frame that failed detection into `issues_dir` (created on demand) for the user to inspect,
+# named by the video and extrinsic timestamp — e.g. `board_t1.0s.png`. `get_frame` reads the frame
+# lazily; the whole thing is best effort (if the frame itself can't be re-read, e.g. a corrupt file,
+# saving is skipped and `nothing` is returned).
+function save_issue_frame(issues_dir, file, extrinsic, get_frame)
+    try
+        image = get_frame()
+        mkpath(issues_dir)
+        path = joinpath(issues_dir, string(first(splitext(basename(file))), "_t", extrinsic, "s.png"))
+        FileIO.save(path, image)
+        return path
+    catch
+        return nothing
+    end
+end
+
+# Append a "saved the frame to ..." note to an issue message, after dumping the failing frame.
+function note_saved_frame(issue, saved)
+    isnothing(saved) && return issue
+    return string(issue, " — saved the extrinsic frame to ", saved, " for inspection")
+end
+
+function verify_extrinsics!(df::AbstractDataFrame, issues_dir)
     # :file is the canonical resolved path, so grouping on it corner-detects a file reached via different
     # spellings once per (extrinsic, blur, n_corners).
     gs = @chain df begin
@@ -256,11 +278,13 @@ function verify_extrinsics!(df::AbstractDataFrame)
         dropmissing([:file, :extrinsic, :blur, :n_corners], view = true)
         @groupby [:file, :extrinsic, :yadif, :blur, :width, :height, :n_corners]
     end
-    issues = @showprogress desc = "Validating extrinsics..." tmap(k -> extrinsic_issue(k.file, k.extrinsic, k.yadif, k.blur, k.width, k.height, k.n_corners), keys(gs))
-    for (g, issue) in zip(gs, issues)
-        if !isnothing(issue)
-            @transform! g :extrinsic = missing :issues = push!.(:issues, issue)
-        end
+    ks = collect(keys(gs))
+    issues = @showprogress desc = "Validating extrinsics..." tmap(k -> extrinsic_issue(k.file, k.extrinsic, k.yadif, k.blur, k.width, k.height, k.n_corners), ks)
+    for (g, k, issue) in zip(gs, ks, issues)
+        isnothing(issue) && continue
+        # dump the frame the detector saw (deinterlaced/blurred) so the user can see what went wrong
+        saved = save_issue_frame(issues_dir, k.file, k.extrinsic, () -> extrinsic_gray_frame(k.file, k.extrinsic, _vf(k.yadif, k.blur), k.width, k.height))
+        @transform! g :extrinsic = missing :issues = push!.(:issues, note_saved_frame(issue, saved))
     end
 end
 
@@ -307,16 +331,20 @@ end
 # must be detectable and their metric fit must converge (coplanar, not mis-detected). Reads real
 # frames, so it runs on the reduced set of otherwise-clean apriltag rows, grouped so a physical file
 # reached via different spellings is checked once per (extrinsic, apriltags, family, checker_size).
-function verify_apriltag_extrinsics!(df::AbstractDataFrame)
+function verify_apriltag_extrinsics!(df::AbstractDataFrame, issues_dir)
     gs = @chain df begin
         subset(:type => ByRow(passmissing(==("apriltag"))), view = true, skipmissing = true)
         subset(:issues => ByRow(isempty), view = true)
         dropmissing([:file, :extrinsic, :apriltags, :family, :checker_size], view = true)
         @groupby [:file, :extrinsic, :apriltags, :family, :checker_size]
     end
-    issues = @showprogress desc = "Validating AprilTag extrinsics..." tmap(k -> PawsomeTracker.apriltag_extrinsic_issue(k.file, k.extrinsic, k.apriltags, k.family, k.checker_size), keys(gs))
-    for (g, issue) in zip(gs, issues)
-        isnothing(issue) || @transform! g :extrinsic = missing :issues = push!.(:issues, issue)
+    ks = collect(keys(gs))
+    issues = @showprogress desc = "Validating AprilTag extrinsics..." tmap(k -> PawsomeTracker.apriltag_extrinsic_issue(k.file, k.extrinsic, k.apriltags, k.family, k.checker_size), ks)
+    for (g, k, issue) in zip(gs, ks, issues)
+        isnothing(issue) && continue
+        # dump the extrinsic frame the tag detector saw so the user can see what went wrong
+        saved = save_issue_frame(issues_dir, k.file, k.extrinsic, () -> collect(PawsomeTracker.read_frame_at(k.file, k.extrinsic)))
+        @transform! g :extrinsic = missing :issues = push!.(:issues, note_saved_frame(issue, saved))
     end
 end
 
@@ -358,7 +386,11 @@ function verify_unique_calibrations!(df::AbstractDataFrame)
     end
 end
 
-function verifications!(df::AbstractDataFrame, data_path)
+function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath("results_dir", "issues"))
+
+    # The issues folder is fully transient: it reflects only the current verification run, so wipe it
+    # up front (it is recreated lazily by save_issue_frame the first time a frame fails to detect).
+    rm(issues_dir; recursive = true, force = true)
 
     verify_unique_ids!(df)
     @transform! df :path = passmissing(joinpath).(data_path, :path)
@@ -428,14 +460,14 @@ function verifications!(df::AbstractDataFrame, data_path)
     verify!(df, (t, a, o) -> (o - a) ÷ t + 1 < 3, "temporal_step too short (results in less than 3 intrinsic images)", :temporal_step, :start, :stop)
 
     # verify that the extrinsic time stamp works (should only be done after extrinsic time-stamps have been verified
-    verify_extrinsics!(df)
+    verify_extrinsics!(df, issues_dir)
 
     # the calibs window must actually contain ≥ 3 detectable-corner frames; runs after
     # verify_extrinsics! so rows whose extrinsic already failed are skipped, not re-scanned
     verify_intrinsics!(df)
 
     # apriltag rows: the extrinsic frame must yield a valid shared reference (tags detectable + coplanar)
-    verify_apriltag_extrinsics!(df)
+    verify_apriltag_extrinsics!(df, issues_dir)
 
     verify_unique_calibrations!(df)
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -41,7 +41,7 @@ function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.c
 
     mkpath(results_dir)
 
-    cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults)
+    cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults, issues_dir = joinpath(results_dir, "issues"))
     rs = load_runs(joinpath(data_path, runs_file); defaults = tracking_defaults)
 
     if !isnothing(run_ids)
@@ -93,7 +93,7 @@ end
 function only_rectify(data_path::String; calibs_file = "calibs.csv", rectification_defaults = (;), calibration_ids = nothing)
     mkpath(results_dir)
 
-    cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults)
+    cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults, issues_dir = joinpath(results_dir, "issues"))
 
     if !isnothing(calibration_ids)
         filter!(c -> c.calibration_id ∈ calibration_ids, cs)

--- a/test/VerifyRectifications/helpers.jl
+++ b/test/VerifyRectifications/helpers.jl
@@ -131,9 +131,12 @@ mixedrow(; kw...) = _merge((calibration_id = "x", path = ".", file = ART.mixed, 
 "Write `rows` to a CSV in DATADIR and load it. Scenario rows keep indices 1:length(rows).
 (`parse_row` back-fills every COLUMNS entry with missing, so even a single-type CSV has every
 column `verifications!` references — no column-completing filler rows are needed.)"
-function check(name, rows; strict = false, header = HEADER, defaults = (;))
+# `issues_dir` defaults to a fresh temp dir so failure scenarios (which now dump the failing
+# extrinsic frame) don't write into the test's working directory; a test that inspects the dumped
+# frames passes an explicit path.
+function check(name, rows; strict = false, header = HEADER, defaults = (;), issues_dir = mktempdir())
     csv = write_csv(joinpath(DATADIR, name), rows; header)
-    VRect.load_rectifications(DATADIR, csv; strict, defaults)
+    VRect.load_rectifications(DATADIR, csv; strict, defaults, issues_dir)
 end
 
 # A clean load returns Vector{RectificationMethod}; a load with issues keeps the df's :issues.

--- a/test/VerifyRectifications/test_extrinsics.jl
+++ b/test/VerifyRectifications/test_extrinsics.jl
@@ -20,4 +20,17 @@
         df = check("e_corrupt.csv", [videorow(file = ART.corrupt)])
         @test flagged(df, 1, "issue with corner detection")
     end
+
+    @testset "a failing extrinsic frame is dumped to the issues folder" begin
+        idir = mktempdir()
+        # a stale file proves the folder is wiped at the start of each run
+        touch(joinpath(idir, "stale.png"))
+        df = check("e_dump.csv", [videorow(file = ART.video, n_corners = (5, 8))]; issues_dir = idir)
+        @test flagged(df, 1, "no corners detected")
+        @test flagged(df, 1, "saved the extrinsic frame")          # the message points at the file
+        pngs = filter(endswith(".png"), readdir(idir))
+        @test !("stale.png" in pngs)                               # emptied at the start of the run
+        @test length(pngs) == 1                                    # exactly the one failing frame
+        @test filesize(joinpath(idir, only(pngs))) > 0             # a real, non-empty image
+    end
 end

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -149,6 +149,22 @@ end
     @test isfile(diag) && filesize(diag) > 0
 end
 
+@testset "AprilTag calibration: failing extrinsic frame is dumped to the issues folder" begin
+    # the video has four tags; asking for six fails detection at the extrinsic frame, and the frame
+    # is dumped to the issues folder (pointed at a temp dir) for the user to inspect.
+    dir = mktempdir(); idir = mktempdir()
+    vid, _, _, _ = make_apriltag_video(dir, "drone")
+    open(joinpath(dir, "calibs.csv"), "w") do io
+        println(io, "calibration_id,type,file,extrinsic,apriltags,family,checker_size")
+        println(io, "drone,apriltag,$vid,0,6,tag36h11,12")
+    end
+    df = Fromage.VerifyRectifications.load_rectifications(dir, joinpath(dir, "calibs.csv"); strict = false, issues_dir = idir)
+    @test any(m -> occursin("only 4 of 6 AprilTags", m), only(df.issues))
+    @test any(m -> occursin("saved the extrinsic frame", m), only(df.issues))
+    pngs = filter(endswith(".png"), readdir(idir))
+    @test length(pngs) == 1 && filesize(joinpath(idir, only(pngs))) > 0
+end
+
 @testset "diagnostic video: multi-run, mixed calibrations" begin
     # All three rectification kinds in one pipeline run: two only_scale rectifications on
     # different-sized source videos (which used to produce a broken mixed-resolution diagnostic —


### PR DESCRIPTION
When a `calibs.csv` row fails to detect the checkerboard (video) or the AprilTags (apriltag) at its `extrinsic` timestamp, dump the extracted frame to an `issues/` folder so the failure can be inspected, and point the reported issue at the file.

**Behaviour**
- Saves the frame the detector actually saw — deinterlaced/blurred for video, raw for apriltag.
- Location: `results_dir/issues/` (an `issues_dir` kwarg on `load_rectifications`; `main` passes it, tests use a temp dir).
- **Transient:** the folder is wiped at the start of every verification run and recreated lazily on the first failure, so it only ever reflects the latest run.
- Filename `<video>_t<timestamp>s.png`; the issue message gains `— saved the extrinsic frame to <path> for inspection`.
- Best effort: if the frame can't be re-read (corrupt file), saving is skipped and the original issue still reports.

**Tests** cover the dump for both the checkerboard and AprilTag paths, including that the folder is emptied at the start of a run. Full suite green (830).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
