### PR TITLE
Share the ffprobe plumbing, and remove the duplicated helpers (#20)

### DIFF
--- a/src/Fromage.jl
+++ b/src/Fromage.jl
@@ -2,10 +2,12 @@ module Fromage
 
 # The four packages of the tracking ecosystem, consolidated as submodules (one repo, one version,
 # one test suite; see the README). Order matters: Rectifications is used by VerifyRectifications,
-# PawsomeTracker by VerifyRuns, and Parsing (the shared CSV-cell machinery) by both gateways.
+# PawsomeTracker by VerifyRuns, and Parsing (the shared CSV-cell machinery) and Probing (the shared
+# ffprobe plumbing) by both gateways.
 include("Rectifications/Rectifications.jl")
 include("PawsomeTracker/PawsomeTracker.jl")
 include("parsing.jl")
+include("probing.jl")
 include("VerifyRectifications/VerifyRectifications.jl")
 include("VerifyRuns/VerifyRuns.jl")
 

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -18,7 +18,6 @@ using OpenCV: OpenCV
 using CoordinateTransformations: LinearMap, Transformation
 using LinearAlgebra: I
 
-const DEFAULT_MAX_DURATION_SECONDS = 86399.999  # 24 hours minus 1 millisecond
 const RowCol = SVector{2, Float32}
 
 # Confidence gate for `detect`: when the window's peak DoG response falls below GATE_FRACTION of
@@ -67,17 +66,6 @@ function get_framerate(file)
 end
 
 get_sigma(target_width) = target_width / 2sqrt(2log(2))
-
-function get_window(target_width, fps, m, t)
-    σ = get_sigma(target_width)
-    ws1 = 4ceil(Int, σ) + 1 # calculates the default window size
-
-    speed = m/t # pixels per second
-    distance = speed / fps # distance traveled per frame
-    ws2 = round(Int, 2distance)
-
-    max(ws1, ws2)
-end
 
 function fix_window_size(wh::NTuple{2, Int}) 
     w, h = wh

--- a/src/Rectifications/Rectifications.jl
+++ b/src/Rectifications/Rectifications.jl
@@ -33,7 +33,7 @@ read_limit() = READ_SEM[].sem_size
 # interpolation into the surrounding `Cmd`. Unlike the deprecated `ffmpeg() do ... end` form it
 # never mutates the process-global `ENV`, so it composes safely under the nested `tmap`
 # concurrency — no snapshot, no `addenv`, no env race (which previously grew `LD_LIBRARY_PATH`
-# without bound until a spawn died with E2BIG). See `_cmd` / `_probe`.
+# without bound until a spawn died with E2BIG). See `_cmd`.
 
 function __init__()
     # Concurrency is bounded only by the share itself; benchmarks against the CIFS mount plateau

--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -10,13 +10,6 @@ An alias for a static vector of three, x, y, and z, indicating a real-world coor
 """
 const XYZ = SVector{3, <: Real}
 
-function _probe(file)
-    s = read(`$(FFMPEG.ffprobe()) -v error -select_streams v:0 -show_entries stream=width,height,field_order -of csv=p=0 $file`, String)
-    w, h, field_order = split(strip(s), ',')
-    yadif = field_order ∈ ("tt", "bb", "tb", "bt") ? true : missing
-    return (parse(Int, w), parse(Int, h), yadif)
-end
-
 # `yadif` marks interlaced footage: `true` ⇒ deinterlace, `false`/`missing` ⇒ progressive, leave as
 # is. `blur` is a gblur sigma; `missing` *and* `0` mean no blur (VerifyRectifications always sends a
 # number, with 0 as its "no blur", so a sigma-0 no-op filter must not be built). Returns the ffmpeg

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -10,7 +10,7 @@ using DataFramesMeta: DataFramesMeta, @groupby, @rtransform!, @transform!, Abstr
     ByRow, Cols, DataFrame, Not, allowmissing!, completecases, dropmissing, groupby,
     nonunique, nrow, passmissing, select, select!, subset
 using ..Parsing: Parsing, MyTemporal, parseto!
-using FFMPEG: ffprobe
+using ..Probing: probe_fields
 using MAT: MAT, matread
 using OhMyThreads: OhMyThreads, tmap
 using PrecompileTools: @setup_workload, @compile_workload

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -202,29 +202,14 @@ end
 
 # Probe one video file with a single ffprobe call: frame width/height, container duration, sample
 # (pixel) aspect ratio and field order (interlacing). Returns a NamedTuple, or an "issue reading..."
-# string if the file can't be probed (corrupt/unreadable). Uses the non-do-block `ffprobe()` (an
-# env-baked Cmd; the deprecated do-block form mutates the global ENV, a race under the tmap that
-# calls this); stderr is dropped so ffmpeg's diagnostics don't leak into the program output.
+# string for a corrupt/unreadable file. The spawn and its `key=value` output are handled by
+# ..Probing (shared with VerifyRuns); what stays here is which entries this gateway asks for and
+# what it derives from them.
 function probe_video(file)
-    exe = ffprobe()   # env-baked Cmd; its env survives interpolation into the command below
-    # Only the spawn is fallible in a way worth catching: ffprobe exiting nonzero on an unreadable
-    # or corrupt file (ProcessFailedException), or the spawn/pipe itself failing (IOError,
-    # SystemError). Reading the output is not — that is handled below, without exceptions.
-    out = try
-        read(pipeline(`$exe -v error -select_streams v:0 -show_entries stream=width,height,sample_aspect_ratio,field_order:format=duration -of default=noprint_wrappers=1 $file`, stderr = devnull), String)
-    catch e
-        e isa ProcessFailedException || e isa Base.IOError || e isa SystemError || rethrow()
-        return "issue reading from video file: $(sprint(showerror, e))"
-    end
-    fields = Dict{String,String}()
-    for line in eachline(IOBuffer(out))
-        occursin('=', line) || continue        # a line without a separator would not destructure
-        k, v = split(line, '='; limit = 2)
-        fields[k] = v
-    end
+    fields = probe_fields(file, "stream=width,height,sample_aspect_ratio,field_order:format=duration")
+    fields isa String && return fields                 # unreadable file: pass the issue straight on
     # The three fields nothing downstream can proceed without. `tryparse` reports an absent or
-    # unparseable one as `nothing`, which becomes a precise issue — where `parse` used to throw
-    # into the catch above and be reported as a read failure, which it is not.
+    # unparseable one as `nothing`, which becomes a precise issue rather than a failed read.
     width    = tryparse(Int, get(fields, "width", ""))
     height   = tryparse(Int, get(fields, "height", ""))
     duration = tryparse(Float64, get(fields, "duration", ""))

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -6,9 +6,9 @@ using DataFramesMeta: DataFramesMeta, @transform!, AbstractDataFrame, ByRow, Col
     DataFrame, Not, allowmissing!, dropmissing, groupby, nrow, passmissing, select!, subset
 using ..Parsing: Parsing, MyTemporal, parseto!
 import ..Parsing: mytryparse                # extended on MyWindow (a type this module owns)
-using FFMPEG: ffprobe
+using ..Probing: probe_fields
 using OhMyThreads: OhMyThreads, tmap
-using ..PawsomeTracker: PawsomeTracker, ApriltagRectification
+using ..PawsomeTracker: PawsomeTracker, ApriltagRectification, get_sigma
 import ..PawsomeTracker: track
 using PrecompileTools: @setup_workload, @compile_workload
 using ProgressMeter: ProgressMeter, @showprogress

--- a/src/VerifyRuns/types.jl
+++ b/src/VerifyRuns/types.jl
@@ -97,8 +97,6 @@ end
 # coalesce only skips `missing`, so a `nothing` would leak through to `track` as-is.
 frame_center(r::Run) = (round(Int, r.source.width * r.source.sar / 2), r.source.height ÷ 2)
 
-get_sigma(target_width) = target_width / 2sqrt(2log(2))
-
 function get_window(target_width, fps, m, duration)
     σ = get_sigma(target_width)
     ws1 = 4ceil(Int, σ) + 1 # calculates the default window size

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -25,29 +25,15 @@ end
 
 # Probe one video file with a single ffprobe call: frame width/height (stored pixels), sample aspect
 # ratio, container duration and the (real) frame rate. Returns a NamedTuple, or an "issue reading..."
-# string for a corrupt/unreadable file. Uses the non-do-block `ffprobe()` (an env-baked Cmd; never
-# mutates the global ENV); stderr is dropped so ffmpeg's diagnostics don't leak into the output.
+# string for a corrupt/unreadable file. The spawn and its `key=value` output are handled by
+# ..Probing (shared with VerifyRectifications); what stays here is which entries this gateway asks
+# for and what it derives from them.
 function probe_video(file)
-    exe = ffprobe()   # env-baked Cmd; its env survives interpolation into the command below
-    # Only the spawn is fallible in a way worth catching: ffprobe exiting nonzero on an unreadable
-    # or corrupt file (ProcessFailedException), or the spawn/pipe itself failing (IOError,
-    # SystemError). Reading the output is not — that is handled below, without exceptions.
-    out = try
-        read(pipeline(`$exe -v error -select_streams v:0 -show_entries stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration -of default=noprint_wrappers=1 $file`, stderr = devnull), String)
-    catch e
-        e isa ProcessFailedException || e isa Base.IOError || e isa SystemError || rethrow()
-        return "issue reading from video file: $(sprint(showerror, e))"
-    end
-    fields = Dict{String, String}()
-    for line in eachline(IOBuffer(out))
-        occursin('=', line) || continue        # a line without a separator would not destructure
-        k, v = split(line, '='; limit = 2)
-        fields[k] = v
-    end
+    fields = probe_fields(file, "stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration")
+    fields isa String && return fields                 # unreadable file: pass the issue straight on
     # The four fields nothing downstream can proceed without (`fps` imputes the run's tracking rate
     # when the csv leaves it blank). `tryparse` reports an absent or unparseable one as `nothing`,
-    # which becomes a precise issue — where `parse` used to throw into the catch above and be
-    # reported as a read failure, which it is not.
+    # which becomes a precise issue rather than being misreported as a failed read.
     width    = tryparse(Int, get(fields, "width", ""))
     height   = tryparse(Int, get(fields, "height", ""))
     duration = tryparse(Float64, get(fields, "duration", ""))

--- a/src/probing.jl
+++ b/src/probing.jl
@@ -1,0 +1,46 @@
+# The ffprobe plumbing shared by the two gateways (VerifyRectifications and VerifyRuns). Both need
+# the same thing from a video file — spawn one ffprobe, read its `key=value` output, report an
+# unreadable file as an issue string — and differ only in which entries they ask for and what they
+# derive from them. That difference stays in the gateways; only the plumbing lives here.
+#
+# It is its own module rather than part of `Parsing` because `Parsing` is CSV-cell machinery that
+# depends on nothing but Dates, and spawning ffprobe has no business widening that.
+module Probing
+
+using FFMPEG: ffprobe
+
+# Run one ffprobe over `file` asking for `entries` (a `-show_entries` spec), and return its output
+# as a `key => value` dict — or an issue string if the file could not be read.
+#
+# Only the spawn is fallible in a way worth catching: ffprobe exiting nonzero on an unreadable or
+# corrupt file (ProcessFailedException), or the spawn/pipe itself failing (IOError, SystemError).
+# Anything else is not an unreadable video and propagates. Uses the non-do-block `ffprobe()` (an
+# env-baked Cmd, so its adjusted PATH/LD_LIBRARY_PATH survive interpolation and the process-global
+# ENV is never mutated — which is what makes this safe under the callers' nested tmaps); stderr is
+# dropped so ffmpeg's diagnostics don't leak into the program output.
+function probe_fields(file, entries)
+    exe = ffprobe()
+    out = try
+        read(pipeline(`$exe -v error -select_streams v:0 -show_entries $entries -of default=noprint_wrappers=1 $file`,
+                      stderr = devnull), String)
+    catch e
+        e isa ProcessFailedException || e isa Base.IOError || e isa SystemError || rethrow()
+        return "issue reading from video file: $(probe_failure(e))"
+    end
+    fields = Dict{String, String}()
+    for line in eachline(IOBuffer(out))
+        occursin('=', line) || continue        # a line without a separator would not destructure
+        k, v = split(line, '='; limit = 2)
+        fields[k] = v
+    end
+    return fields
+end
+
+# `showerror` on a ProcessFailedException prints the whole failed `Cmd` — including the env-baked
+# PATH and LD_LIBRARY_PATH, some 7 kB of it — and this message goes straight into the user-facing
+# issues report. The exit status carries no information a user can act on either, so say what
+# actually happened instead. Other failures are rare and worth printing in full.
+probe_failure(::ProcessFailedException) = "ffprobe could not read it (the file is corrupt, truncated, or not a video)"
+probe_failure(e) = sprint(showerror, e)
+
+end # module Probing

--- a/test/Rectifications/test_module_state.jl
+++ b/test/Rectifications/test_module_state.jl
@@ -1,5 +1,5 @@
 # Module-level state set up in __init__: the read-concurrency semaphore.
-# (The ffmpeg runtime env is no longer snapshotted — `_cmd`/`_probe` get it straight from the
+# (The ffmpeg runtime env is no longer snapshotted — `_cmd` gets it straight from the
 # env-baked `FFMPEG.ffmpeg()`/`ffprobe()` Cmds; see test_ffmpeg_cmd.jl.)
 
 @testset "module state" begin

--- a/test/Rectifications/test_rectification.jl
+++ b/test/Rectifications/test_rectification.jl
@@ -66,12 +66,6 @@
         common = (extrinsic_t, start, stop, step, missing, missing, Wimg, Himg,
                   n_corners, checker_size, 1.0, 1)
 
-        @testset "_probe" begin
-            w, h, yadif = R._probe(vid)
-            @test (w, h) == (Wimg, Himg)
-            @test yadif === missing            # progressive clip ⇒ no deinterlace
-        end
-
         diag = mktempdir()
         # center = missing ⇒ defaults to the frame centre (the intended behaviour)
         rect = R.Rectification(vid, common..., missing, missing; diagnostic = diag)

--- a/test/probing.jl
+++ b/test/probing.jl
@@ -1,0 +1,59 @@
+# Unit tests for the shared ffprobe plumbing (Fromage.Probing). Both gateways reach it through
+# their own probe_video, which is covered end to end in their suites; here we pin the plumbing
+# itself once, rather than once per gateway.
+module ProbingTests
+
+using Test
+using Fromage: Fromage
+using FFMPEG: FFMPEG
+
+const P = Fromage.Probing
+
+@testset "Probing (shared ffprobe plumbing)" begin
+    dir = mktempdir()
+    vid = joinpath(dir, "v.mp4")
+    FFMPEG.ffmpeg_exe(`-y -loglevel error -f lavfi -i testsrc=duration=1:size=320x240:rate=25 -pix_fmt yuv420p $vid`)
+    corrupt = joinpath(dir, "c.mp4")
+    write(corrupt, rand(UInt8, 500))
+
+    @testset "a readable file yields its requested entries" begin
+        f = P.probe_fields(vid, "stream=width,height:format=duration")
+        @test f isa Dict{String, String}
+        @test f["width"] == "320"
+        @test f["height"] == "240"
+        @test parse(Float64, f["duration"]) ≈ 1.0 atol = 0.2
+        # only what was asked for comes back
+        @test !haskey(f, "r_frame_rate")
+    end
+
+    @testset "unreadable files become issue strings, never throws" begin
+        for f in (corrupt, joinpath(dir, "nope.mp4"))
+            issue = P.probe_fields(f, "stream=width")
+            @test issue isa String
+            @test startswith(issue, "issue reading from video file")   # the prefix both gateways flag on
+        end
+    end
+
+    @testset "a failed ffprobe reports briefly, not by dumping the command" begin
+        # `showerror` on a ProcessFailedException prints the entire env-baked Cmd — the full PATH
+        # and LD_LIBRARY_PATH, some 7 kB — and this message lands in the user-facing issues report.
+        # The exit status carries nothing a user can act on, so it is replaced by what happened.
+        issue = P.probe_fields(corrupt, "stream=width")
+        @test length(issue) < 200
+        @test !occursin("LD_LIBRARY_PATH", issue)
+        @test occursin("corrupt, truncated, or not a video", issue)
+    end
+
+    @testset "probe_failure: brief for a failed process, verbatim otherwise" begin
+        # The two arms directly: a failed ffprobe is summarized (the Cmd dump is the whole problem),
+        # while any other failure — rare, and not something we can paraphrase usefully — is printed
+        # in full. Driving probe_fields only ever produces the first arm, hence the direct test.
+        pfe = try read(`false`) catch e; e end
+        @test pfe isa ProcessFailedException
+        @test occursin("corrupt, truncated, or not a video", P.probe_failure(pfe))
+        @test P.probe_failure(ErrorException("boom")) == "boom"
+        @test occursin("nope", P.probe_failure(SystemError("nope", 2)))
+    end
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
     # Only on the pinned CI minor — see the header of jet.jl.
     VERSION.major == 1 && VERSION.minor == 11 && include("jet.jl")
     include("parsing.jl")
+    include("probing.jl")
     include("rectifications.jl")
     include("pawsometracker.jl")
     include("apriltag.jl")


### PR DESCRIPTION
Follow-up to #34 (now closed). **Closes #20.**

Two probe_video bodies were near-identical, and the same copy-paste problem existed one layer down between PawsomeTracker and VerifyRuns. One shared home each.

### The shared plumbing

Spawn one ffprobe, read its `key=value` output, report an unreadable file as an issue string — that moves to a small `Probing` module. Each gateway keeps what genuinely differs: which entries it asks for and what it derives from them.

```julia
fields = probe_fields(file, "stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration")
fields isa String && return fields          # unreadable file: pass the issue straight on
```

Its own module rather than part of `Parsing`, because `Parsing` is CSV-cell machinery depending on nothing but `Dates`, and spawning ffprobe has no business widening that.

**`parse_sar` and `parse_sample_aspect` are deliberately NOT merged.** Both read `sample_aspect_ratio`, but produce different types (`Rational` vs `Float64`) under different validity rules. Unifying them would be a behaviour change dressed as a refactor — the opposite of what a dedupe PR should do.

### A 7,354-character error message, fixed

`showerror` on a `ProcessFailedException` prints the entire env-baked `Cmd` — the full `PATH` and `LD_LIBRARY_PATH` — and that message went **straight into the user-facing issues report**. For a corrupt video it ran to 7,354 characters, none of it actionable. Now 105:

```
issue reading from video file: ffprobe could not read it (the file is corrupt, truncated, or not a video)
```

The `"issue reading from video file"` prefix both gateways flag on is unchanged, and a test pins the length under 200 chars with no `LD_LIBRARY_PATH`, so this can't come back quietly.

### #20's four items

| Item | Resolution |
|---|---|
| `get_window` dead in PawsomeTracker | deleted — coverage showed it never executed; the live copy imputes `window_size` in VerifyRuns |
| `get_sigma` duplicated verbatim | VerifyRuns' copy deleted, imports PawsomeTracker's — that module's `Tracker` genuinely uses it (47 hits) |
| `DEFAULT_MAX_DURATION_SECONDS` unused | deleted — zero references |
| `_probe` called only from its own test | deleted, with its testset and two stale comment references |

Each was confirmed against coverage data before removal rather than by reading. `Fromage.VerifyRuns.get_sigma === Fromage.PawsomeTracker.get_sigma` now returns `true` — one function, not two that can drift.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **949 passed, 0 failed** (6m46s). Run with `coverage = true`: `probing.jl` and `VerifyRuns/types.jl` have **zero uncovered lines**.

Note on JET: it is gated to Julia 1.11, and a local 1.11 run is not currently possible — 1.11's Pkg rejects the checked-in `Manifest.toml` (resolved under 1.12, referencing the 1.12 stdlib `JuliaSyntaxHighlighting`). JET did validate the immediately preceding commit cleanly; the delta since is deletion of dead code plus one import change. main's 1.11 jobs will confirm after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4