### PR TITLE
Add the Aqua QA badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Test workflow status](https://github.com/yakir12/Fromage.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/yakir12/Fromage.jl/actions/workflows/Test.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/yakir12/Fromage.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/yakir12/Fromage.jl)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![BestieTemplate](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/JuliaBesties/BestieTemplate.jl/main/docs/src/assets/badge.json)](https://github.com/JuliaBesties/BestieTemplate.jl)
 
 This is the main package used to organise, calibrate, and track video files in the Dacke lab.


### PR DESCRIPTION
The test suite already runs Aqua (plus ExplicitImports) in `test/quality.jl` on every CI run — this just surfaces that with the badge [Aqua.jl itself prescribes](https://github.com/JuliaTesting/Aqua.jl#badge).

Note for the record: this is a manual addition, not a BestieTemplate mechanism — Bestie (installed v0.18.6 and upstream main) has no Aqua integration of any kind. We're already ahead of the template on this front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdidNw6AP1Zq5miiPxZgaj