### PR TITLE
Declare the diagnostic's playback speed from the effective frame rate (#55)

### DIFF
--- a/docs/src/runs.md
+++ b/docs/src/runs.md
@@ -65,6 +65,7 @@ long,afternoon,beetle03_b.mp4,0,00:01:03,
 ```
 
 - `file`, `start`, `stop`, and `start_location` are per segment; all other parameters (`target_width`, `fps`, `calibration_id`, …) must be identical across the segments of one run, and all segments must come from the same camera setup (same frame size).
+- The segments are assumed to have been **filmed at the same frame rate** — they are pieces of one continuous recording, so normally they are. This is not checked: if you give segments with different frame rates an explicit `fps`, each one is tracked at the nearest rate *its own* footage allows, and the diagnostic video's playback speed is derived from the first segment. Leave `fps` blank and mismatched segments are caught, because the rate is then read from each video and the segments must agree on it.
 - Leave `start_location` blank on the second segment onwards: tracking continues from where the previous segment ended.
 - `run_id` is all-or-nothing: as soon as one row has a `run_id`, every row needs one (rows with a `run_id` all of their own are ordinary single-video runs). If no row has one, each row is its own run.
 

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -65,6 +65,15 @@ function get_framerate(file)
     parse(Rational{Int}, only(txt))
 end
 
+# The sampler advances whole frames, so the only rates it can deliver are `vid_fps / skip`; this is
+# the stride nearest a request, and the rate it therefore yields. Both the sampler (`Video`) and the
+# diagnostic writer derive from these — the writer declares a playback speed in terms of the rate its
+# frames actually arrive at, and computing that from the *requested* fps instead made the diagnostic
+# claim 2.67x real time at fps = 20 on 30 fps footage (#55). Keeping one definition is also what
+# stops the two drifting apart again.
+frame_skip(vid_fps, requested) = max(1, round(Int, vid_fps / min(requested, vid_fps)))
+effective_fps(vid_fps, requested) = vid_fps / frame_skip(vid_fps, requested)
+
 get_sigma(target_width) = target_width / 2sqrt(2log(2))
 
 function fix_window_size(wh::NTuple{2, Int}) 
@@ -129,7 +138,7 @@ struct Video
     function Video(file, fps, start, stop, scale)
         vid = open_gray_video(file)          # serialized open (openvideo isn't thread-safe); see OPENVIDEO_LOCK
         vid_fps = framerate(vid)
-        skip = max(1, round(Int, vid_fps / min(fps, vid_fps)))
+        skip = frame_skip(vid_fps, fps)
         fps = vid_fps / skip                 # the rate actually delivered; `fps` means this from here on
         img = read(vid)
         t₀ = gettime(vid)
@@ -401,12 +410,17 @@ function track(
     # `Missing` never reaches fix_window_size (which has no method for it).
     window_size = ismissing(window_size) ? round(Int, 2target_width) : window_size
 
+    # The diagnostic must declare the rate its frames actually arrive at, not the one requested: a
+    # non-divisor `fps` otherwise makes it claim the wrong playback speed (#55). The rate is only
+    # knowable from the video, hence the probe; `Video` derives the same stride from the same rule.
+    dia_fps = effective_fps(get_framerate(file), fps)
+
     # AprilTag mode (drone footage): the rectification carries the shared reference and detector
     # family; register out camera motion, track, and return metric ground coordinates with the
     # rectification's centre/north gauge applied. The DiagnoseApriltag (top-down rectified) is created
     # here and shared with track_apriltag.
     if rectification isa ApriltagRectification
-        dia = diagnose_apriltag(diagnostic_file, rectification.reference, darker_target, fps)
+        dia = diagnose_apriltag(diagnostic_file, rectification.reference, darker_target, dia_fps)
         ts, coords = try
             track_apriltag(file, start, stop, scale * target_width, start_location,
                 round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia,
@@ -419,7 +433,7 @@ function track(
         return (ts, _apply_image2real(rectification.image2real, coords))
     end
 
-    ts, coords = diagnose(diagnostic_file, darker_target, rectification, fps) do dia
+    ts, coords = diagnose(diagnostic_file, darker_target, rectification, dia_fps) do dia
         track_one(file, start, stop, scale*target_width, start_location, round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia, scale * initial_search_factor, white_point, scale, background_length)
     end
     # With a rectification, return the target in real-world coordinates (its `image2real` applied);
@@ -465,6 +479,13 @@ function track(
     # `missing` means "use the default", like a blank csv cell (see the single-file method).
     window_size = ismissing(window_size) ? round(Int, 2target_width) : window_size
 
+    # The diagnostic must declare the rate its frames actually arrive at, not the one requested: a
+    # non-divisor `fps` otherwise makes it claim the wrong playback speed (#55). The rate is only
+    # knowable from the video, hence the probe; `Video` derives the same stride from the same rule.
+    # Segments are assumed to share one native frame rate (see the note in runs.md), so the first
+    # one's is representative — as it already is for the `fps` default in this method's signature.
+    dia_fps = effective_fps(get_framerate(files[1]), fps)
+
     nfiles = length(files)
     tss = Vector{StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}(undef, nfiles)
     args = zip(files, start, stop, start_location)
@@ -477,7 +498,7 @@ function track(
     # segments.
     if rectification isa ApriltagRectification
         segs = Vector{Vector{Union{Missing, RowCol}}}(undef, nfiles)
-        dia = diagnose_apriltag(diagnostic_file, rectification.reference, darker_target, fps)
+        dia = diagnose_apriltag(diagnostic_file, rectification.reference, darker_target, dia_fps)
         try
             for (i, (f, t_start, t_stop, loc)) in enumerate(args)
                 tss[i], segs[i] = track_apriltag(f, t_start, t_stop, scale * target_width, loc,
@@ -495,7 +516,7 @@ function track(
     end
 
     ijs = Vector{Vector{RowCol}}(undef, nfiles)
-    diagnose(diagnostic_file, darker_target, rectification, fps) do dia
+    diagnose(diagnostic_file, darker_target, rectification, dia_fps) do dia
         end_location = missing
         for (i, (f, t_start, t_stop, loc)) in enumerate(args)
             loc = coalesce(loc, end_location)

--- a/test/pawsometracker.jl
+++ b/test/pawsometracker.jl
@@ -115,6 +115,29 @@ const DATADIR = mktempdir()
         @test (s.width, s.height) == (640, 360)     # the fixed unrectified canvas
         @test s.nframes == 25
         @test s.fps ≈ 25
+        # the contract as a property of the file itself: playing it takes real_duration/SPEEDUP
+        @test s.nframes / s.fps * 2 ≈ 2 rtol = 0.01
+    end
+
+    @testset "diagnostic playback speed holds for a non-divisor fps (#55)" begin
+        # The check above only covers a divisor rate, where requested == effective and the bug is
+        # invisible. The diagnostic declares its framerate from the fps it is handed, so handing it
+        # the *requested* rate made it claim the wrong speed: measured on this fixture before the
+        # fix, fps = 20 declared 2.67× and fps = 12 declared 1.6×, against a contract of 2×.
+        v30, _ = make_target_video(DATADIR, "diag_fps30"; fps = 30, duration = 2)
+        f30 = joinpath(DATADIR, only(v30))
+        for requested in (30, 25, 20, 12)
+            df = joinpath(DATADIR, "diag_$requested.mp4")
+            track(f30; fps = requested, start_location = (55, 50), target_width = 10,
+                  diagnostic_file = df)
+            s = probe_stream(df)
+            @testset "fps = $requested" begin
+                @test s.nframes > 0
+                # playback duration × speedup == the real duration it covers, whatever rate the
+                # sampler actually delivered
+                @test s.nframes / s.fps * 2 ≈ 2 rtol = 0.01
+            end
+        end
     end
 end
 


### PR DESCRIPTION
**Closes #55.** Follow-up to #54, which fixed the track; this fixes the last place still reading the *requested* fps.

### Measured before and after, not derived

`results.md` promises the diagnostic plays at 2× real time. It declared its framerate from the requested fps while its frames arrived at the effective one, so it claimed `SPEEDUP × requested/effective`. On 30 fps / 2 s footage:

| `fps` | effective | **before** |  | **after** |
|---|---|---|---|---|
| | | written @ declared → playback | speed | speed |
| 30 | 30 | 30 @ 30.0 → 1.00 s | **2.00×** ✓ | 2.00× ✓ |
| 25 | 30 | 30 @ 25.0 → 1.20 s | **1.67×** | 2.00× ✓ |
| 20 | 15 | 15 @ 20.0 → 0.75 s | **2.67×** | 2.00× ✓ |
| 12 | 15 | 30 @ 24.0 → 1.25 s | **1.60×** | 2.00× ✓ |

The 2.67× figure from the issue is confirmed exactly, as is the formula on all four cases.

The frames themselves were always real and correctly annotated — only the rate the container advertised was wrong, which made `results.md` false and would mislead anyone timing something off the video.

### The fix

The stride rule now lives in **one** place:

```julia
frame_skip(vid_fps, requested)    = max(1, round(Int, vid_fps / min(requested, vid_fps)))
effective_fps(vid_fps, requested) = vid_fps / frame_skip(vid_fps, requested)
```

used by both the sampler (`Video`) and the four diagnostic construction sites (two `track` methods × plain and AprilTag branches). Two copies of that rule is precisely what #20 was about, and deriving the sampler and the writer from *separate inputs* is what produced #15, #17 and this — one definition removes the room to disagree.

**Cost:** one extra `get_framerate` per `track` call. The rate is only knowable from the video, and `VideoWriter`'s framerate is fixed at `open_video_out` — which happens before any video is opened for tracking — so there is nothing cheaper to read. Negligible against decoding the frames.

### ⚠️ Side effect

At a non-divisor `fps` the diagnostic's stride recomputes to 1, so it now writes **every** tracked frame instead of every second one: same playback duration, larger file. At `fps = 20` that's 30 frames rather than 15.

### Tests

The existing diagnostic test only covered a divisor rate, where requested == effective and the bug is invisible. It now also asserts the contract as a property of the file — `nframes / fps × SPEEDUP ≈ duration` — and a new testset sweeps 30, 25, 20 and 12 on 30 fps footage, the same cases measured above.

### Docs

`runs.md` gains the segmented-video assumption: segments are taken to share one native frame rate. That is **unchecked** when `fps` is given explicitly (each segment then tracks at the nearest rate its own footage allows, and the diagnostic follows the first), and **caught** when `fps` is left blank, because the rate is imputed per video and `verify_run_consistency!` requires the segments to agree.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **993 passed, 0 failed** (7m59s). With `coverage = true`, every new line is covered (97/45/52/41/4 hits), including the multi-segment path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4