### PR TITLE
Split the probe catches from the output parsing (#34)

### DIFF
--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -103,6 +103,12 @@ function read_matlab(file)
     try
         matread(file)
     catch e
+        # MAT.jl signals essentially every corruption through a generic `error(...)`: a truncated
+        # file, a valid header followed by garbage, and an absent file all arrive as
+        # ErrorException, a directory as EOFError (all verified). ErrorException is therefore as
+        # narrow as this can honestly get — but it still excludes the MethodError/BoundsError that
+        # would mean a bug on our side, and the InterruptException a bare catch used to swallow.
+        e isa ErrorException || e isa EOFError || e isa SystemError || e isa Base.IOError || rethrow()
         return "error opening matlab file: $e"
     end
 end
@@ -196,23 +202,35 @@ end
 # env-baked Cmd; the deprecated do-block form mutates the global ENV, a race under the tmap that
 # calls this); stderr is dropped so ffmpeg's diagnostics don't leak into the program output.
 function probe_video(file)
-    try
-        exe = ffprobe()   # env-baked Cmd; its env survives interpolation into the command below
-        out = read(pipeline(`$exe -v error -select_streams v:0 -show_entries stream=width,height,sample_aspect_ratio,field_order:format=duration -of default=noprint_wrappers=1 $file`, stderr = devnull), String)
-        fields = Dict{String,String}()
-        for line in eachline(IOBuffer(out))
-            isempty(line) && continue
-            k, v = split(line, '='; limit = 2)
-            fields[k] = v
-        end
-        return (; width    = parse(Int, fields["width"]),
-                  height   = parse(Int, fields["height"]),
-                  duration = parse(Float64, fields["duration"]),
-                  aspect   = parse_sample_aspect(get(fields, "sample_aspect_ratio", "1:1")),
-                  yadif    = get(fields, "field_order", "progressive") in INTERLACED_FIELD_ORDERS)
+    exe = ffprobe()   # env-baked Cmd; its env survives interpolation into the command below
+    # Only the spawn is fallible in a way worth catching: ffprobe exiting nonzero on an unreadable
+    # or corrupt file (ProcessFailedException), or the spawn/pipe itself failing (IOError,
+    # SystemError). Reading the output is not — that is handled below, without exceptions.
+    out = try
+        read(pipeline(`$exe -v error -select_streams v:0 -show_entries stream=width,height,sample_aspect_ratio,field_order:format=duration -of default=noprint_wrappers=1 $file`, stderr = devnull), String)
     catch e
+        e isa ProcessFailedException || e isa Base.IOError || e isa SystemError || rethrow()
         return "issue reading from video file: $(sprint(showerror, e))"
     end
+    fields = Dict{String,String}()
+    for line in eachline(IOBuffer(out))
+        occursin('=', line) || continue        # a line without a separator would not destructure
+        k, v = split(line, '='; limit = 2)
+        fields[k] = v
+    end
+    # The three fields nothing downstream can proceed without. `tryparse` reports an absent or
+    # unparseable one as `nothing`, which becomes a precise issue — where `parse` used to throw
+    # into the catch above and be reported as a read failure, which it is not.
+    width    = tryparse(Int, get(fields, "width", ""))
+    height   = tryparse(Int, get(fields, "height", ""))
+    duration = tryparse(Float64, get(fields, "duration", ""))
+    if isnothing(width) || isnothing(height) || isnothing(duration)
+        return "malformed ffprobe output (missing or unparseable width/height/duration)"
+    end
+    # aspect and field order have documented fallbacks, so a missing one is not an error.
+    return (; width, height, duration,
+              aspect = parse_sample_aspect(get(fields, "sample_aspect_ratio", "1:1")),
+              yadif  = get(fields, "field_order", "progressive") in INTERLACED_FIELD_ORDERS)
 end
 
 function verify!(df::AbstractDataFrame, predicate, msg, args...)

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -1,10 +1,15 @@
-# Reduce ffprobe's "num/den" r_frame_rate to a Float64. A zero denominator (undefined rate) falls
-# back to the numerator so the value stays finite and the fps checks below behave sanely.
+# Reduce ffprobe's "num/den" r_frame_rate to a Float64, or `nothing` when the field is absent or
+# unparseable (tryparse semantics, so the caller reports it as malformed output rather than having
+# a `parse` throw out of the probe). A zero denominator (undefined rate) falls back to the
+# numerator so the value stays finite and the fps checks below behave sanely.
 function parse_framerate(s)
-    occursin('/', s) || return parse(Float64, s)
-    num, den = split(s, '/')
-    d = parse(Float64, den)
-    iszero(d) ? parse(Float64, num) : parse(Float64, num) / d
+    occursin('/', s) || return tryparse(Float64, s)
+    parts = split(s, '/')
+    length(parts) == 2 || return nothing
+    num = tryparse(Float64, parts[1])
+    den = tryparse(Float64, parts[2])
+    (isnothing(num) || isnothing(den)) && return nothing
+    return iszero(den) ? num : num / den
 end
 
 # ffprobe reports the sample (pixel) aspect ratio as "num:den"; "N/A" or "0:1" mean undefined and
@@ -23,23 +28,35 @@ end
 # string for a corrupt/unreadable file. Uses the non-do-block `ffprobe()` (an env-baked Cmd; never
 # mutates the global ENV); stderr is dropped so ffmpeg's diagnostics don't leak into the output.
 function probe_video(file)
-    try
-        exe = ffprobe()   # env-baked Cmd; its env survives interpolation into the command below
-        out = read(pipeline(`$exe -v error -select_streams v:0 -show_entries stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration -of default=noprint_wrappers=1 $file`, stderr = devnull), String)
-        fields = Dict{String, String}()
-        for line in eachline(IOBuffer(out))
-            isempty(line) && continue
-            k, v = split(line, '='; limit = 2)
-            fields[k] = v
-        end
-        return (; width    = parse(Int, fields["width"]),
-                  height   = parse(Int, fields["height"]),
-                  duration = parse(Float64, fields["duration"]),
-                  fps      = parse_framerate(fields["r_frame_rate"]),
-                  sar      = parse_sar(get(fields, "sample_aspect_ratio", "1:1")))
+    exe = ffprobe()   # env-baked Cmd; its env survives interpolation into the command below
+    # Only the spawn is fallible in a way worth catching: ffprobe exiting nonzero on an unreadable
+    # or corrupt file (ProcessFailedException), or the spawn/pipe itself failing (IOError,
+    # SystemError). Reading the output is not — that is handled below, without exceptions.
+    out = try
+        read(pipeline(`$exe -v error -select_streams v:0 -show_entries stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration -of default=noprint_wrappers=1 $file`, stderr = devnull), String)
     catch e
+        e isa ProcessFailedException || e isa Base.IOError || e isa SystemError || rethrow()
         return "issue reading from video file: $(sprint(showerror, e))"
     end
+    fields = Dict{String, String}()
+    for line in eachline(IOBuffer(out))
+        occursin('=', line) || continue        # a line without a separator would not destructure
+        k, v = split(line, '='; limit = 2)
+        fields[k] = v
+    end
+    # The four fields nothing downstream can proceed without (`fps` imputes the run's tracking rate
+    # when the csv leaves it blank). `tryparse` reports an absent or unparseable one as `nothing`,
+    # which becomes a precise issue — where `parse` used to throw into the catch above and be
+    # reported as a read failure, which it is not.
+    width    = tryparse(Int, get(fields, "width", ""))
+    height   = tryparse(Int, get(fields, "height", ""))
+    duration = tryparse(Float64, get(fields, "duration", ""))
+    fps      = parse_framerate(get(fields, "r_frame_rate", ""))
+    if isnothing(width) || isnothing(height) || isnothing(duration) || isnothing(fps)
+        return "malformed ffprobe output (missing or unparseable width/height/duration/frame rate)"
+    end
+    # sar has a documented square-pixel fallback, so a missing one is not an error.
+    return (; width, height, duration, fps, sar = parse_sar(get(fields, "sample_aspect_ratio", "1:1")))
 end
 
 # One ffprobe per physical video file fills the intermediate :dimension/:duration/:video_fps columns

--- a/test/VerifyRuns/test_video_metadata.jl
+++ b/test/VerifyRuns/test_video_metadata.jl
@@ -21,4 +21,27 @@
     @testset "corrupt/unreadable video is reported" begin
         @test flagged(check("vm_corrupt.csv", [runrow(file = ART.corrupt)]), 1, "issue reading from video file")
     end
+
+    @testset "parse_framerate: tryparse semantics, never a throw" begin
+        # ffprobe reports r_frame_rate as "num/den", or occasionally a bare number.
+        @test VR.parse_framerate("30000/1001") ≈ 29.97 atol = 0.01
+        @test VR.parse_framerate("25")   == 25.0
+        @test VR.parse_framerate("25/1") == 25.0
+        @test VR.parse_framerate("25/0") == 25.0        # undefined rate: fall back to the numerator
+        # Anything unparseable is `nothing`, so probe_video reports malformed output rather than
+        # letting a `parse` throw into its catch. "N/A" is the case that used to throw: it contains
+        # a '/', so it took the fraction branch and split into ("N", "A").
+        @test VR.parse_framerate("N/A") === nothing
+        @test VR.parse_framerate("")    === nothing
+        @test VR.parse_framerate("abc") === nothing
+        @test VR.parse_framerate("1/2/3") === nothing
+    end
+
+    @testset "parse_sar: undefined ratios fall back to square pixels" begin
+        @test VR.parse_sar("64:45") == 64//45
+        @test VR.parse_sar("1:1")   == 1//1
+        @test VR.parse_sar("N/A")   == 1//1
+        @test VR.parse_sar("0:1")   == 1//1             # undefined
+        @test VR.parse_sar("")      == 1//1
+    end
 end


### PR DESCRIPTION
Part of #34, following #44, #45, #46 and #47. The `probe_video` **dedupe is deliberately not here** — this PR is behavior only, so the dedupe can land later as a pure refactor.

### The two `probe_video` copies

Each wrapped two unrelated things in one `try`: the ffprobe spawn, which is genuinely fallible, and the reading of its output, which need not throw at all. A malformed probe result was therefore reported as *"issue reading from video file"* — describing a read that had in fact succeeded.

The catch now covers only the spawn, narrowed to:

- `ProcessFailedException` — ffprobe exiting nonzero on an unreadable or corrupt file
- `Base.IOError` / `SystemError` — the spawn or pipe itself failing

The output is handled without exceptions: `tryparse` for the fields nothing downstream can proceed without, `get` with the documented fallbacks for the optional ones (aspect, field order, sar), and a guard so a line without a `=` is skipped rather than failing to destructure. Output that parses to nothing usable now reports **"malformed ffprobe output"**.

### `parse_framerate`

Had to change with it, since it used a throwing `parse`. Now tryparse-style, which fixes a real latent case: ffprobe's `"N/A"` contains a `/`, so it took the fraction branch, split into `("N", "A")`, and threw an `ArgumentError` that the old catch reported as a read failure. The zero-denominator fallback (`25/0 → 25.0`) is unchanged.

### `read_matlab` — narrowed as far as MAT.jl honestly allows

I probed its failure modes rather than guessing. A truncated file, a valid header followed by garbage, and an absent file **all** arrive as a generic `ErrorException`; a directory gives `EOFError`. So there is no precise type to catch here. Narrowing to `ErrorException`/`EOFError`/`SystemError`/`IOError` still buys something real — it excludes the `MethodError`/`BoundsError` that would mean a bug on our side, and the `InterruptException` a bare catch swallowed — and the comment states this plainly so the breadth is not mistaken for an oversight.

### Tests

13 new assertions pinning the now-pure helpers: `parse_framerate` across fraction, bare, zero-denominator, and four unparseable forms (including the `"N/A"` case that used to throw), and `parse_sar` across valid, undefined, and empty ratios.

### Testing

Full suite locally, Julia 1.12.6, `JULIA_NUM_THREADS=auto`: **904 passed, 0 failed** (7m36s) — 891 on current main, +13.

### Note

Unrelated and pre-existing, found while testing: the issue message for a corrupt video is ~7,400 characters, because `sprint(showerror, ::ProcessFailedException)` dumps the whole env-baked `Cmd` including `PATH` and `LD_LIBRARY_PATH`, straight into the user-facing report. Not touched here; it pairs naturally with the dedupe PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4