### PR TITLE
Remove `white_point`, which was plumbed everywhere and read nowhere (#19)

### DIFF
--- a/docs/src/help.md
+++ b/docs/src/help.md
@@ -60,7 +60,7 @@ main("path/to/data";
 ```
 
 - `rectification_defaults` may set: `checker_size`, `n_corners`, `temporal_step`, `radial_parameters`, `blur`, `yadif`.
-- `tracking_defaults` may set: `target_width`, `window_size`, `darker_target`, `fps`, `initial_search_factor`, `white_point`, `scale`.
+- `tracking_defaults` may set: `target_width`, `window_size`, `darker_target`, `fps`, `initial_search_factor`, `scale`, `background_length`.
 
 Anything else (identities, file names, timestamps, `start_location`/`center`/`north`) is per-row only, and an unrecognized or unconvertible entry is rejected with an error before anything runs. Global values pass through the same validation as csv cells — e.g. a global `fps` must still not exceed each video's own frame rate. `only_rectify` and `only_track` accept their respective keyword (`rectification_defaults` / `tracking_defaults`).
 

--- a/docs/src/runs.md
+++ b/docs/src/runs.md
@@ -41,7 +41,10 @@ beetle03.mp4,afternoon
 | `comment` | — | free text, ignored. |
 
 !!! note
-    The `white_point` column is accepted for compatibility but currently has **no effect**. AprilTag drone tracking is configured entirely from `calibs.csv` — see [`type = apriltag`](calibs.md#Columns-for-type-apriltag) — so `runs.csv` has no `apriltags` column.
+    AprilTag drone tracking is configured entirely from `calibs.csv` — see [`type = apriltag`](calibs.md#Columns-for-type-apriltag) — so `runs.csv` has no `apriltags` column.
+
+!!! warning "Removed in v0.1.18"
+    The `white_point` column was accepted but never had any effect, so it has been removed. A `runs.csv` that still has the column is now rejected with `unrecognized column/s in runs file: [:white_point]` — delete the column and the file loads as before. Nothing about tracking changes, since the value was never read.
 
 !!! tip "The one parameter worth measuring: `target_width`"
     Pause a run video on a frame where the animal is clearly visible, and measure how many pixels wide it is (many image viewers let you draw a selection box and read off its size). If the tracker keeps losing your animal, a wrong `target_width` is the first thing to check.

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -348,7 +348,7 @@ function track!(coords, stack, guess, tr, vid, dia)
     end
 end
 
-function track_one(file, start, stop, target_width, start_location, window_size, darker_target, fps, dia, initial_search_factor, white_point, scale, background_length)
+function track_one(file, start, stop, target_width, start_location, window_size, darker_target, fps, dia, initial_search_factor, scale, background_length)
     video(file, fps, start, stop, scale) do vid
         update_ratio!(dia, size(vid.img))
         subtract = background_length != 0
@@ -401,7 +401,6 @@ function track(
         diagnostic_file::Union{Nothing, AbstractString} = nothing,
         initial_search_factor::Real=4,
         scale::Real = 1,
-        white_point::Real = 1,
         background_length::Integer = DEFAULT_BACKGROUND_LENGTH,
         rectification = nothing # rectification object
     )
@@ -426,7 +425,7 @@ function track(
                 round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia,
                 rectification.reference, rectification.family,
                 (rectification.height, rectification.width), scale * initial_search_factor,
-                white_point, scale, background_length)
+                scale, background_length)
         finally
             close(dia)
         end
@@ -434,7 +433,7 @@ function track(
     end
 
     ts, coords = diagnose(diagnostic_file, darker_target, rectification, dia_fps) do dia
-        track_one(file, start, stop, scale*target_width, start_location, round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia, scale * initial_search_factor, white_point, scale, background_length)
+        track_one(file, start, stop, scale*target_width, start_location, round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia, scale * initial_search_factor, scale, background_length)
     end
     # With a rectification, return the target in real-world coordinates (its `image2real` applied);
     # without one, the raw pixel track.
@@ -469,7 +468,6 @@ function track(
         diagnostic_file::Union{Nothing, AbstractString} = nothing,
         initial_search_factor::Real = 4,
         scale::Real = 1,
-        white_point::Real = 1, # clamped linear rescaling
         background_length::Integer = DEFAULT_BACKGROUND_LENGTH,
         rectification = nothing
     )
@@ -505,7 +503,7 @@ function track(
                     round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia,
                     rectification.reference, rectification.family,
                     (rectification.height, rectification.width), scale * initial_search_factor,
-                    white_point, scale, background_length)
+                    scale, background_length)
             end
         finally
             close(dia)
@@ -520,7 +518,7 @@ function track(
         end_location = missing
         for (i, (f, t_start, t_stop, loc)) in enumerate(args)
             loc = coalesce(loc, end_location)
-            tss[i], ijs[i] = track_one(f, t_start, t_stop, scale*target_width, loc, round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia, scale * initial_search_factor, white_point, scale, background_length)
+            tss[i], ijs[i] = track_one(f, t_start, t_stop, scale*target_width, loc, round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia, scale * initial_search_factor, scale, background_length)
             end_location = ijs[i][end]
         end
     end

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -524,7 +524,7 @@ diagnose_apriltag(file::AbstractString, ref, darker_target, fps) = DiagnoseApril
 # reference frame's (rows, cols) — the run may have a different resolution. `dia` is a
 # `DiagnoseApriltag`/`Dont` created (and closed) by the caller — shared across a run's segments.
 function track_apriltag(file, start, stop, target_width, start_location, window_size, darker_target,
-                        fps, dia, ref::ReferenceFrame, family, ref_sz, initial_search_factor, white_point, scale, background_length)
+                        fps, dia, ref::ReferenceFrame, family, ref_sz, initial_search_factor, scale, background_length)
     ids = ref.ids
     ntags = length(ids)
     video(file, fps, start, stop, scale) do vid

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -19,7 +19,7 @@ export load_runs
 # Every column maps onto a `PawsomeTracker.track` keyword, plus `run_id` (identity / segment grouping)
 # and `path` (path resolution). This is the full set of recognized CSV columns; anything else is
 # rejected as unrecognized.
-const COLUMNS = (:calibration_id, :comment, :run_id, :path, :file, :start, :stop, :target_width, :start_location, :window_size, :darker_target, :fps, :initial_search_factor, :white_point, :scale, :background_length)
+const COLUMNS = (:calibration_id, :comment, :run_id, :path, :file, :start, :stop, :target_width, :start_location, :window_size, :darker_target, :fps, :initial_search_factor, :scale, :background_length)
 
 include("types.jl")
 include("parsers.jl")

--- a/src/VerifyRuns/parsers.jl
+++ b/src/VerifyRuns/parsers.jl
@@ -24,7 +24,6 @@ const DEFAULTS = (;
     darker_target = true,
     fps = missing,
     initial_search_factor = 4.0,
-    white_point = 1.0,
     scale = 1.0,
     background_length = PawsomeTracker.DEFAULT_BACKGROUND_LENGTH,
 )
@@ -35,7 +34,6 @@ const DEFAULT_TYPES = (;
     darker_target = Bool,
     fps = Float64,
     initial_search_factor = Float64,
-    white_point = Float64,
     scale = Float64,
     background_length = Int,
 )
@@ -60,7 +58,6 @@ function parse_run!(dict, row, defaults)
     parseto!(dict, row, :darker_target, Bool, defaults.darker_target)
     parseto!(dict, row, :fps, Float64, defaults.fps)             # imputed from video framerate when missing
     parseto!(dict, row, :initial_search_factor, Float64, defaults.initial_search_factor)
-    parseto!(dict, row, :white_point, Float64, defaults.white_point)
     parseto!(dict, row, :scale, Float64, defaults.scale)
     parseto!(dict, row, :background_length, Int, defaults.background_length)
 end

--- a/src/VerifyRuns/types.jl
+++ b/src/VerifyRuns/types.jl
@@ -22,7 +22,6 @@ struct Source
     darker_target::Bool
     fps::Float64
     initial_search_factor::Float64
-    white_point::Float64
     scale::Float64
     background_length::Int
     width::Int
@@ -56,7 +55,7 @@ end
 function Source(g::AbstractDataFrame)
     width, height = g.dimension[1]
     Source(g.target_width[1], g.window_size[1], g.darker_target[1],
-        g.fps[1], g.initial_search_factor[1], g.white_point[1], g.scale[1],
+        g.fps[1], g.initial_search_factor[1], g.scale[1],
         g.background_length[1], width, height, g.sar[1])
 end
 
@@ -83,7 +82,7 @@ end
 # impute_window_size).
 function shared_kw(r::Run)
     s = r.source
-    (; s.target_width, s.darker_target, s.fps, s.initial_search_factor, s.white_point, s.scale, s.background_length)
+    (; s.target_width, s.darker_target, s.fps, s.initial_search_factor, s.scale, s.background_length)
 end
 
 # Drive `PawsomeTracker.track` from a verified run — the scalar method for a one-segment `SingleRun`,

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -96,7 +96,7 @@ end
 # missing) is true). All but `calibration_id` (run metadata) and `dimension`/`sar` (the ffprobe-read
 # pixel width/height and sample aspect ratio, not CSV columns) feed `track`.
 const SHARED_PARAMS = (:target_width, :window_size, :darker_target, :fps,
-    :initial_search_factor, :white_point, :scale, :background_length, :calibration_id, :dimension, :sar)
+    :initial_search_factor, :scale, :background_length, :calibration_id, :dimension, :sar)
 
 # A run may be split across several CSV rows (one per segment video) sharing a :run_id. Those rows
 # must agree on every run-level parameter — only file/start/stop/start_location may vary. Compared
@@ -139,7 +139,6 @@ function verifications!(df::AbstractDataFrame, data_path)
     # track downsamples via round(video_fps/fps) - 1, so a requested fps above the video's own rate is nonsensical.
     verify!(df, (f, vf) -> f > vf, "fps cannot exceed the video frame rate", :fps, :video_fps)
     verify!(df, ≤(0), "initial_search_factor must be larger than zero", :initial_search_factor)
-    verify!(df, ≤(0), "white_point must be larger than zero", :white_point)
     verify!(df, ≤(0), "scale must be larger than zero", :scale)
     # scale is a downsampling factor; > 1 would artificially enlarge the frames for no benefit.
     verify!(df, >(1), "scale cannot be larger than one", :scale)

--- a/test/VerifyRuns/helpers.jl
+++ b/test/VerifyRuns/helpers.jl
@@ -33,7 +33,7 @@ make_target_video(name; kw...) = make_target_video(DATADIR, name; kw...)
 
 const HEADER = ["run_id", "calibration_id", "path", "file", "start", "stop", "target_width",
                 "start_location", "window_size", "darker_target", "fps",
-                "initial_search_factor", "white_point", "scale", "background_length"]
+                "initial_search_factor", "scale", "background_length"]
 
 row(; kw...) = buildrow(HEADER; kw...)
 write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)

--- a/test/VerifyRuns/test_input.jl
+++ b/test/VerifyRuns/test_input.jl
@@ -14,4 +14,14 @@
         csv = write_csv(joinpath(DATADIR, "badcol.csv"), [["x", "y"]]; header = ["run_id", "foo"])
         @test_throws "unrecognized column" VR.load_runs(DATADIR, csv)
     end
+
+    @testset "the removed white_point column is now rejected by name (#19)" begin
+        # It was accepted and validated but never read, so it was removed rather than implemented.
+        # A csv that still carries it is rejected up front, naming the column — the migration is
+        # deleting it, and nothing about tracking changes, since the value never reached the tracker.
+        csv = write_csv(joinpath(DATADIR, "wp_removed.csv"), [["c1", "a.mp4", "1.0"]];
+                        header = ["calibration_id", "file", "white_point"])
+        @test_throws "unrecognized column" VR.load_runs(DATADIR, csv)
+        @test_throws "white_point" VR.load_runs(DATADIR, csv)
+    end
 end

--- a/test/VerifyRuns/test_parsing.jl
+++ b/test/VerifyRuns/test_parsing.jl
@@ -59,7 +59,6 @@
         @test flagged(check("p_win.csv",    [runrow(window_size = "wide")]),          1, "wrong window_size format")
         @test flagged(check("p_fps.csv",    [runrow(fps = "fast")]),                  1, "wrong fps format")
         @test flagged(check("p_isf.csv",    [runrow(initial_search_factor = "x")]),   1, "wrong initial_search_factor format")
-        @test flagged(check("p_wp.csv",     [runrow(white_point = "x")]),             1, "wrong white_point format")
         @test flagged(check("p_sc.csv",     [runrow(scale = "big")]),                 1, "wrong scale format")
         @test flagged(check("p_dark.csv",   [runrow(darker_target = "maybe")]),       1, "wrong darker_target format")
     end
@@ -76,7 +75,6 @@
         @test r.start_location               === missing
         @test r.source.darker_target         == true
         @test r.source.initial_search_factor == 4.0
-        @test r.source.white_point           == 1.0
         @test r.source.scale                 == 1.0
     end
 

--- a/test/VerifyRuns/test_values.jl
+++ b/test/VerifyRuns/test_values.jl
@@ -16,7 +16,6 @@
         @test flagged(check("v_win.csv",  [runrow(window_size = "0")]),             1, "window_size must be larger than zero")
         @test flagged(check("v_wint.csv", [runrow(window_size = "(0, 5)")]),        1, "window_size must be larger than zero")
         @test flagged(check("v_isf.csv",  [runrow(initial_search_factor = "0")]),   1, "initial_search_factor must be larger than zero")
-        @test flagged(check("v_wp.csv",   [runrow(white_point = "0")]),             1, "white_point must be larger than zero")
     end
 
     @testset "scale must be in (0, 1]" begin


### PR DESCRIPTION
**Closes #19.**

`white_point` was parsed from `runs.csv`, range-validated, whitelisted in `tracking_defaults`, carried on `Source`, and threaded through **six signatures** — `track` (both methods), `track_one`, `track_apriltag` — to reach code that never looked at it. `runs.md` already conceded it had "no effect".

Of the issue's two options — implement the intended clamped linear rescaling, or strip the plumbing — this strips it, as agreed.

### Removed

The CSV column, `DEFAULTS`/`DEFAULT_TYPES`, the `Source` field and its constructor argument, `shared_kw`, `SHARED_PARAMS`, the `parseto!` call, the `"must be larger than zero"` check, both `track` keywords, and the pass-through parameter with all four call sites.

### ⚠️ User-visible: existing csv files with the column now fail

Unrecognized columns are a **hard error** in `runs.csv`, so a file that still carries `white_point` is rejected with:

```
unrecognized column/s in runs file: [:white_point]
```

The migration is deleting the column, and **nothing about tracking changes**, because the value never reached the tracker. This is the intended behaviour rather than an oversight — an explicit error beats silently accepting a dead column forever.

Handled three ways so it stays diagnosable:

- `runs.md` gains a migration note saying what the error looks like and what to do, replacing the old "accepted for compatibility" one
- a test pins that the rejection **names the column**
- the old note's other half — that `runs.csv` has no `apriltags` column — is still true and stays

### Worth noting

A parameter with no consumer looks exactly like a live one at every layer it passes through. That is how this survived long enough for the docs to end up *documenting* that it did nothing, rather than anyone deleting it — and it's the same species of leftover as the stray TODO in #24.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **1016 passed, 0 failed** (8m14s), run with `coverage = true`. The `quality` testset (Aqua + all five ExplicitImports checks) runs unconditionally, so a stale import or dangling reference left by removing a struct field and six signature parameters would have failed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4