### PR TITLE
Reject an id filter that matches nothing, instead of failing later (#21)

### DIFF
--- a/docs/src/help.md
+++ b/docs/src/help.md
@@ -47,7 +47,7 @@ Fromage.only_rectify("path/to/data"; calibs_file = "calibs.csv", calibration_ids
 Fromage.only_track("path/to/data"; runs_file = "runs.csv", run_ids = ["run1", "long"])
 ```
 
-`main` itself also accepts `run_ids` to process only a subset of the runs (only the calibrations those runs reference are built).
+`main` itself also accepts `run_ids` to process only a subset of the runs (only the calibrations those runs reference are built). Every id you list must exist: if even one does not, the run stops with an error naming it and listing the ids that do exist, rather than quietly processing the ones that matched.
 
 ## Changing a default for all rows at once
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -36,6 +36,24 @@ function save2csv(run_id, (ts, coords))
     end
 end
 
+# Keep only the entries whose `id` field was asked for, and reject any requested id that matched
+# nothing. Filtering by id is a convenience for iterating on one run or calibration, so an id that
+# matches nothing is a typo rather than a request for less — and left unchecked it failed in two
+# unhelpful ways (#21). A total miss emptied the pipeline and only surfaced at the very end, when
+# `concatenate` handed ffmpeg's concat demuxer a zero-entry list: reported as "Error opening input:
+# Invalid data found when processing input", which points at the footage rather than at the filter.
+# A PARTIAL miss was quieter and worse — it simply processed fewer runs than asked for, with no error
+# at all, so nothing prompted the user to look. Hence the strict rule: every requested id must match.
+function filter_ids!(xs, requested, id, what)
+    isnothing(requested) && return xs
+    available = [getfield(x, id) for x in xs]
+    unmatched = setdiff(requested, available)
+    if !isempty(unmatched)
+        error("unknown $id(s) in `$(what)`: $(sort(unmatched)). Available $(id)s: $(sort(available))")
+    end
+    return filter!(x -> getfield(x, id) ∈ requested, xs)
+end
+
 # `rectification_defaults`/`tracking_defaults` globally replace the hardcoded defaults of the
 # tuning parameters (e.g. `rectification_defaults = (n_corners = (5, 8), blur = 0)`,
 # `tracking_defaults = (target_width = 60,)`). The hierarchy is: csv cell → these kwargs → the
@@ -53,9 +71,7 @@ function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.c
     cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults, issues_dir = joinpath(results_dir, "issues"))::Vector{RectificationMethod}
     rs = load_runs(joinpath(data_path, runs_file); defaults = tracking_defaults)::Vector{Run}
 
-    if !isnothing(run_ids)
-        filter!(r -> r.run_id ∈ run_ids, rs)
-    end
+    filter_ids!(rs, run_ids, :run_id, "run_ids")
 
     run_calib_ids = [r.calibration_id for r in rs]
     filter!(c -> c.calibration_id ∈ run_calib_ids, cs)
@@ -91,9 +107,7 @@ function only_track(data_path::String; runs_file = "runs.csv", tracking_defaults
 
     rs = load_runs(joinpath(data_path, runs_file); defaults = tracking_defaults)::Vector{Run}
 
-    if !isnothing(run_ids)
-        filter!(r -> r.run_id ∈ run_ids, rs)
-    end
+    filter_ids!(rs, run_ids, :run_id, "run_ids")
 
     runs = @showprogress desc = "Building runs" tmap((i, r) -> track(r; diagnostic_file = joinpath(results_dir, "$i.mp4")), 1:length(rs), rs)
 
@@ -105,9 +119,7 @@ function only_rectify(data_path::String; calibs_file = "calibs.csv", rectificati
 
     cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults, issues_dir = joinpath(results_dir, "issues"))::Vector{RectificationMethod}
 
-    if !isnothing(calibration_ids)
-        filter!(c -> c.calibration_id ∈ calibration_ids, cs)
-    end
+    filter_ids!(cs, calibration_ids, :calibration_id, "calibration_ids")
 
     calibs = @showprogress desc = "Building rectifications" tmap(Rectification, cs)
 

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -148,6 +148,39 @@ end
     @test filesize(diag) > 0
 end
 
+@testset "an id filter that matches nothing is reported, not obeyed silently (#21)" begin
+    # Filtering by id is a convenience for iterating on one run; an id that matches nothing is a
+    # typo, not a request for less. Unchecked, a total miss emptied the pipeline and only failed at
+    # the very end, when ffmpeg's concat demuxer was handed a zero-entry list — reported as
+    # "Error opening input: Invalid data found when processing input", which points at the footage
+    # rather than the filter. A PARTIAL miss was worse: it silently tracked fewer runs than asked,
+    # with no error at all.
+    dir = mktempdir()
+    make_video(joinpath(dir, "cal.mp4"); size = (320, 240), duration = 2)
+    target, _ = make_target_video(dir, "idf")
+    open(joinpath(dir, "calibs.csv"), "w") do io
+        println(io, "calibration_id,type,file,extrinsic,scale")
+        println(io, "c1,only_scale,cal.mp4,1,2")
+    end
+    open(joinpath(dir, "runs.csv"), "w") do io
+        println(io, "run_id,calibration_id,file,start_location")
+        println(io, "r1,c1,$(only(target)),\"(55, 50)\"")
+    end
+    outdir = mktempdir()
+
+    # a total miss: named, and nothing about ffmpeg
+    @test_throws "r_typo" cd(() -> main(dir; run_ids = ["r_typo"]), outdir)
+    # a partial miss is an error too — strict, because a mistyped id is never intentional
+    @test_throws "r_typo" cd(() -> main(dir; run_ids = ["r1", "r_typo"]), outdir)
+    # the message says which ids exist, so the typo is obvious
+    @test_throws "r1" cd(() -> main(dir; run_ids = ["r_typo"]), outdir)
+    # both partial-pipeline helpers, which returned an empty vector with no error at all
+    @test_throws "r_typo" cd(() -> Fromage.only_track(dir; run_ids = ["r_typo"]), outdir)
+    @test_throws "c_typo" cd(() -> Fromage.only_rectify(dir; calibration_ids = ["c_typo"]), outdir)
+    # and a filter that does match still works
+    @test nrow(cd(() -> main(dir; run_ids = ["r1"], tracking_defaults = (target_width = 10,)), outdir)) == 1
+end
+
 @testset "Fromage end-to-end: AprilTag drone tracking" begin
     # The whole AprilTag path through `main`: a `type = apriltag` calibs row builds the shared
     # reference from the extrinsic frame; the run registers each frame to it (cancelling the drone


### PR DESCRIPTION
**Closes #21.**

`main`, `only_track` and `only_rectify` each filtered by id and never checked that the filter matched.

### A total miss failed at the wrong end, pointing at the wrong thing

The existing consistency guard **cannot** catch it: `any(∉(calib_ids), run_calib_ids)` is vacuously true when both sides are empty — it exists to catch a run referencing a missing calibration, and needs at least one run. So empty frames flowed all the way through to `concatenate`, which handed ffmpeg's concat demuxer a **0-byte `list.txt`**:

```
[in#0 @ 0x99f39c0] Error opening input: Invalid data found when processing input
```

That names ffmpeg and implicates the *footage* — the one thing not wrong. A user with a typo in `run_ids` goes looking at their videos.

### The partial miss is the one that matters, and the issue doesn't mention it

```
main(dir; run_ids = ["r1", "r_typo"])   ->   DataFrame with 1 row, no error
```

One run of two, a clean-looking DataFrame, a diagnostic that merely has less in it. **Nothing fails, so nothing prompts you to check.** Ask for twelve runs, mistype one, get eleven. That is the case that can quietly corrupt an analysis, and it is why the strict rule is the right one.

### The fix

One `filter_ids!` helper replaces all three ad-hoc `filter!` blocks and errors when **any** requested id is unmatched, naming both the offenders and the ids that exist:

```
unknown run_id(s) in `run_ids`: ["r_typo"]. Available run_ids: ["r1"]
unknown calibration_id(s) in `calibration_ids`: ["c_typo"]. Available calibration_ids: ["c1"]
```

`only_track` and `only_rectify` are covered by the same call — both previously returned an empty vector with **no error at all**.

### Two limits, stated rather than glossed

- **It errors after loading, not before.** The filter needs the loaded runs, so the check cannot precede `load_runs`; a typo still pays for csv verification. It *does* now precede rectification building and tracking, the two expensive phases.
- **It is a behaviour change.** Anyone deliberately passing a superset of ids across datasets now gets an error. Strict was the explicit choice: a mistyped id is never intentional.

`help.md` documents the strictness, since it was the only place describing these filters.

### ⚠️ Also: a one-word correction of my own from #60

The `runs.md` migration note said `white_point` was **"Removed in v0.1.18"**. It wasn't — v0.1.18 still contains it; the removal shipped in **v0.1.19**. Verified by checking both tags:

```
v0.1.18: white_point present in src? YES (not yet removed)
v0.1.19: white_point present in src? no  (removed)
```

Unrelated to this change and folded in anyway, because a wrong version in a migration note actively misleads someone deciding whether they need to act.

### Testing

Tests written first: 5 of 6 assertions failed before the fix, all pass after. Full suite, `JULIA_NUM_THREADS=auto`, **1022 passed, 0 failed** (8m23s) with `coverage = true`; `filter_ids!` is fully covered including both branches (5 error paths, 2 filters, 11 passthroughs).

Note the local run predates merging main (#60, #61) into this branch; the merge itself was clean and is verified by this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4