### PR TITLE
Make the corrupt-video fixture deterministic, and report a stream-less file as unreadable

### DIFF
--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -209,12 +209,18 @@ function probe_video(file)
     fields = probe_fields(file, "stream=width,height,sample_aspect_ratio,field_order:format=duration")
     fields isa String && return fields                 # unreadable file: pass the issue straight on
     # The three fields nothing downstream can proceed without. `tryparse` reports an absent or
-    # unparseable one as `nothing`, which becomes a precise issue rather than a failed read.
+    # unparseable one as `nothing`.
+    #
+    # Reaching here means ffprobe *succeeded* and still could not describe a video: it opened the
+    # file but `-select_streams v:0` matched nothing (an audio-only file), or it recognised some
+    # container in what is really junk. Both mean the same thing to the user — this is not a usable
+    # video — so it joins the "issue reading from video file" family rather than getting a message
+    # of its own, which would suggest our parsing broke rather than their file being bad.
     width    = tryparse(Int, get(fields, "width", ""))
     height   = tryparse(Int, get(fields, "height", ""))
     duration = tryparse(Float64, get(fields, "duration", ""))
     if isnothing(width) || isnothing(height) || isnothing(duration)
-        return "malformed ffprobe output (missing or unparseable width/height/duration)"
+        return "issue reading from video file: ffprobe reported no usable video stream (missing or unparseable width/height/duration)"
     end
     # aspect and field order have documented fallbacks, so a missing one is not an error.
     return (; width, height, duration,

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -32,14 +32,19 @@ function probe_video(file)
     fields = probe_fields(file, "stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration")
     fields isa String && return fields                 # unreadable file: pass the issue straight on
     # The four fields nothing downstream can proceed without (`fps` imputes the run's tracking rate
-    # when the csv leaves it blank). `tryparse` reports an absent or unparseable one as `nothing`,
-    # which becomes a precise issue rather than being misreported as a failed read.
+    # when the csv leaves it blank). `tryparse` reports an absent or unparseable one as `nothing`.
+    #
+    # Reaching here means ffprobe *succeeded* and still could not describe a video: it opened the
+    # file but `-select_streams v:0` matched nothing (an audio-only file), or it recognised some
+    # container in what is really junk. Both mean the same thing to the user — this is not a usable
+    # video — so it joins the "issue reading from video file" family rather than getting a message
+    # of its own, which would suggest our parsing broke rather than their file being bad.
     width    = tryparse(Int, get(fields, "width", ""))
     height   = tryparse(Int, get(fields, "height", ""))
     duration = tryparse(Float64, get(fields, "duration", ""))
     fps      = parse_framerate(get(fields, "r_frame_rate", ""))
     if isnothing(width) || isnothing(height) || isnothing(duration) || isnothing(fps)
-        return "malformed ffprobe output (missing or unparseable width/height/duration/frame rate)"
+        return "issue reading from video file: ffprobe reported no usable video stream (missing or unparseable width/height/duration/frame rate)"
     end
     # sar has a documented square-pixel fallback, so a missing one is not an error.
     return (; width, height, duration, fps, sar = parse_sar(get(fields, "sample_aspect_ratio", "1:1")))

--- a/test/common.jl
+++ b/test/common.jl
@@ -24,7 +24,20 @@ function make_checkerboard_video(path, png; duration = 5)
     path
 end
 
-make_corrupt_video(path) = (write(path, rand(UInt8, 500)); path)
+# A file ffprobe reliably refuses: the leading bytes of a real mp4, with the moov atom and all the
+# media data cut off. This used to be `rand(UInt8, 500)`, which made every corrupt-video test a dice
+# roll — roughly 1 random blob in 300 is recognised by ffprobe as some container, whereupon it exits
+# 0 and reports nothing usable rather than failing. That input is real and the code must handle it,
+# but it has no business arriving at random: it is now covered deliberately by the audio-only case
+# in test/probing.jl, while this fixture always exercises the outright-unreadable path.
+function make_corrupt_video(path)
+    mktempdir() do dir
+        whole = joinpath(dir, "whole.mp4")
+        make_video(whole; duration = 1, size = (64, 64), rate = 5)
+        write(path, read(whole)[1:500])
+    end
+    return path
+end
 
 # A disc whose display-space center follows x(N) = col − A·sin(0.5π·N/fps), y(N) = row (ffmpeg
 # 0-based coordinates, A = width/2.5), drawn by ffmpeg's geq expression at width×height square

--- a/test/probing.jl
+++ b/test/probing.jl
@@ -13,8 +13,17 @@ const P = Fromage.Probing
     dir = mktempdir()
     vid = joinpath(dir, "v.mp4")
     FFMPEG.ffmpeg_exe(`-y -loglevel error -f lavfi -i testsrc=duration=1:size=320x240:rate=25 -pix_fmt yuv420p $vid`)
+    # Deterministically unreadable: a real mp4 with everything after the first 500 bytes cut off.
+    # (Random bytes were used here before — see make_corrupt_video in common.jl for why they are not.)
     corrupt = joinpath(dir, "c.mp4")
-    write(corrupt, rand(UInt8, 500))
+    whole = joinpath(dir, "whole.mp4")
+    FFMPEG.ffmpeg_exe(`-y -loglevel error -f lavfi -i testsrc=duration=1:size=64x64:rate=5 -pix_fmt yuv420p $whole`)
+    write(corrupt, read(whole)[1:500])
+
+    # Opens cleanly, but has no video stream at all: ffprobe exits 0 and reports only the container
+    # duration. This is the case that used to arrive by luck through a random fixture.
+    audio_only = joinpath(dir, "audio.m4a")
+    FFMPEG.ffmpeg_exe(`-y -loglevel error -f lavfi -i sine=frequency=440:duration=1 -c:a aac $audio_only`)
 
     @testset "a readable file yields its requested entries" begin
         f = P.probe_fields(vid, "stream=width,height:format=duration")
@@ -31,6 +40,22 @@ const P = Fromage.Probing
             issue = P.probe_fields(f, "stream=width")
             @test issue isa String
             @test startswith(issue, "issue reading from video file")   # the prefix both gateways flag on
+        end
+    end
+
+    @testset "a file with no video stream is reported, not mistaken for usable" begin
+        # ffprobe *succeeds* here — it opens the file and prints the container duration — so
+        # probe_fields correctly returns a dict, and it is the gateways that must notice no video
+        # stream was described. Both must say so in the same family as an outright failed read: to
+        # the user the file is simply not a usable video either way.
+        f = P.probe_fields(audio_only, "stream=width,height:format=duration")
+        @test f isa Dict{String, String}          # the probe itself did not fail...
+        @test !haskey(f, "width")                 # ...it just had no video stream to describe
+        for gateway in (Fromage.VerifyRectifications, Fromage.VerifyRuns)
+            issue = gateway.probe_video(audio_only)
+            @test issue isa String
+            @test startswith(issue, "issue reading from video file")
+            @test occursin("no usable video stream", issue)
         end
     end
 


### PR DESCRIPTION
Fixes the `Test` failure on main after #52 merged (run [31876911863](https://github.com/yakir12/Fromage.jl/actions/runs/31876911863)), which skipped AutoRelease. **Main is currently red; merging this should be the run that cuts the release**, covering both #52 and this fix. The failed job has deliberately not been re-run.

### It was a dice roll, not a code fault

The failure was on `test (1, ubuntu-latest)` — the *same* configuration the PR check runs and passes. The other five matrix jobs passed, including all three Julia 1.11 jobs, so JET is clean on #52.

`make_corrupt_video` wrote `rand(UInt8, 500)`. Roughly **1 random blob in 300** is recognised by ffprobe as some container, whereupon it **exits 0** and reports nothing usable instead of failing. Measured locally over 300 draws: 299 exit 1, one exits 0 (emitting `duration=N/A`). With ~3 corrupt fixtures per run that is about 1% per CI run, and main's run lost the toss. It would pass on a re-run — which is exactly why it deserved a fix rather than a retry.

The failing assertion said so precisely:

```
Expression: issue isa String
Evaluated:  Dict{String, String}() isa String
```

### History: introduced in #48, surfaced in #52

Before #48, a stream-less probe reached `fields["width"]`, threw `KeyError` inside the one big catch, and came out as `"issue reading from video file"`. **Both ffprobe outcomes produced the same message**, so the tests passed either way.

#48 narrowed that catch to the spawn and replaced the parsing with `tryparse`, so the same input began returning `"malformed ffprobe output"` — a message the gateway tests do not accept. #52 only relocated that code and added a third corrupt fixture, widening the exposure until it surfaced. So the divergence has been latent on main since #48; #52 was the trigger, not the cause.

### ⚠️ User-visible wording change

A file that ffprobe opens but which has **no video stream** now reports:

```
issue reading from video file: ffprobe reported no usable video stream (missing or unparseable width/height/duration)
```

where since #48 it said `"malformed ffprobe output (…)"`. Anyone who saw the old string in the field between #48 and now will see the new one. The change is deliberate: to a user, a file with no video stream and a file ffprobe cannot open mean the same thing — theirs is not a usable video — and "malformed ffprobe output" wrongly implied our parsing had broken rather than their file being bad. It also restores the pre-#48 behaviour.

### One deviation from the brief

The check stays in the **gateways**, not `probe_fields`. An audio-only file makes ffprobe exit 0 and print only `duration=1.000000` — a **non-empty** dict — so an `isempty(fields)` guard would have caught CI's shape and missed that one, leaving the bug half-fixed. `probe_fields` is generic; only the caller knows which entries it required.

### Tests

- fixture is now the leading 500 bytes of a real mp4 (moov atom and media data cut off) — refused by ffprobe every time, verified in both gateways
- the exit-0 path is exercised **deliberately** rather than by luck, via an audio-only file, asserting both gateways report it in the right family
- `test/probing.jl` goes 16 → 24 assertions; nothing anywhere asserted the old wording

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **957 passed, 0 failed** (7m50s). With `coverage = true`: both new message lines are covered, and `VerifyRuns/verifications.jl` has zero uncovered lines. The two uncovered lines in `VerifyRectifications/verifications.jl` are `read_matlab`'s catch body from #48, outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4