### PR TITLE
Stop the remaining catch-alls from swallowing Ctrl-C (#34)

### DIFF
--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -101,7 +101,11 @@ end
         redirect_stdout(devnull) do
             try
                 load_rectifications(dir, csv; strict = false)
-            catch
+            catch e
+                # Deliberately broad: precompilation must not fail because the workload did. An
+                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
+                # absorbed here.
+                e isa InterruptException && rethrow()
             end
         end
     end

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -84,9 +84,13 @@ const MATLAB_REQUIRED_KEYS = ("TranslationVectors", "RotationVectors", "RadialDi
 # opaque error. `read(file, 6)` opens the file and returns up to 6 bytes (fewer if the file is
 # shorter), so a too-short file simply fails the comparison.
 function matlab_magic_issue(file)
+    # Existence was already checked upstream, so what remains is a race or a permission problem:
+    # `read` reports both as SystemError/IOError. Anything else is not an unreadable file and is
+    # not this function's to describe.
     magic = try
         read(file, 6)
     catch e
+        e isa SystemError || e isa Base.IOError || rethrow()
         return "error reading matlab file: $e"
     end
     magic == codeunits("MATLAB") ? nothing : "file is not a matlab file (missing \"MATLAB\" magic bytes)"
@@ -259,7 +263,11 @@ function save_issue_frame(issues_dir, file, extrinsic, get_frame)
         path = joinpath(issues_dir, string(first(splitext(basename(file))), "_t", extrinsic, "s.png"))
         FileIO.save(path, image)
         return path
-    catch
+    catch e
+        # Deliberately broad: saving a diagnostic frame must never break verification, and the
+        # three steps above (frame read, mkpath, encode+write) fail in too many ways to enumerate
+        # usefully. An interrupt is not one of those failures — Ctrl-C must not be absorbed here.
+        e isa InterruptException && rethrow()
         return nothing
     end
 end

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -98,7 +98,11 @@ end
         redirect_stdout(devnull) do
             try
                 load_runs(dir, csv; strict = false)
-            catch
+            catch e
+                # Deliberately broad: precompilation must not fail because the workload did. An
+                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
+                # absorbed here.
+                e isa InterruptException && rethrow()
             end
         end
     end

--- a/test/VerifyRectifications/test_reading.jl
+++ b/test/VerifyRectifications/test_reading.jl
@@ -38,6 +38,8 @@
         # a genuine .mat and a message otherwise. bad.mat ("this is not a mat file") fails the check.
         @test VRect.matlab_magic_issue(joinpath(DATADIR, ART.good_mat)) === nothing
         @test VRect.matlab_magic_issue(joinpath(DATADIR, ART.bad_mat))  isa String
+        # an unreadable path (here: absent) is a SystemError from `read`, reported as an issue
+        @test VRect.matlab_magic_issue(joinpath(DATADIR, "definitely_not_here.mat")) isa String
         # end-to-end: a non-mat file is flagged and has :matlab_file nulled (the source video :file is fine)
         df = check("r_mat_magic.csv", [matlabrow(matlab_file = ART.bad_mat)])
         @test flagged(df, 1, "missing \"MATLAB\" magic bytes")
@@ -95,6 +97,16 @@
                                        videorow(calibration_id = "v2", path = "./.", center = (9000, 9000))])
         @test flagged(df, 1, "center cannot be larger than the dimensions")
         @test flagged(df, 2, "center cannot be larger than the dimensions")
+    end
+
+    @testset "save_issue_frame is best-effort, but does not swallow interrupts" begin
+        # The frame reader is injected, so both failure kinds can be driven directly. A failed read
+        # must leave verification unharmed (nothing returned, nothing thrown)...
+        dir = joinpath(DATADIR, "issues_besteffort")
+        @test VRect.save_issue_frame(dir, "v.mp4", 1.0, () -> error("no frame")) === nothing
+        @test !isdir(dir)                       # nothing created when the frame never arrived
+        # ...while a Ctrl-C during the read propagates instead of being absorbed as a failed save.
+        @test_throws InterruptException VRect.save_issue_frame(dir, "v.mp4", 1.0, () -> throw(InterruptException()))
     end
 
     @testset "matlab without ImageSize is flagged" begin


### PR DESCRIPTION
Part of #34, following #44, #45 and #46. Independent of all three.

Four sites, and they split into two kinds — which is the point of the change.

### One genuine narrowing

`matlab_magic_issue` — existence is checked upstream, so a failing `read(file, 6)` is a race or a permission problem, both of which `read` reports as `SystemError`/`Base.IOError`. Narrowed to those; anything else propagates, because it is not an unreadable file and not this function's to describe.

### Three that stay broad, on purpose

`save_issue_frame` and the two `@compile_workload` blocks keep catching everything, because **breadth is the correct policy there**:

- saving a diagnostic frame must never break verification — and its three steps (frame read, `mkpath`, encode+write) fail in too many ways to enumerate usefully
- precompilation must not fail because its workload did

What was wrong is only that the breadth also absorbed `InterruptException`, so Ctrl-C did nothing during a precompile or a slow diagnostic save. Each now rethrows it.

Each of the three also gains a comment stating which kind of catch it is. That is the durable part: a deliberate catch-all is otherwise indistinguishable from an overlooked one, which is how #34 accumulated in the first place.

### Tests

`save_issue_frame` takes its frame reader as a callback, so both paths are driven directly rather than asserted by inspection: a failed read returns `nothing` and creates no directory, while an `InterruptException` escapes. `matlab_magic_issue` gains an unreadable-path case.

### Testing

Full suite locally, Julia 1.12.6, `JULIA_NUM_THREADS=auto`: **882 passed, 0 failed** (7m42s) — 878 before, +4 for the new assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4