### PR TITLE
Exclude the precompile workloads from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,12 @@ coverage:
       default:
         target: 90%
   range: "80...90" # Yellow within this range
+
+# The PrecompileTools workloads are build-time scaffolding, not runtime code: they execute during
+# precompilation, which the coverage run does not instrument, so their lines can never be hit by the
+# test suite however well the package is tested. Counting them drags patch coverage down whenever one
+# is touched and says nothing about how well-tested the change is. They live in their own files purely
+# so they can be excluded here — codecov ignores whole paths, not lines.
+ignore:
+  - "src/VerifyRectifications/precompile.jl"
+  - "src/VerifyRuns/precompile.jl"

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -79,36 +79,6 @@ function load_rectifications(data_path, file; strict = true, defaults = (;), iss
     return RectificationMethod[RectificationMethod(r) for r in eachrow(df)]
 end
 
-# Precompile the parse → verify → report pipeline at build time. The bulk of first-call latency is the
-# DataFrames/DataFramesMeta/Chain macro machinery (column-typed `@transform!`/`@chain`/`subset`/`verify!`
-# specializations), which a single `load_rectifications` run compiles. The workload CSV points at
-# nonexistent files (one row per type), so the run exercises the full pipeline for all three types but
-# bails before any ffprobe/matread/corner detection — no bundled media needed, fast deterministic
-# precompile. (The video-read/corner-detection paths are left to compile on first real use.)
-@setup_workload begin
-    dir = mktempdir()
-    csv = joinpath(dir, "precompile.csv")
-    open(csv, "w") do io
-        # Minimal header (other columns are back-filled by parse_row); one row per type so all three
-        # parse branches and the type-specific verifications compile. All point at a nonexistent file.
-        println(io, "calibration_id,file,matlab_file,type,extrinsic,extrinsic_index,scale")
-        println(io, "v,nope.mp4,,video,1,,")
-        println(io, "m,nope.mp4,nope.mat,matlab,1,1,")
-        println(io, "s,nope.mp4,,only_scale,1,,9.5")
-        println(io, "a,nope.mp4,,apriltag,1,,")
-    end
-    @compile_workload begin
-        redirect_stdout(devnull) do
-            try
-                load_rectifications(dir, csv; strict = false)
-            catch e
-                # Deliberately broad: precompilation must not fail because the workload did. An
-                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
-                # absorbed here.
-                e isa InterruptException && rethrow()
-            end
-        end
-    end
-end
+include("precompile.jl")   # build-time workload; excluded from coverage
 
 end

--- a/src/VerifyRectifications/precompile.jl
+++ b/src/VerifyRectifications/precompile.jl
@@ -1,0 +1,35 @@
+# Build-time precompilation scaffolding, kept in its own file so it can be excluded from coverage
+# (see codecov.yml): these lines run during precompilation, which the coverage run does not
+# instrument, so they can never be hit by the test suite no matter how well the package is tested.
+
+# Precompile the parse → verify → report pipeline at build time. The bulk of first-call latency is the
+# DataFrames/DataFramesMeta/Chain macro machinery (column-typed `@transform!`/`@chain`/`subset`/`verify!`
+# specializations), which a single `load_rectifications` run compiles. The workload CSV points at
+# nonexistent files (one row per type), so the run exercises the full pipeline for all three types but
+# bails before any ffprobe/matread/corner detection — no bundled media needed, fast deterministic
+# precompile. (The video-read/corner-detection paths are left to compile on first real use.)
+@setup_workload begin
+    dir = mktempdir()
+    csv = joinpath(dir, "precompile.csv")
+    open(csv, "w") do io
+        # Minimal header (other columns are back-filled by parse_row); one row per type so all three
+        # parse branches and the type-specific verifications compile. All point at a nonexistent file.
+        println(io, "calibration_id,file,matlab_file,type,extrinsic,extrinsic_index,scale")
+        println(io, "v,nope.mp4,,video,1,,")
+        println(io, "m,nope.mp4,nope.mat,matlab,1,1,")
+        println(io, "s,nope.mp4,,only_scale,1,,9.5")
+        println(io, "a,nope.mp4,,apriltag,1,,")
+    end
+    @compile_workload begin
+        redirect_stdout(devnull) do
+            try
+                load_rectifications(dir, csv; strict = false)
+            catch e
+                # Deliberately broad: precompilation must not fail because the workload did. An
+                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
+                # absorbed here.
+                e isa InterruptException && rethrow()
+            end
+        end
+    end
+end

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -82,30 +82,6 @@ function load_runs(data_path, file; strict = true, defaults = (;))
     return Run[Run(g) for g in groupby(df, :run_id)]
 end
 
-# Precompile the parse → verify → report pipeline at build time. The bulk of first-call latency is the
-# DataFrames/DataFramesMeta/Chain macro machinery a single `load_runs` run compiles. The workload CSV
-# points at a nonexistent file, so the run exercises the full parse + verification path but bails (file
-# does not exist) before any ffprobe — no bundled media needed, fast and deterministic. (The video-read
-# path is left to compile on first real use.)
-@setup_workload begin
-    dir = mktempdir()
-    csv = joinpath(dir, "precompile.csv")
-    open(csv, "w") do io
-        println(io, "run_id,calibration_id,file,start,stop")
-        println(io, "r,c,nope.mp4,0,5")
-    end
-    @compile_workload begin
-        redirect_stdout(devnull) do
-            try
-                load_runs(dir, csv; strict = false)
-            catch e
-                # Deliberately broad: precompilation must not fail because the workload did. An
-                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
-                # absorbed here.
-                e isa InterruptException && rethrow()
-            end
-        end
-    end
-end
+include("precompile.jl")   # build-time workload; excluded from coverage
 
 end

--- a/src/VerifyRuns/precompile.jl
+++ b/src/VerifyRuns/precompile.jl
@@ -1,0 +1,29 @@
+# Build-time precompilation scaffolding, kept in its own file so it can be excluded from coverage
+# (see codecov.yml): these lines run during precompilation, which the coverage run does not
+# instrument, so they can never be hit by the test suite no matter how well the package is tested.
+
+# Precompile the parse → verify → report pipeline at build time. The bulk of first-call latency is the
+# DataFrames/DataFramesMeta/Chain macro machinery a single `load_runs` run compiles. The workload CSV
+# points at a nonexistent file, so the run exercises the full parse + verification path but bails (file
+# does not exist) before any ffprobe — no bundled media needed, fast and deterministic. (The video-read
+# path is left to compile on first real use.)
+@setup_workload begin
+    dir = mktempdir()
+    csv = joinpath(dir, "precompile.csv")
+    open(csv, "w") do io
+        println(io, "run_id,calibration_id,file,start,stop")
+        println(io, "r,c,nope.mp4,0,5")
+    end
+    @compile_workload begin
+        redirect_stdout(devnull) do
+            try
+                load_runs(dir, csv; strict = false)
+            catch e
+                # Deliberately broad: precompilation must not fail because the workload did. An
+                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
+                # absorbed here.
+                e isa InterruptException && rethrow()
+            end
+        end
+    end
+end


### PR DESCRIPTION
Fixes the `codecov/patch` failure seen on #47, and prevents it recurring on the remaining #34 work.

### The problem

The PrecompileTools workloads are build-time scaffolding, not runtime code. They execute during precompilation, which the coverage run does not instrument, so their lines **can never be hit by the test suite** however well the package is tested.

That means touching one mechanically drags patch coverage down while saying nothing about whether the change was tested. #47 landed at 66.66% of diff hit (target 90%) purely because two of its interrupt guards live inside these blocks — its `codecov/project` was 96.49% and its suite was green.

It would recur: every remaining #34 site that adds a guard in an untestable position does the same thing.

### The fix

Codecov ignores **whole paths, not lines** (there is no comment-marker exclusion), so each workload moves into its own `precompile.jl`, `include`d from the same position in its module — identical precompilation behavior — and both paths are added to `ignore:` in codecov.yml.

The blocks are moved **verbatim**, #47's interrupt guards included. I verified this rather than assuming: both moved `@setup_workload` blocks are byte-identical to the ones on `main`.

### Why not the simpler options

- `patch.informational: true` would make the check never fail again, for any PR — losing the signal that new code arrived untested, not just for these guards.
- `patch.threshold: 10%` would silently tolerate genuinely untested new code.

Moving the blocks keeps the patch target meaningful for every line a test can actually reach.

### Testing

Full suite locally, Julia 1.12.6, `JULIA_NUM_THREADS=auto`: **895 passed, 0 failed** (7m40s) — the current main baseline, since this PR adds no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4