### PR TITLE
Replace the matlab metadata catches with explicit checks (#34)

### DIFF
--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -67,13 +67,16 @@ function matlab_dimension(dict)
         return "matlab file does not contain any image size; file might not be a calibration file"
     end
     imagesize = last(res)
-    try
-        length(imagesize) == 2 || return "matlab ImageSize is malformed (expected two values)"
-        height, width = imagesize
-        return (Int(width), Int(height))
-    catch
-        return "matlab ImageSize is malformed (expected two integers)"
-    end
+    # Every assumption about this `Any` is checked up front rather than by catching its failure:
+    # a two-element collection whose entries are exact integers (matlab stores them as Float64).
+    # The eltype guard is what makes `Int(width)` total — an InexactError on 1.5 was the throw the
+    # old catch existed for, and a two-character String would otherwise have destructured into
+    # character codepoints and returned a silently wrong dimension.
+    imagesize isa Union{AbstractArray, Tuple} || return "matlab ImageSize is malformed (expected two values)"
+    length(imagesize) == 2 || return "matlab ImageSize is malformed (expected two values)"
+    all(x -> x isa Real && isinteger(x), imagesize) || return "matlab ImageSize is malformed (expected two integers)"
+    height, width = imagesize
+    return (Int(width), Int(height))
 end
 
 # The fields CameraCalibrations.jl needs to build a calibration object from a matlab result file.
@@ -167,12 +170,11 @@ function matlab_extrinsic_count(dict)
     counts = Int[]
     for k in ("TranslationVectors", "RotationVectors")
         vecs = last(findfirstkey(dict, k))
-        n = try
-            size(vecs, 1)            # N×3 -> N poses
-        catch
-            return "matlab $k is malformed (expected an N×3 matrix)"
-        end
-        push!(counts, n)
+        # `size(vecs, 1)` is only meaningful for an array; a scalar, a string or a nested dict is a
+        # malformed field. Checking that up front is what the catch was standing in for — and it
+        # keeps the accepted shapes exactly as they were, since `size(v, 1)` worked for any array.
+        vecs isa AbstractArray || return "matlab $k is malformed (expected an N×3 matrix)"
+        push!(counts, size(vecs, 1))   # N×3 -> N poses
     end
     allequal(counts) || return "matlab TranslationVectors and RotationVectors disagree on the number of extrinsics"
     return first(counts)

--- a/test/VerifyRectifications/test_extrinsic_index.jl
+++ b/test/VerifyRectifications/test_extrinsic_index.jl
@@ -11,6 +11,21 @@
         @test VRect.matlab_extrinsic_count(MAT.matread(joinpath(DATADIR, ART.mismatch_mat))) isa String
     end
 
+    @testset "malformed pose vectors are flagged, never thrown" begin
+        # TranslationVectors/RotationVectors present but not an array at all: `size(v, 1)` has no
+        # meaning there, so the field is reported as malformed rather than throwing a MethodError.
+        for k in ("TranslationVectors", "RotationVectors")
+            p = joinpath(DATADIR, "badpose_$k.mat")
+            MAT.matwrite(p, merge(MATLAB_CALIB_FIELDS, Dict("ImageSize" => [480.0, 640.0], k => "nope")))
+            issue = VRect.matlab_extrinsic_count(MAT.matread(p))
+            @test issue isa String
+            @test occursin(k, issue)                 # names the offending field
+        end
+        # end-to-end: such a file is flagged and load_rectifications does not throw
+        @test flagged(check("ei_badpose.csv", [matlabrow(matlab_file = "badpose_TranslationVectors.mat")]),
+                      1, "expected an N×3 matrix")
+    end
+
     @testset "in-range index loads clean (both boundaries)" begin
         @test clean(check("ei_min.csv", [matlabrow(extrinsic_index = 1)]))                    # low boundary
         @test clean(check("ei_max.csv", [matlabrow(extrinsic_index = MATLAB_N_EXTRINSICS)]))  # high boundary (pins ≤ N)


### PR DESCRIPTION
Part of #34, following #44. Two more `try`/`catch` sites, both **eliminated outright** rather than narrowed — these read unconstrained `Any` values out of a `.mat` dict, and every failure they were catching is cheap to test for up front.

### `matlab_dimension`

Require a two-element collection whose entries are exact integers:

```julia
imagesize isa Union{AbstractArray, Tuple} || return "…(expected two values)"
length(imagesize) == 2                    || return "…(expected two values)"
all(x -> x isa Real && isinteger(x), imagesize) || return "…(expected two integers)"
```

The eltype guard is what makes `Int(width)` total — an `InexactError` on `1.5` was the throw being caught. It also closes a latent bug: a two-character `String` passed the old `length == 2` test and destructured into character codepoints, so `"ab"` returned a **silently wrong dimension** `(98, 97)` instead of an issue.

### `matlab_extrinsic_count`

Require an array before asking for `size(v, 1)`. Deliberately `AbstractArray` and not `AbstractMatrix`: `size(v, 1)` was meaningful for any array, so the stricter check would reject shapes that previously worked. **This changes what throws, not what is accepted.**

### Tests

The `size` failure had no coverage at all. Added one case per field asserting the issue string names the offending field, plus an end-to-end flag through `load_rectifications`. The four existing malformed-`ImageSize` cases (`[1,2,3]`, `[1.5,2.5]`, `42`, `"hello"`) return byte-identical messages to before — I checked each against the new path.

### Testing

Full suite locally, Julia 1.12.6, `JULIA_NUM_THREADS=auto`: **883 passed, 0 failed** (7m47s) — 878 before, +5 for the new assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4