### PR TITLE
Classify corner-detection failures, and reject n_corners OpenCV rejects (#34)

### DIFF
--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -236,21 +236,32 @@ end
 #     end
 # end
 
+# Errors raised inside a `tmap` come back wrapped in a TaskFailedException — but only when the
+# scheduler actually spawned a task, so the same failure arrives bare when the work ran inline (a
+# single-element batch, say). Both shapes have to be unwrapped to the original before classifying;
+# a narrowing that skipped this would silently stop catching under the threaded path.
+_unwrap_task(e) = e isa TaskFailedException ? _unwrap_task(e.task.result) :
+                  e isa CompositeException ? _unwrap_task(first(e.exceptions)) : e
+
+# What corner detection can legitimately fail with, as opposed to a bug here. Verified against the
+# real pipeline: the frame read raises ProcessFailedException/IOError/SystemError (see
+# Rectifications._read_frame, which already retried the transient ones); a seek that yields no frame
+# raises DimensionMismatch out of the reshape ("new dimensions … must be consistent with array
+# length 0"); and OpenCV reports every C++ error as a plain ErrorException. ErrorException is
+# therefore as narrow as this can honestly get — but it still excludes the MethodError/BoundsError
+# of a bug on our side, and the InterruptException a bare catch used to swallow.
+_detection_failure(e) = e isa ProcessFailedException || e isa Base.IOError || e isa SystemError ||
+                        e isa DimensionMismatch || e isa ErrorException
+
 function extrinsic_issue(file, extrinsic, yadif, blur, width, height, n_corners)
-    mktempdir() do path
-        # to = CameraCalibrations.extract(extrinsic, file, path, blur)
-        # @show to
-        try
-            vf = _vf(yadif, blur)
-            res = get_corners(file, extrinsic, vf, width, height, n_corners)
-            if ismissing(res)
-                return "no corners detected"
-            else
-                return nothing
-            end
-        catch e
-            return "issue with corner detection: $e"
-        end
+    try
+        vf = _vf(yadif, blur)
+        res = get_corners(file, extrinsic, vf, width, height, n_corners)
+        return ismissing(res) ? "no corners detected" : nothing
+    catch e
+        err = _unwrap_task(e)
+        _detection_failure(err) || rethrow()
+        return "issue with corner detection: $err"
     end
 end
 
@@ -315,7 +326,11 @@ function intrinsic_issue(file, start, stop, temporal_step, yadif, blur, width, h
         end
         return "fewer than 3 frames with detectable corners in the calibs window"
     catch e
-        return "issue with corner detection in the calibs window: $e"
+        # the reads run under `tmap`, so unwrap before classifying (see _unwrap_task) — and report
+        # the original rather than a nested TaskFailedException dump
+        err = _unwrap_task(e)
+        _detection_failure(err) || rethrow()
+        return "issue with corner detection in the calibs window: $err"
     end
 end
 
@@ -453,9 +468,13 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
     verify!(df, f -> !PawsomeTracker.valid_apriltag_family(f), "family is not a supported AprilTag family (" * join(PawsomeTracker.APRIL_FAMILY_NAMES, ", ") * ")", :family)
     verify!(df, ∉(1:3), "radial_parameters must be 1, 2, or 3", :radial_parameters)
     verify!(df, <(0), "blur must be larger than or equal to zero", :blur)
-    # a checkerboard needs at least a 2×2 grid of inner corners: OpenCV's detector can't find a
-    # 1-wide pattern, and checker_size_pixel divides by 2·prod(n) − sum(n), which is 0 at (1, 1)
-    verify!(df, x -> any(<(2), x), "n_corners must all be at least 2", :n_corners)
+    # OpenCV's findChessboardCorners requires both pattern dimensions to be strictly bigger than 2
+    # ("(-211:One of the arguments' values is out of range) Both width and height of the pattern
+    # should have bigger than 2"), so the bound is ≥ 3. It was ≥ 2, which let an n_corners of
+    # (2, n) pass validation and then throw out of the detector below — a precondition worth
+    # checking here instead of catching there. (checker_size_pixel's 2·prod(n) − sum(n) divisor is
+    # also 0 at (1, 1), which this subsumes.)
+    verify!(df, x -> any(<(3), x), "n_corners must all be at least 3", :n_corners)
     verify!(df, <(0), "extrinsic must be larger than or equal to zero", :extrinsic)
     # strictly before: seeking at exactly the duration yields no frame at all
     verify!(df, (e, d) -> e ≥ d, "extrinsic must come before the video duration", :extrinsic, :duration)

--- a/test/VerifyRectifications/test_intrinsics.jl
+++ b/test/VerifyRectifications/test_intrinsics.jl
@@ -21,6 +21,17 @@
         @test flagged(df, 1, "fewer than 3 frames with detectable corners")
     end
 
+    @testset "a throwing read is reported, not propagated" begin
+        # The gateway never reaches the window scan with an unreadable file — verify_intrinsics!
+        # skips rows already flagged, so the probe and extrinsic checks catch it first, which is
+        # exactly why this path has no end-to-end coverage. Call it directly: a throw out of
+        # get_corners must become an issue string rather than escape and kill the whole
+        # verification run. The reads run under tmap, so this exercises the unwrapping too.
+        issue = VRect.intrinsic_issue(joinpath(DATADIR, ART.corrupt), 0.0, 2.0, 1.0, missing, 0.0, 640, 480, (7, 10))
+        @test issue isa String
+        @test occursin("issue with corner detection in the calibs window", issue)
+    end
+
     @testset "rows that already failed the extrinsic check are not re-scanned" begin
         # video.mp4 has no corners anywhere: the extrinsic check flags it first, and the (expensive)
         # window scan must then skip the row instead of piling on a second issue.

--- a/test/VerifyRectifications/test_reading.jl
+++ b/test/VerifyRectifications/test_reading.jl
@@ -109,6 +109,33 @@
         @test_throws InterruptException VRect.save_issue_frame(dir, "v.mp4", 1.0, () -> throw(InterruptException()))
     end
 
+    @testset "corner-detection failures are classified, not caught blindly" begin
+        # What the real pipeline raises (see the _detection_failure comment): a seek yielding no
+        # frame, OpenCV's C++ errors, and the frame read itself.
+        @test VRect._detection_failure(DimensionMismatch("new dimensions"))
+        @test VRect._detection_failure(ErrorException("OpenCV(4.13.0) … findChessboardCorners"))
+        @test VRect._detection_failure(SystemError("open", 2))
+        # A bug here, or a Ctrl-C, is not a detection failure and must propagate.
+        @test !VRect._detection_failure(InterruptException())
+        @test !VRect._detection_failure(MethodError(identity, ()))
+        @test !VRect._detection_failure(BoundsError([1], 2))
+    end
+
+    @testset "task-wrapped failures are unwrapped before classifying" begin
+        # tmap wraps a failure in a TaskFailedException only when it actually spawned; the same
+        # error arrives bare when the work ran inline. Both shapes must reach the same verdict.
+        bare = ErrorException("boom")
+        wrapped = try fetch(Threads.@spawn error("boom")) catch e; e end
+        @test wrapped isa TaskFailedException
+        @test VRect._unwrap_task(wrapped) isa ErrorException
+        @test VRect._detection_failure(VRect._unwrap_task(wrapped))
+        @test VRect._unwrap_task(bare) === bare
+        @test VRect._unwrap_task(CompositeException([bare])) === bare
+        # an interrupt raised inside a task still refuses classification once unwrapped
+        interrupted = try fetch(Threads.@spawn throw(InterruptException())) catch e; e end
+        @test !VRect._detection_failure(VRect._unwrap_task(interrupted))
+    end
+
     @testset "matlab without ImageSize is flagged" begin
         # matlab_dimension guards findfirstkey(...) === nothing and returns the "does not contain any
         # image size" message instead of crashing when ImageSize is absent.

--- a/test/VerifyRectifications/test_values.jl
+++ b/test/VerifyRectifications/test_values.jl
@@ -38,11 +38,13 @@
         @test flagged(check("v_radial.csv", [videorow(radial_parameters = 4)]),   1, "radial_parameters must be 1, 2, or 3")
         @test flagged(check("v_radial0.csv",[videorow(radial_parameters = 0)]),   1, "radial_parameters must be 1, 2, or 3")
         @test flagged(check("v_blur.csv",   [videorow(blur = -1)]),               1, "blur must be larger than or equal to zero")
-        # a checkerboard needs at least 2×2 inner corners (a 1-wide pattern is undetectable and
-        # breaks the checker-size arithmetic), so the bound is ≥ 2, not merely > 0
-        @test flagged(check("v_ncorn.csv",  [videorow(n_corners = (0, 5))]),      1, "n_corners must all be at least 2")
-        @test flagged(check("v_ncorn1.csv", [videorow(n_corners = (1, 5))]),      1, "n_corners must all be at least 2")
-        @test flagged(check("v_ncorn11.csv",[videorow(n_corners = (1, 1))]),      1, "n_corners must all be at least 2")
+        # OpenCV's findChessboardCorners requires both pattern dimensions strictly bigger than 2, so
+        # the bound is ≥ 3. (2, n) used to pass validation and then throw out of the detector.
+        @test flagged(check("v_ncorn.csv",  [videorow(n_corners = (0, 5))]),      1, "n_corners must all be at least 3")
+        @test flagged(check("v_ncorn1.csv", [videorow(n_corners = (1, 5))]),      1, "n_corners must all be at least 3")
+        @test flagged(check("v_ncorn11.csv",[videorow(n_corners = (1, 1))]),      1, "n_corners must all be at least 3")
+        @test flagged(check("v_ncorn2.csv", [videorow(n_corners = (2, 5))]),      1, "n_corners must all be at least 3")
+        @test flagged(check("v_ncorn22.csv",[videorow(n_corners = (2, 2))]),      1, "n_corners must all be at least 3")
         @test flagged(check("v_step.csv",   [videorow(temporal_step = 0)]),       1, "temporal_step must be larger than zero")
         @test flagged(check("v_aspect0.csv",[videorow(aspect = 0)]),              1, "aspect must be larger than zero")
         @test flagged(check("v_aspectn.csv",[videorow(aspect = -1.2)]),           1, "aspect must be larger than zero")


### PR DESCRIPTION
Part of #34 — two of the three Tier 4 sites (`extrinsic_issue`, `intrinsic_issue`). `apriltag_extrinsic_issue` is left out: it needs an API decision on how `reference_frame` should signal failure.

**This one changes a user-facing validation rule**, so it deserves a closer look than the earlier PRs.

### A bug, found by probing rather than reasoning

OpenCV's `findChessboardCorners` requires both pattern dimensions to be **strictly bigger than 2**:

> `(-211:One of the arguments' values is out of range) Both width and height of the pattern should have bigger than 2`

The verification only rejected `< 2`. So `n_corners = (2, 5)` passed validation and then threw out of the detector, reaching the user as that opaque OpenCV text under "issue with corner detection" rather than as a clear validation failure. `(3,3)` is fine.

The bound is now **≥ 3**. This is #34's "check preconditions up front instead of catching the failure" in its purest form — the failure class stops existing rather than being caught more precisely.

### The classifier

Both catches now share one predicate, built on what the pipeline was measured to raise:

```julia
_detection_failure(e) = e isa ProcessFailedException || e isa Base.IOError || e isa SystemError ||
                        e isa DimensionMismatch || e isa ErrorException
```

`DimensionMismatch` is the non-obvious one: a seek past the end makes ffmpeg emit zero bytes, and the failure surfaces from `reshape` as *"new dimensions (320, 240) must be consistent with array length 0"*. `ErrorException` covers OpenCV, which — like MAT.jl in #48 — reports every C++ error that way, so it is as narrow as honesty allows; the comment says so, so the breadth is not mistaken for an oversight.

### The `tmap` wrinkle

`intrinsic_issue` reads under `tmap`, which wraps failures in a `TaskFailedException` **only when it actually spawns** — with a single-element batch the work ran inline and the error arrived bare. Both shapes are unwrapped before classifying. Without that, this narrowing would have silently stopped catching on exactly the threaded path that matters in production. As a side benefit the issue message now reports the original exception instead of a nested `TaskFailedException` dump.

### Also

`extrinsic_issue`'s `mktempdir() do path` wrapper is dropped — `path` was referenced only by commented-out `CameraCalibrations` code, so it created a temp dir per calibration for nothing.

### Tests

14 new assertions: `(2,5)` and `(2,2)` pinning the corrected bound, the classifier across all three real failure types plus the three that must propagate, and the unwrapper across bare / `TaskFailedException` / `CompositeException` — including that an interrupt raised *inside a task* still refuses classification once unwrapped.

### Testing

Full suite locally, Julia 1.12.6, `JULIA_NUM_THREADS=auto`: **909 passed, 0 failed** (7m49s) — 895 on current main, +14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4