### PR TITLE
Narrow resolve_defaults' convert catch to rejected values (#34)

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -70,10 +70,17 @@ function resolve_defaults(overrides, defaults, types, what)
     unknown = setdiff(keys(overrides), keys(defaults))
     isempty(unknown) || throw(ArgumentError("unknown $what default(s): $(join(unknown, ", ")) (settable: $(join(keys(defaults), ", ")))"))
     isempty(overrides) && return defaults
+    # `convert` has no non-throwing counterpart, so this failure stays a caught exception — but only
+    # the two it can actually be. Over every whitelisted target type (Float64, Int, Bool,
+    # NTuple{2,Int}, Union{Int,NTuple{2,Int}}) a rejected value fails as either a `MethodError` (no
+    # such conversion: "yes" -> Bool) or an `InexactError` (a conversion that would lose
+    # information: 1.5 -> Int, 2 -> Bool). Anything else is not a rejected default and must not be
+    # relabelled as one — it propagates.
     converted = NamedTuple{keys(overrides)}(map(keys(overrides)) do k
         try
             convert(types[k], overrides[k])
-        catch
+        catch e
+            e isa MethodError || e isa InexactError || rethrow()
             throw(ArgumentError("$what default $k must be convertible to $(types[k]), got $(repr(overrides[k]))"))
         end
     end)

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -8,6 +8,11 @@ using Fromage: Fromage
 
 const P = Fromage.Parsing
 
+# A value whose conversion fails with something other than the two "rejected value" exceptions —
+# used to pin that such an error propagates instead of being relabelled as a bad default.
+struct Boom end
+Base.convert(::Type{Int}, ::Boom) = error("boom")
+
 @testset "Parsing (shared cell machinery)" begin
     @testset "MyTemporal: seconds vs HH:MM:SS precedence" begin
         @test P.mytryparse(P.MyTemporal, "1.5")      == 1.5    # float path taken before Time
@@ -25,6 +30,30 @@ const P = Fromage.Parsing
         @test P.mytryparse(NTuple{2, Int}, "1,2,3")       === nothing   # not a 2-tuple
         @test P.mytryparse(NTuple{2, Int}, "abc")         === nothing
         @test P.mytryparse(NTuple{2, Int}, "(10000000000000000000,1)") === nothing  # >Int64 overflows -> nothing, not a throw
+    end
+
+    @testset "resolve_defaults: rejected values vs. genuine errors" begin
+        # A miniature whitelist standing in for a gateway's DEFAULTS/DEFAULT_TYPES pair.
+        defaults = (; a = 1.0, n = 2, flag = true)
+        types    = (; a = Float64, n = Int, flag = Bool)
+        resolve(o) = P.resolve_defaults(o, defaults, types, "test")
+
+        @test resolve((;)) == defaults                          # no overrides: untouched
+        @test resolve((; a = 3)).a === 3.0                      # converted to the column's type
+        @test resolve((; n = 5)) == (; a = 1.0, n = 5, flag = true)
+
+        # Not on the whitelist at all -> fails fast, naming the settable keys.
+        @test_throws ArgumentError resolve((; nope = 1))
+
+        # The two ways a value can be rejected, both relabelled as ArgumentError:
+        @test_throws ArgumentError resolve((; flag = "yes"))    # MethodError: no such conversion
+        @test_throws ArgumentError resolve((; n = 1.5))         # InexactError: would lose information
+        @test_throws ArgumentError resolve((; flag = 2))        # InexactError: 2 is not a Bool
+
+        # ...and an error that is NOT a rejected value must propagate unchanged rather than be
+        # reported to the user as "must be convertible to". Boom is our own type, so extending
+        # convert on it is not piracy.
+        @test_throws ErrorException resolve((; n = Boom()))
     end
 
     @testset "String: trimmed and materialized" begin


### PR DESCRIPTION
Part of #34, following #44 and #45. Independent of #45 — different files.

A bare `catch` around `convert` relabelled **any** failure as "must be convertible to", so an unrelated error reached the user as a misleading complaint about their default, and Ctrl-C during resolution was swallowed.

`convert` has no non-throwing counterpart, so unlike #45 the catch has to stay — but only for the two exceptions it can actually be:

```julia
catch e
    e isa MethodError || e isa InexactError || rethrow()
    throw(ArgumentError("$what default $k must be convertible to $(types[k]), got …"))
end
```

### Why those two

Determined empirically rather than by reasoning: every one of the five whitelisted target types (`Float64`, `Int`, `Bool`, `NTuple{2,Int}`, `Union{Int,NTuple{2,Int}}`) was converted against thirteen plausible inputs (`"x"`, `1.5`, `2`, `true`, `(1,2)`, `(1,2,3)`, `(1.5,2.5)`, `[1,2]`, `nothing`, `missing`, `:sym`, `1//2`, `3.0`). The only failures produced were:

- `MethodError` — no such conversion (`"yes" → Bool`)
- `InexactError` — a conversion that would lose information (`1.5 → Int`, `2 → Bool`)

### Tests

`resolve_defaults` had no unit tests at all — the gateways only reached it end to end, and only through the `MethodError` path (`darker_target = "yes"`). Added 8 assertions covering the happy paths, unknown-key rejection, both rejection modes, and a local `Boom` type whose `convert` throws an `ErrorException`, pinning that it **propagates** rather than being relabelled as a bad default. `test/parsing.jl` goes 14 → 22.

### Testing

Full suite locally, Julia 1.12.6, `JULIA_NUM_THREADS=auto`: **886 passed, 0 failed** (7m40s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4