### PR TITLE
Drop CartesianIndex{2} from start_location's declared type (#18)

### DIFF
--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -394,7 +394,13 @@ function track(
         start::Real = 0,
         stop::Real = get_duration(file),
         target_width::Real = 25,
-        start_location::Union{Missing, NTuple{2, Int}, CartesianIndex{2}} = missing,
+        # `CartesianIndex{2}` was in this union with no `get_guess` method behind it, so it
+        # type-checked at the call and then failed with a MethodError once the video was already
+        # open (#18). The union is now exactly what is supported. `RowCol` is absent on purpose
+        # despite having a method: that is the internal form a *later* segment's start takes in the
+        # vector method, carried over from the previous segment's last coordinate — not something a
+        # caller supplies here.
+        start_location::Union{Missing, NTuple{2, Int}} = missing,
         window_size::Union{Missing, Int, NTuple{2, Int}} = round(Int, 2target_width),
         darker_target::Bool = true,
         fps::Real = get_framerate(file),

--- a/test/pawsometracker.jl
+++ b/test/pawsometracker.jl
@@ -26,6 +26,14 @@ const DATADIR = mktempdir()
         @test tracking_rmse(ij, base_exp) < 1
     end
 
+    @testset "start_location's declared type is what is actually supported (#18)" begin
+        # CartesianIndex{2} sat in this union with no get_guess method behind it, so it type-checked
+        # at the call and then died with a MethodError once the video was open and the background
+        # stack built. Rejecting it at the keyword boundary names the expected type and costs nothing.
+        # If it is ever reinstated it needs a get_guess method — and this test to change with it.
+        @test_throws TypeError track(base_file; start_location = CartesianIndex(50, 55))
+    end
+
     @testset "defaults (frame-center start)" begin
         _, ij = track(base_file)
         @test tracking_rmse(ij, base_exp) < 1


### PR DESCRIPTION
**Closes #18.** Independent of #60 — different files, either order.

`track`'s `start_location` union listed `CartesianIndex{2}`, but `get_guess` has no method for it.

### Before and after

```
before:  MethodError: no method matching get_guess(::CartesianIndex{2}, ::PaddedView{...
after:   TypeError: in keyword argument start_location,
                    expected Union{Missing, Tuple{Int64, Int64}},
                    got a value of type CartesianIndex{2}
```

Not only clearer: the old failure came **after** the video was opened and the background stack collected, so on a long run you waited before finding out. Now it is rejected at the call.

### Two things left as comments, since neither is visible in the diff

**`RowCol` is absent from the union on purpose** — even though `get_guess` *does* have a method for it. It is the internal form a later segment's start takes in the vector method, carried over from the previous segment's last coordinate, not something a caller supplies. So the union was wrong in one direction (a type with no method) while correctly omitting a type that has one. Without a note, that asymmetry invites being "fixed" the wrong way.

**Nothing user-facing over-promised.** Both the docstring and `runs.md` document the `"(x, y)"` tuple only. It was purely the type signature — which is exactly why this survived: no document contradicted another, and the declared type is the one thing a reader tends to trust without checking.

### Test

Pins the `TypeError`, with a comment stating that reinstating `CartesianIndex{2}` requires a `get_guess` method **and** a change to the test — so the union cannot drift back out of sync quietly.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **1018 passed, 0 failed** (8m13s), run with `coverage = true`. PawsomeTracker alone: 55/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4