### PR TITLE
Serialize AprilTag detection — detector is not reentrant (fixes calib + tracking races)

### DIFF
--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -33,6 +33,16 @@ const GATE_DECAY = 0.99
 
 export track, ApriltagRectification
 
+# VideoIO.openvideo (libav's demuxer/codec open) is not thread-safe: concurrent opens race — badly so
+# on a cold network share, where the open path is slow enough to widen the window (it silently yields
+# garbled/wrong frames, not an error). Decoding independent streams IS safe, so we serialize only the
+# open and let every seek/read/decode run concurrently. This guards both the extrinsic-frame reads
+# (`read_frame_at`, run under `tmap` in verification and rectification building) and the per-run
+# tracking opens (the `Video` constructor); the open is fast, so serializing it costs essentially
+# nothing against the decode that follows.
+const OPENVIDEO_LOCK = ReentrantLock()
+open_gray_video(file) = lock(() -> openvideo(file; target_format = AV_PIX_FMT_GRAY8), OPENVIDEO_LOCK)
+
 include("diagnose.jl")
 include("apriltag.jl")
 
@@ -109,7 +119,7 @@ struct Video
     sar::Rational
 
     function Video(file, fps, start, stop, scale)
-        vid = openvideo(file; target_format = AV_PIX_FMT_GRAY8)
+        vid = open_gray_video(file)          # serialized open (openvideo isn't thread-safe); see OPENVIDEO_LOCK
         vid_fps = framerate(vid)
         fps = min(fps, vid_fps)
         skip = round(Int, vid_fps / fps)

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -43,11 +43,12 @@ export track, ApriltagRectification
 const OPENVIDEO_LOCK = ReentrantLock()
 open_gray_video(file) = lock(() -> openvideo(file; target_format = AV_PIX_FMT_GRAY8), OPENVIDEO_LOCK)
 
-# Establishing an AprilTag reference frame (a one-shot VideoIO read + the AprilTag C detector) is not
-# thread-safe: run under the verification / rectification-building `tmap` over many calibrations it
-# silently corrupts frames (tags "vanish") and can even segfault the process. Serializing only the
-# video open is NOT enough — the detection itself is unsafe. Reference building is one-time setup over
-# a handful of calibs, so we serialize it wholesale; per-run tracking is unaffected. See reference_frame.
+# The AprilTag C detector (`apriltag_detector_detect`) is not reentrant: it has global/static state
+# that concurrent calls corrupt — even distinct, per-thread detectors on distinct frames race
+# (verified: fresh-per-task, pre-created-per-frame, and pooled-per-thread all fail concurrently while
+# serial detection is clean), and under enough pressure it segfaults. So every detection call is
+# serialized process-wide through this lock (see `detect_locked`); this covers both the calibration
+# reference building AND per-run tracking. Reads/decode stay concurrent — only the detect is serial.
 const APRILTAG_LOCK = ReentrantLock()
 
 include("diagnose.jl")

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -43,6 +43,13 @@ export track, ApriltagRectification
 const OPENVIDEO_LOCK = ReentrantLock()
 open_gray_video(file) = lock(() -> openvideo(file; target_format = AV_PIX_FMT_GRAY8), OPENVIDEO_LOCK)
 
+# Establishing an AprilTag reference frame (a one-shot VideoIO read + the AprilTag C detector) is not
+# thread-safe: run under the verification / rectification-building `tmap` over many calibrations it
+# silently corrupts frames (tags "vanish") and can even segfault the process. Serializing only the
+# video open is NOT enough — the detection itself is unsafe. Reference building is one-time setup over
+# a handful of calibs, so we serialize it wholesale; per-run tracking is unaffected. See reference_frame.
+const APRILTAG_LOCK = ReentrantLock()
+
 include("diagnose.jl")
 include("apriltag.jl")
 

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -176,21 +176,17 @@ end
 # of `family`, take the `ntags` lowest ids, and fit the metric map from their known cell geometry
 # (`fit_metric` throws if the tags are not coplanar / were mis-detected).
 function reference_frame(file, extrinsic, ntags, family, checker_size)
