### PR TITLE
Narrow `_read_frame`'s bare catch to the transient failures (#25)

### DIFF
--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -34,6 +34,14 @@ _cmd(file, t, ::Missing) = `$(FFMPEG.ffmpeg()) -hide_banner -loglevel error -ss 
 _cmd(file, t, vf) = `$(FFMPEG.ffmpeg()) -hide_banner -loglevel error -ss $t -i $file -frames:v 1 -vf $vf -f rawvideo -pix_fmt gray pipe:1`
 
 
+# The failures `_read_frame` retries, i.e. everything a flaky share can plausibly do to a frame
+# read: ffmpeg exiting nonzero (`ProcessFailedException` — how an EAGAIN against the share surfaces,
+# since it is ffmpeg itself that fails), and the Julia-side spawn/pipe failures (`IOError`,
+# `SystemError`). Everything else is not transient and retrying it is wrong: an `InterruptException`
+# above all — a bare `catch` ate Ctrl-C for the whole backoff sequence — but equally a caller's bug,
+# which should surface at once instead of after four attempts.
+_transient(e) = e isa ProcessFailedException || e isa Base.IOError || e isa SystemError
+
 # Read one frame, retrying transient failures. EAGAIN ("Resource temporarily unavailable") from
 # the CIFS share is transient by definition, so a few backoff retries ride out residual blips even
 # under the concurrency limit. A persistent failure still rethrows after the last try.
@@ -41,7 +49,8 @@ function _read_frame(cmd; tries = 4)
     for i in 1:(tries - 1)
         try
             return read(cmd)
-        catch
+        catch e
+            _transient(e) || rethrow()
             sleep(0.2 * 2^(i - 1))          # 0.2s, 0.4s, 0.8s backoff
         end
     end

--- a/test/Rectifications/test_read_frame.jl
+++ b/test/Rectifications/test_read_frame.jl
@@ -1,0 +1,51 @@
+# `_read_frame`'s retry loop and the predicate that decides what it retries. The commands here are
+# trivial shell utilities, not ffmpeg — what is under test is the retry/rethrow policy, not decoding.
+
+@testset "_read_frame retry policy" begin
+
+    # Real instances of the three transient failures, produced the way `_read_frame` would meet
+    # them, so the test can't drift from the actual constructors.
+    grab(f) = try f(); nothing catch e; e end
+    process_failed = grab(() -> read(`false`))                 # ffmpeg exiting nonzero
+    io_error       = grab(() -> read(`__no_such_executable__`))# spawn failure
+    system_error   = grab(() -> read("/nonexistent/nope", 6))  # file-level failure
+
+    @testset "_transient classifies what may be retried" begin
+        @test process_failed isa ProcessFailedException && R._transient(process_failed)
+        @test io_error isa Base.IOError && R._transient(io_error)
+        @test system_error isa SystemError && R._transient(system_error)
+
+        # Not transient, and the whole point of the change: a bare `catch` swallowed Ctrl-C for the
+        # entire backoff sequence (issue #25). A caller's bug must surface at once, too.
+        @test !R._transient(InterruptException())
+        @test !R._transient(MethodError(identity, ()))
+        @test !R._transient(ErrorException("boom"))
+    end
+
+    @testset "a persistent failure propagates after the last try" begin
+        # `false` always exits nonzero: transient by the predicate, so every retry is used, and the
+        # final attempt (outside the try) is what throws.
+        @test_throws ProcessFailedException R._read_frame(`false`; tries = 2)
+    end
+
+    @testset "retries actually happen, with backoff" begin
+        # tries = 3 ⇒ two failed attempts, sleeping 0.2s then 0.4s before the last one throws.
+        t = @elapsed try
+            R._read_frame(`false`; tries = 3)
+        catch
+        end
+        @test t ≥ 0.6
+    end
+
+    @testset "a non-transient failure is not retried" begin
+        # `read(42)` is a MethodError — a caller's bug, not a flaky share. It must escape on the
+        # first attempt: were it (wrongly) retried, tries = 4 would sleep 0.2 + 0.4 + 0.8s first.
+        t = @elapsed @test_throws MethodError R._read_frame(42; tries = 4)
+        @test t < 0.2
+    end
+
+    @testset "a successful read returns the bytes" begin
+        @test R._read_frame(`echo hi`) == codeunits("hi\n")
+    end
+
+end

--- a/test/rectifications.jl
+++ b/test/rectifications.jl
@@ -17,6 +17,7 @@ const R = Rectifications
     include("Rectifications/test_lens_distortion.jl")
     include("Rectifications/test_geometry.jl")
     include("Rectifications/test_ffmpeg_cmd.jl")
+    include("Rectifications/test_read_frame.jl")
     include("Rectifications/test_module_state.jl")
     include("Rectifications/test_from_scale.jl")
     include("Rectifications/test_from_matlab.jl")


### PR DESCRIPTION
Closes #25. First step of #34.

`_read_frame`'s retry loop used a bare `catch`, so it swallowed `InterruptException` — Ctrl-C during a flaky read was eaten for the whole backoff sequence — and retried a caller's bug three times before letting it surface.

This adds a named predicate for the failures a flaky share can actually produce:

```julia
_transient(e) = e isa ProcessFailedException || e isa Base.IOError || e isa SystemError
```

- `ProcessFailedException` — ffmpeg exiting nonzero, which is how an EAGAIN against the CIFS share surfaces (it is ffmpeg itself that fails)
- `Base.IOError` / `SystemError` — the Julia-side spawn/pipe failures

Anything else `rethrow()`s immediately.

Naming the predicate instead of inlining the condition into the `catch` keeps the policy unit-testable. The new `test/Rectifications/test_read_frame.jl` covers it end to end: the three transient exceptions are built by provoking real ones (so the tests cannot drift from the actual constructors), `InterruptException`/`MethodError`/`ErrorException` are asserted *not* transient, retries still happen with backoff, and a non-transient error is shown to escape on the first attempt rather than after four.

### Tradeoff

If some other exception type turns out to be transient on the share in the field, it now fails immediately instead of retrying. That's the intended direction for #34 — silent retry of an unknown error is what the issue argues against — but it is a behavior change worth knowing about.

### Testing

Full suite locally on Julia 1.12.6, `JULIA_NUM_THREADS=auto`: **878 passed, 0 failed** (8m45s). The new file on its own: 11 passed. JET is skipped off 1.11, so CI covers that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4