### PR TITLE
Serialize AprilTag reference read+detect at 32 threads; handle missing coords in save2csv

### DIFF
--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -176,17 +176,24 @@ end
 # of `family`, take the `ntags` lowest ids, and fit the metric map from their known cell geometry
 # (`fit_metric` throws if the tags are not coplanar / were mis-detected).
 function reference_frame(file, extrinsic, ntags, family, checker_size)
-    img = read_frame_at(file, extrinsic)
-    det = set_detector!(AprilTagDetector(april_family(family)))
-    try
-        tags = detect_locked(det, collect(img))     # serialized: the detector is not reentrant
-        length(tags) ≥ ntags || error("only $(length(tags)) of $ntags AprilTags detected at the extrinsic frame")
-        ids = sort(getfield.(tags, :id))[1:ntags]
-        tc = detect_tags(det, img, ids)
-        isnothing(tc) && error("could not read all $ntags AprilTag corners at the extrinsic frame")
-        return ReferenceFrame(ids, tc; canon = canon_square(family, checker_size))
-    finally
-        freeDetector!(det)
+    # Serialize the WHOLE read + detect. Two separate hazards, both under the verification /
+    # rectification-building `tmap` at high thread counts on a cold network share: the one-shot VideoIO
+    # read (open+seek+read) races and returns garbled/wrong frames, and the AprilTag detector is not
+    # reentrant. Reference building is one-time setup over a handful of calibs, so serializing it costs
+    # essentially nothing. (Per-run tracking keeps concurrent decode; only its detection is serialized.)
+    lock(APRILTAG_LOCK) do
+        img = read_frame_at(file, extrinsic)
+        det = set_detector!(AprilTagDetector(april_family(family)))
+        try
+            tags = det(collect(img))                # already holding APRILTAG_LOCK
+            length(tags) ≥ ntags || error("only $(length(tags)) of $ntags AprilTags detected at the extrinsic frame")
+            ids = sort(getfield.(tags, :id))[1:ntags]
+            tc = detect_tags(det, img, ids)         # re-enters the lock (re-entrant), fine
+            isnothing(tc) && error("could not read all $ntags AprilTag corners at the extrinsic frame")
+            ReferenceFrame(ids, tc; canon = canon_square(family, checker_size))
+        finally
+            freeDetector!(det)
+        end
     end
 end
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -19,13 +19,19 @@ end
 # kinds a pixel→real map, for AprilTag a metric ground map carrying the same centre/north gauge — so
 # the origin is at `center`, north-aligned when `north` was given, in `checker_size`/`scale` units.
 # Axis orientation follows the image — x rightward, y downward — as
-# `(y-direction, x-direction)`, so we unpack `y, x`.
+# `(y-direction, x-direction)`, so we unpack `y, x`. AprilTag tracking reports `missing` for a frame
+# whose target couldn't be localized (e.g. a tag was momentarily lost); such a row keeps its `time`
+# with empty `x`/`y`, so the time axis stays intact and the gaps are explicit.
 function save2csv(run_id, (ts, coords))
     open(joinpath(results_dir, string(run_id, ".csv")), "w") do io
         println(io, "time,x,y")
         for (t, c) in zip(ts, coords)
-            y, x = c
-            println(io, t, ',', x, ',', y)
+            if ismissing(c)
+                println(io, t, ",,")
+            else
+                y, x = c
+                println(io, t, ',', x, ',', y)
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes the segfault/`load_rectifications` failures when running the real 158-run drone pipeline at 32 threads. The earlier fixes were validated single-threaded, which never stressed the concurrency — testing at `-t 32` on a cold network share surfaced the rest.

**1. `reference_frame`: serialize read + detect (not just detect).**
The AprilTag detector isn't reentrant (already serialized via `detect_locked`), but at high thread counts on a cold CIFS mount the one-shot VideoIO read (`open+seek+read`) *also* races and returns garbled/wrong frames. The detect-only lock I'd merged removed the read serialization, so verification/build spuriously failed ~15–20/31 calibs and could segfault. This restores the whole `reference_frame` under `APRILTAG_LOCK` (read + detect) — one-time setup, negligible cost. Per-run tracking keeps concurrent decode; only its detection stays serialized.

**2. `save2csv`: handle `missing` coordinates.**
AprilTag tracking legitimately reports `missing` for a frame whose target couldn't be localized (tag briefly lost); `y, x = c` threw on `missing`. Such rows are now written as `time,,` (empty x/y) so the time axis stays intact and gaps are explicit.

**Verified end-to-end on the real dataset at 32 threads:** verification clean and deterministic (only the one genuinely-marginal calib), and a 14-run concurrent tracking run completes with no segfault and correct CSV output. Also confirmed tracking itself does not segfault at 32-way. Full suite green (830).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