-    # Serialize the whole read+detect: concurrent AprilTag detection here corrupts/crashes (see
-    # APRILTAG_LOCK). One-time per calib, so the serial cost is negligible.
-    lock(APRILTAG_LOCK) do
-        img = read_frame_at(file, extrinsic)
-        det = set_detector!(AprilTagDetector(april_family(family)))
-        try
-            tags = det(collect(img))
-            length(tags) ≥ ntags || error("only $(length(tags)) of $ntags AprilTags detected at the extrinsic frame")
-            ids = sort(getfield.(tags, :id))[1:ntags]
-            tc = detect_tags(det, img, ids)
-            isnothing(tc) && error("could not read all $ntags AprilTag corners at the extrinsic frame")
-            ReferenceFrame(ids, tc; canon = canon_square(family, checker_size))
-        finally
-            freeDetector!(det)
-        end
+    img = read_frame_at(file, extrinsic)
+    det = set_detector!(AprilTagDetector(april_family(family)))
+    try
+        tags = detect_locked(det, collect(img))     # serialized: the detector is not reentrant
+        length(tags) ≥ ntags || error("only $(length(tags)) of $ntags AprilTags detected at the extrinsic frame")
+        ids = sort(getfield.(tags, :id))[1:ntags]
+        tc = detect_tags(det, img, ids)
+        isnothing(tc) && error("could not read all $ntags AprilTag corners at the extrinsic frame")
+        return ReferenceFrame(ids, tc; canon = canon_square(family, checker_size))
+    finally
+        freeDetector!(det)
     end
 end
 
@@ -271,11 +267,18 @@ function set_detector!(det; nthreads = 1)
     return det
 end
 
+# `apriltag_detector_detect` (the C detector) is NOT reentrant: it has global/static state that
+# concurrent calls corrupt — even distinct, per-thread detectors on distinct frames race (verified
+# three ways), and under enough pressure it segfaults. So EVERY detection call goes through this,
+# which serializes them process-wide via APRILTAG_LOCK. Reads/decode stay concurrent; only the
+# (comparatively cheap) detect is serial.
+detect_locked(det, img) = lock(() -> det(img), APRILTAG_LOCK)
+
 # Detect and return the 16 corners grouped per tag, aligned to `ids` order (each tag's `.p` corners
 # as [col, row]); `nothing` if any expected id is absent. `SVector`-typed so the geometry consumes
 # them directly.
 function detect_tags(det, img, ids)
-    tags = det(collect(img))
+    tags = detect_locked(det, collect(img))
     byid = Dict(t.id => t for t in tags)
     all(haskey(byid, i) for i in ids) || return nothing
     [SVector{2,Float64}[SVector(p[1], p[2]) for p in byid[i].p] for i in ids]
@@ -306,7 +309,7 @@ end
 function find_tag_roi(det, img, id, box, sz)
     r1, c1, r2, c2 = box
     while true
-        tags = det(collect(@view img[r1:r2, c1:c2]))
+        tags = detect_locked(det, collect(@view img[r1:r2, c1:c2]))
         k = findfirst(t -> t.id == id, tags)
         if k !== nothing
             corners = SVector{2,Float64}[SVector(p[1] + c1 - 1, p[2] + r1 - 1) for p in tags[k].p]
@@ -319,13 +322,11 @@ function find_tag_roi(det, img, id, box, sz)
 end
 
 # detect all tags by per-tag local search, updating `boxes` in place; corners aligned to `ids`
-# order, or `nothing` if any tag is not found anywhere in the frame. PHASE 5: the tags are
-# independent, so each is searched concurrently on its OWN detector (`dets[k]`) — the AprilTag C
-# detector is not safe to share across threads, and each reads a disjoint crop of the (read-only)
-# frame, so the searches compose cleanly.
+# order, or `nothing` if any tag is not found anywhere in the frame. Detection is SEQUENTIAL: the
+# AprilTag C detector is not reentrant (see detect_locked), so every detect is serialized process-
+# wide anyway — spawning one task per tag would only contend on that lock, for no gain.
 function detect_tags_roi!(dets, img, ids, boxes, sz)
-    tasks = [Threads.@spawn find_tag_roi(dets[k], img, ids[k], boxes[k], sz) for k in eachindex(ids)]
-    results = fetch.(tasks)
+    results = [find_tag_roi(dets[k], img, ids[k], boxes[k], sz) for k in eachindex(ids)]
     any(r -> isnothing(first(r)), results) && return nothing
     for k in eachindex(ids); boxes[k] = results[k][2]; end
     return [first(results[k]) for k in eachindex(ids)]

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -162,7 +162,7 @@ end
 # Read the single frame at timestamp `t` (seconds), in the same orientation `track_apriltag` sees
 # frames in, so reference and run corners correspond directly.
 function read_frame_at(file, t)
-    vid = openvideo(file; target_format = AV_PIX_FMT_GRAY8)
+    vid = open_gray_video(file)   # serialized open (openvideo isn't thread-safe); see OPENVIDEO_LOCK
     try
         read(vid)                 # prime a frame so gettime returns the stream's base time
         seek(vid, t + gettime(vid))

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -176,17 +176,21 @@ end
 # of `family`, take the `ntags` lowest ids, and fit the metric map from their known cell geometry
 # (`fit_metric` throws if the tags are not coplanar / were mis-detected).
 function reference_frame(file, extrinsic, ntags, family, checker_size)
