### PR TITLE
Impute a MultiRun's start location without mutating the run (#23)

### DIFF
--- a/src/VerifyRuns/types.jl
+++ b/src/VerifyRuns/types.jl
@@ -129,9 +129,15 @@ function track(r::SingleRun; center = missing, rectification = nothing, kwargs..
     track(r.file; start = r.start, stop = r.stop, start_location, window_size = impute_window_size(r), shared_kw(r)..., rectification, kwargs...)
 end
 
+# The per-segment start locations with the first segment's fallbacks applied, as a vector `track` can
+# take. The `copy` is what makes this a query rather than an edit: assigning into `r.start_locations`
+# meant the first `track` wrote its `center` into the run, so a later call with a *different* `center`
+# silently kept the first one — the coalesce then saw a non-missing first element, and the
+# frame-centre fallback was unreachable too (#23). A `Run` describes what the csv said; tracking it
+# must leave it alone.
 function impute_start_location(r::MultiRun, center)
-    sls = r.start_locations
-    sls[1] = @coalesce r.start_locations[1] center frame_center(r)
+    sls = copy(r.start_locations)
+    sls[1] = @coalesce sls[1] center frame_center(r)
     return sls
 end
 

--- a/test/VerifyRuns/test_segments.jl
+++ b/test/VerifyRuns/test_segments.jl
@@ -81,4 +81,34 @@
         @test df isa AbstractDataFrame
         @test flagged(df, 2, "file does not exist")
     end
+
+    @testset "imputing the start location leaves the run untouched (#23)" begin
+        # A `Run` describes what the csv said; tracking it must not rewrite it. The imputation used
+        # to assign into `r.start_locations` itself, so the first `track` baked its `center` into the
+        # run — and a later call with a *different* `center` then silently kept the first one, because
+        # the coalesce saw a non-missing first element.
+        # (`isequal`, not `==`: comparing vectors that contain `missing` yields `missing`.)
+        runs = check("seg_nomutate.csv", [runrow(run_id = "m", file = ART.a, start_location = missing),
+                                          runrow(run_id = "m", file = ART.b)])
+        r = only(runs)
+        @test r isa VR.MultiRun
+        before = copy(r.start_locations)
+        @test all(ismissing, before)                  # nothing to impute from the csv
+
+        sls = VR.impute_start_location(r, (7, 9))
+        @test sls[1] == (7, 9)                        # the caller gets the imputed vector...
+        @test ismissing(sls[2])                       # ...with later segments left alone
+        @test sls !== r.start_locations               # ...as a vector of its own
+        @test isequal(r.start_locations, before)      # and the run itself is unchanged
+
+        # so a second call is free to impute something else
+        sls2 = VR.impute_start_location(r, (11, 13))
+        @test sls2[1] == (11, 13)
+        @test isequal(r.start_locations, before)
+
+        # the frame-centre fallback (no centre given) must not write back either
+        sls3 = VR.impute_start_location(r, missing)
+        @test sls3[1] == VR.frame_center(r)
+        @test isequal(r.start_locations, before)
+    end
 end


### PR DESCRIPTION
**Closes #23.** Independent of #56 and #58 — different files.

`impute_start_location` assigned into `r.start_locations`, so `track(r::MultiRun)` edited what looks like a value object describing the csv.

### The issue undersells it

It says "idempotent in practice, but surprising". It is **not** idempotent. Once the first call writes its `center` in, the coalesce sees a non-`missing` first element, so a later call with a **different** `center` silently returns the first one — and the frame-centre fallback becomes unreachable entirely.

Written as failing tests first, and the output says it better than prose:

```
sls2[1] == (11, 13)             Evaluated: (7, 9) == (11, 13)
sls3[1] == VR.frame_center(r)   Evaluated: (7, 9) == (320, 240)
```

It is idempotent only if every call happens to pass the same centre.

### The fix

`copy` — which is what turns this back into a query rather than an edit.

I verified it is the **only** such aliasing rather than assuming: that assignment was the sole write to `start_location(s)` anywhere in `src`. The AprilTag branch does hand `track` the run's own vector, but the callee only `zip`s and iterates it (`loc` is rebound per segment, never assigned back), so it is read-only and copying there would be noise.

### Visible consequence beyond the API surprise

`main` returns a DataFrame whose `r` column holds these runs, so `runs.r[i].start_locations` used to show an imputed value **that was never in the user's csv**. It now shows what the csv said — which is what `results.md` describes that column as ("the parsed run and calibration entries").

### Tests

6 failing assertions before the fix, 216/216 in VerifyRuns after. They cover the distinct-vector guarantee, the run staying unchanged, a second call being free to impute something else, and the frame-centre fallback — each of which failed on the old code.

`isequal` rather than `==` throughout, since comparing vectors that contain `missing` yields `missing` rather than a Bool.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **999 passed, 0 failed** (8m05s). With `coverage = true`, both changed lines are covered (12 and 6 hits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4