### PR TITLE
Test a segmented AprilTag run, with one diagnostic spanning both segments

### DIFF
--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -223,6 +223,46 @@ end
     @test maximum(abs((p - a)[1] * d[2] - (p - a)[2] * d[1]) for p in present) < 3
 end
 
+@testset "AprilTag: a segmented run, with one diagnostic spanning both segments" begin
+    # The vector `track` method's AprilTag branch had no coverage at all — every other AprilTag test
+    # drives the single-file method. That left the per-segment loop, the shared DiagnoseApriltag,
+    # `reduce(vcat, segs)` and the timestamp stitching untested; the field case is a long drone
+    # flight the camera split across files. Both segments are filmed over the same (stationary) tags,
+    # so one shared reference registers both, which is the premise of AprilTag mode.
+    dir = mktempdir()
+    vidA, groundA, slA, nA = make_apriltag_video(dir, "segA"; nframes = 40)
+    vidB, _, slB, nB = make_apriltag_video(dir, "segB"; nframes = 40)
+    fileA, fileB = joinpath(dir, vidA), joinpath(dir, vidB)
+    # the reference comes from segment A's extrinsic frame and serves both segments
+    rect = Fromage.PawsomeTracker.ApriltagRectification(fileA, 0.2, 4, "tag36h11", 8, missing, missing, 480, 480)
+
+    diag = joinpath(dir, "segmented.mp4")
+    sls = Vector{Union{Missing, NTuple{2, Int}}}([slA, slB])
+    ts, xy = Fromage.PawsomeTracker.track([fileA, fileB]; rectification = rect, start_location = sls,
+                                          target_width = 12, diagnostic_file = diag)
+
+    @test length(xy) == nA + nB                        # both segments, concatenated
+    @test length(ts) == length(xy)
+    # the stitched timestamps continue at the tracked rate across the join — the vector method
+    # rebuilds the range from the first segment's step, so a wrong step shows up only here
+    @test step(ts) ≈ 1 / 25 rtol = 1e-6
+    @test first(ts) == 0
+
+    # tags are visible throughout these fixtures, so every frame should have registered
+    @test count(ismissing, xy) == 0
+    # the coordinates are metric: the disc covers the same known ground distance in each segment,
+    # so both halves must span the same distance (checker_size = 8 ⇒ metric unit = ground px)
+    ground_disp = hypot((groundA[nA] .- groundA[1])...)
+    @test hypot((xy[nA] - xy[1])...) ≈ ground_disp rtol = 0.1
+    @test hypot((xy[end] - xy[nA + 1])...) ≈ ground_disp rtol = 0.1
+
+    # one diagnostic covers both segments and still plays at 2× real time over their combined
+    # duration — the contract that was never checked for a spanning diagnostic
+    @test isfile(diag) && filesize(diag) > 0
+    s = probe_stream(diag)
+    @test s.nframes / s.fps * 2 ≈ (nA + nB) / 25 rtol = 0.05
+end
+
 @testset "AprilTag calibration: failing extrinsic frame is dumped to the issues folder" begin
     # the video has four tags; asking for six fails detection at the extrinsic frame, and the frame
     # is dumped to the issues folder (pointed at a temp dir) for the user to inspect.


### PR DESCRIPTION
Unblocks #56's `codecov/patch` failure — but it is worth more than a coverage number.

### The gap

**The vector `track` method's AprilTag branch had no coverage at all.** Every AprilTag test in the suite drives the single-file method (`test/fromage.jl:187` and `:213`), so all of this was untested:

- the per-segment tracking loop
- the shared `DiagnoseApriltag` spanning segments
- `reduce(vcat, segs)`
- the timestamp stitching

The field case is a long drone flight the camera split across files — which is why `MultiRun` exists in the first place.

### How it surfaced

#56 modifies one line inside that branch, so codecov counted a **pre-existing** hole against its patch: 88.88% of diff hit, one line short of the 90% target, the single miss being `diagnose_apriltag` in this branch.

Unlike the precompile guards excluded in #49, this line is perfectly testable — so the right answer is a test, not an exclusion.

### What the test actually checks

Assertions aimed at what only this path can get wrong:

- **`step(ts)` across the join.** The vector method discards segment 2's own timestamps and extrapolates the first segment's step (`range(tss[1][1], step = step(tss[1]), length = n)`). A wrong step here would be invisible everywhere else in the suite.
- **Both halves span the same known ground distance.** Each segment covers the same disc trajectory, so this catches a segment registered against the wrong reference.
- **The spanning diagnostic plays at 2× over the segments' *combined* duration** — the contract #55/#56 is about, and one that was never checked for a multi-segment diagnostic.
- Plus: concatenated length, no `missing` frames (tags are visible throughout), `first(ts) == 0`.

### Why it is green on plain main

The fixture stays at its native 25 fps, so `requested == effective` and the diagnostic contract holds with or without #56's fix. Had I used a non-divisor rate the test would fail on main for #56's reason rather than its own, and could not land first.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **998 passed, 0 failed** (7m05s). New testset: 9/9. Coverage confirms the branch is now exercised end to end:

```
segs = Vector{...}                    1 hit
dia = diagnose_apriltag(...)          1 hit    <- the line that failed #56
track_apriltag(...)  [in the loop]    2 hits   <- once per segment
reduce(vcat, segs)                    1 hit
```

### After this merges

#56 needs only `git merge main` and a re-run — its diff still contains that line, but the line is then covered, taking its patch coverage to 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4