-    img = read_frame_at(file, extrinsic)
-    det = set_detector!(AprilTagDetector(april_family(family)))
-    try
-        tags = det(collect(img))
-        length(tags) ≥ ntags || error("only $(length(tags)) of $ntags AprilTags detected at the extrinsic frame")
-        ids = sort(getfield.(tags, :id))[1:ntags]
-        tc = detect_tags(det, img, ids)
-        isnothing(tc) && error("could not read all $ntags AprilTag corners at the extrinsic frame")
-        return ReferenceFrame(ids, tc; canon = canon_square(family, checker_size))
-    finally
-        freeDetector!(det)
+    # Serialize the whole read+detect: concurrent AprilTag detection here corrupts/crashes (see
+    # APRILTAG_LOCK). One-time per calib, so the serial cost is negligible.
+    lock(APRILTAG_LOCK) do
+        img = read_frame_at(file, extrinsic)
+        det = set_detector!(AprilTagDetector(april_family(family)))
+        try
+            tags = det(collect(img))
+            length(tags) ≥ ntags || error("only $(length(tags)) of $ntags AprilTags detected at the extrinsic frame")
+            ids = sort(getfield.(tags, :id))[1:ntags]
+            tc = detect_tags(det, img, ids)
+            isnothing(tc) && error("could not read all $ntags AprilTag corners at the extrinsic frame")
+            ReferenceFrame(ids, tc; canon = canon_square(family, checker_size))
+        finally
+            freeDetector!(det)
+        end
     end
 end
 

--- a/todo.md
+++ b/todo.md
@@ -18,3 +18,13 @@ Parked ideas and follow-ups, so they don't get lost.
   raw `vid.img` each frame with a `collect` conversion instead of reusing the stack slices. If the
   frames stayed `N0f8` (or the stack slices were detector-compatible), detection could run directly
   on the stack. Check whether the DoG path (imfilter, background subtraction) tolerates `N0f8`.
+
+## Performance / tooling
+
+- **Set up PkgBenchmark for regression tracking.** Add a `benchmark/benchmarks.jl` `BenchmarkGroup`
+  (wraps BenchmarkTools) covering representative operations — a rectification build on a synthetic
+  checkerboard, a short synthetic track — so `PkgBenchmark.judge(Fromage, "branch", "main")` reports
+  how much a change moved performance. `BenchmarkCI.jl` can run it in Actions and comment on PRs (the
+  BestieTemplate `.gitignore` already carries a `.benchmarkci` entry). Caveat: environment-specific
+  costs like concurrent VideoIO opens over a network share won't show up in a portable/synthetic
+  suite — those need timing on the real data + mount.


### PR DESCRIPTION
AprilTag calibrations spuriously failed detection (*"0 of 4 AprilTags"*) on frames that clearly show all four tags, nondeterministically — and concurrent detection could **segfault** the process.

**Root cause (definitive):** `apriltag_detector_detect` (the C detector) is **not reentrant**. On identical, clean, pre-read, in-memory frames:

| detection | result |
| --- | --- |
| sequential | clean |
| concurrent, fresh detector per task | 9–17/31 fail, random |
| concurrent, pre-created detector per frame | 12–20 fail, random |
| concurrent, pooled one detector per thread | 5–16 fail, random |

So the race is **global state inside the C library**, not detector sharing or reads — and it affects **tracking** too (`track_apriltag`'s phase-5 `@spawn` per tag, and concurrent runs), not just the calibration build.

**Fix:** a single `detect_locked()` choke point serializes every detector call through `APRILTAG_LOCK` — used by `detect_tags`, `find_tag_roi`, and `reference_frame`, covering calibration reference-building **and** per-run tracking. Reads/decode stay concurrent (frame-accurate, verified), so only the cheap `detect` serializes. `detect_tags_roi!` is now sequential (the `@spawn` only contended on the lock). `OPENVIDEO_LOCK` is kept for the tracking video opens.

Verified on the real dataset: concurrent detection and three consecutive full `load_rectifications` runs are clean and deterministic (only the one genuinely-marginal calib). Full suite green (830).

*Perf note:* detection now serializes across concurrent runs during tracking (it's on small ROI crops, so cheap, but multi-run tracking could become somewhat detection-bound — a candidate for the parked PkgBenchmark work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


(Supersedes #7, which got stuck on a stale head ref.)