### PR TITLE
Exempt `comment` from the irrelevant-column check (#16)

### DIFF
--- a/src/VerifyRectifications/parsers.jl
+++ b/src/VerifyRectifications/parsers.jl
@@ -116,10 +116,16 @@ end
 # row is irrelevant to this type. Blank cells are fine: mixed-type CSVs share one header, so
 # irrelevant *columns* must be allowed to exist, just not filled. Must run before the COLUMNS
 # back-fill (which adds every column to `dict`).
+#
+# `type` and `comment` are exempt, for different reasons. `type` is what selects the parser, so it
+# is consumed by definition. `comment` is consumed by NO parser, by design — it is free text, and
+# the docs promise it is ignored — which made it look exactly like a wrong-type column and turned a
+# filled comment into a hard error under the default strict mode. It is the only column no type
+# reads, so this exemption closes that case completely.
 function verify_irrelevant(dict, row)
     ismissing(dict[:type]) && return          # wrong type: already reported, no field list to check
     for k in Tables.columnnames(row)
-        (haskey(dict, k) || k == :type) && continue
+        (haskey(dict, k) || k == :type || k == :comment) && continue
         v = row[k]
         (ismissing(v) || (v isa AbstractString && isempty(strip(v)))) && continue
         push!(dict[:issues], "$k is not used by type $(dict[:type])")

--- a/test/VerifyRectifications/helpers.jl
+++ b/test/VerifyRectifications/helpers.jl
@@ -101,7 +101,7 @@ end
 const HEADER = ["calibration_id", "path", "file", "matlab_file", "type", "extrinsic", "extrinsic_index",
                 "start", "stop", "center", "north", "n_corners",
                 "checker_size", "scale", "temporal_step", "radial_parameters", "blur",
-                "yadif", "aspect", "apriltags", "family"]
+                "yadif", "aspect", "apriltags", "family", "comment"]
 
 row(; kw...) = buildrow(HEADER; kw...)
 write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)

--- a/test/VerifyRectifications/test_parsing.jl
+++ b/test/VerifyRectifications/test_parsing.jl
@@ -80,6 +80,21 @@
         @test !flagged(df, 1, "is not used by type")
     end
 
+    @testset "a filled comment is free text, not an irrelevant column" begin
+        # No type parser consumes `comment` — it is free text and data-folder.md promises it is
+        # ignored — so it looked exactly like a wrong-type column and made a filled comment a hard
+        # error under the default strict mode. It must be accepted on every type.
+        note = "measured the board twice; second run looked better"
+        @test clean(check("p_com_vid.csv", [videorow(comment = note)]))
+        @test clean(check("p_com_mat.csv", [matlabrow(comment = note)]))
+        @test clean(check("p_com_sc.csv",  [scalerow(comment = note)]))
+        # a comment on one row of a mixed-type file, blank on the others, is also fine
+        @test clean(check("p_com_mix.csv", [videorow(), matlabrow(comment = note), scalerow()]))
+        # and the check it was caught by still works — the exemption is for `comment` alone
+        @test flagged(check("p_com_still.csv", [videorow(comment = note, scale = 9.5)]),
+                      1, "scale is not used by type video")
+    end
+
     @testset "north without center" begin
         # verify_center2north is called from a separate branch of parse_row per type; assert all three
         # call sites, not just video (the matlab/only_scale wiring was the original 2.1 bug).


### PR DESCRIPTION
**Closes #16.** Independent of #56 — no overlapping files, so either can merge first.

`data-folder.md` promises both csv files accept a free-text `comment` column that is ignored. `runs.csv` does; `calibs.csv` made it a **hard error** under the default strict mode, aborting `main`.

### The asymmetry has nothing to do with comments

`runs.csv` has **one kind of row** — every column maps to a `track` keyword — so there is nothing to check, and `VerifyRuns` has no such check at all.

`calibs.csv` has **four types sharing one header**, each reading a different subset. That creates a mistake `runs.csv` cannot make: filling a column belonging to a *different* type. A `scale` on a `video` row almost certainly means the `type` is wrong — and without the check that `scale` would be silently discarded while the calibration was built by an entirely different method. That is what `verify_irrelevant` is for, and it stays.

`comment` was collateral damage: consumed by no parser, hence indistinguishable from a wrong-type column. The check already exempted `type` — it selects the parser, so it is consumed by definition — and `comment` needed the same treatment for the *opposite* reason: it is consumed by nothing, on purpose.

I checked whether anything else sits in that position. For each type, the other unconsumed columns are all genuinely other-type columns (`matlab_file`, `scale`, `extrinsic_index`, `apriltags`, `family`). **`comment` is the only column no type reads**, so this one exemption closes the case completely — there is no second instance waiting.

### Verified end to end

```
                                        before        after
calibs with comment                     FLAGGED       CLEAN
runs   with comment                      CLEAN        CLEAN
calibs, scale on a video row            FLAGGED      FLAGGED   <- the check still works
strict mode with a filled comment       THREW          OK      <- the reported symptom
```

### Why no test caught this

The test `HEADER` did not include `comment` at all — so neither the filled *nor* the blank case had any coverage. It is there now, which means all ~287 VerifyRectifications scenarios additionally exercise a blank comment column. The new testset covers a filled comment on all three types, on one row of a mixed-type file, and asserts that a wrong-type column *alongside* a comment is still reported — so the exemption cannot be widened by accident.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **989 passed, 0 failed** (7m54s). With `coverage = true`, the exemption line is covered (8910 hits). VerifyRectifications alone: 287/287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4