### PR TITLE
Label the AprilTag diagnostic, and name the label correctly in the docs (#22)

### DIFF
--- a/docs/src/results.md
+++ b/docs/src/results.md
@@ -20,7 +20,7 @@ The coordinates are already fully converted — lens distortion, perspective, an
 
 ## The diagnostic video
 
-`main` also writes `results_dir/diagnostic.mp4`: every run rendered top-down through its calibration into a fixed 540×540 canvas, with a circle around the tracked position, a trailing trace, and the video's file name as a label — one run after the other, playing at 2× real time (≈24 fps regardless of the tracking fps).
+`main` also writes `results_dir/diagnostic.mp4`: every run rendered top-down through its calibration into a fixed 540×540 canvas, with a circle around the tracked position, a trailing trace, and the run's `run_id` as a label — one run after the other, playing at 2× real time (≈24 fps regardless of the tracking fps).
 
 This is what a healthy run looks like — the circle sits on the animal for the whole run, and the trace grows behind it from the centre of the arena to the edge (one complete run, looping):
 

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -447,6 +447,7 @@ end
 # judge both rectification quality and tracking at a glance. The canvas covers the reference tags'
 # cm bounding box (plus a margin) at a fixed pixel size, with square pixels.
 struct DiagnoseApriltag <: Diagnosis
+    label::String
     writer::VideoWriter
     m::Int
     xc::Float64                                   # canvas ↔ cm: centre (cm) …
@@ -457,8 +458,11 @@ struct DiagnoseApriltag <: Diagnosis
     state::Ref{Int}
     skip::Int
     radius::Int
+    font::Int
+    face::FTFont                                  # private per writer; see the FONT note in diagnose.jl
 
     function DiagnoseApriltag(file::AbstractString, ref, darker_target, fps)
+        label = first(splitext(basename(file)))
         m = DIAGNOSTIC_SIZE
         cm = [apply_h(ref.M, p) for p in ref.corners]           # tag corners in ground cm
         xs = getindex.(cm, 1)
@@ -472,8 +476,9 @@ struct DiagnoseApriltag <: Diagnosis
         buffer = Matrix{Gray{N0f8}}(undef, m, m)
         writer = open_video_out(file, buffer; framerate = diagnostic_framerate(fps, skip),
             encoder_private_options = DIAGNOSTIC_ENCODER)
-        new(writer, m, xc, yc, ppc, darker_target ? Gray{N0f8}(1) : Gray{N0f8}(0),
-            CircularBuffer{CartesianIndex{2}}(TRACE_BUFFER_SIZE), Ref(0), skip, max(2, m ÷ 60))
+        new(label, writer, m, xc, yc, ppc, darker_target ? Gray{N0f8}(1) : Gray{N0f8}(0),
+            CircularBuffer{CartesianIndex{2}}(TRACE_BUFFER_SIZE), Ref(0), skip, max(2, m ÷ 60),
+            m ÷ 16, FTFont(String(FONT)))
     end
 end
 
@@ -501,7 +506,12 @@ function (d::DiagnoseApriltag)(frame, beetle, H)
         draw!(wimg, CirclePointRadius(ij, d.radius; thickness = max(1, d.radius ÷ 2), fill = false), d.color)
         draw!(wimg, Path(d.trace), d.color)
     end
-    write(d.writer, parent(wimg))
+    out = parent(wimg)
+    # Stamp the run's name, as the other two writers do. `main` concatenates every run's diagnostic
+    # into one video, so without it no segment can be told from the next — and a dataset of drone
+    # runs is *all* AprilTag, so previously none of them carried a label at all (#22).
+    renderstring!(out, d.label, d.face, d.font, d.font, d.font, halign = :hleft, valign = :vtop)
+    write(d.writer, out)
     return nothing
 end
 diagnose_apriltag(::Nothing, _, _, _) = Dont()

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -296,6 +296,32 @@ end
     @test s.nframes / s.fps * 2 ≈ (nA + nB) / 25 rtol = 0.05
 end
 
+@testset "the AprilTag diagnostic carries the run's label (#22)" begin
+    # `main` concatenates every run's diagnostic into one video, and a dataset of drone footage is
+    # entirely AprilTag — so with no label, no segment of the combined video could be attributed to
+    # a run, which is exactly what results.md tells the user to do with it.
+    dir = mktempdir()
+    vid, _, sl, _ = make_apriltag_video(dir, "lbl"; nframes = 40)
+    file = joinpath(dir, vid)
+    PT = Fromage.PawsomeTracker
+    rect = PT.ApriltagRectification(file, 0.2, 4, "tag36h11", 8, missing, missing, 480, 480)
+
+    # the label is the diagnostic file's name — which `main` sets to the run_id
+    dia = PT.DiagnoseApriltag(joinpath(dir, "run7.mp4"), rect.reference, true, 25)
+    @test dia.label == "run7"
+    close(dia)
+
+    # and it reaches the *pixels*: two diagnostics differing only in file name must differ in
+    # content. The encoder is deterministic, so before the label they came out byte-identical.
+    outs = map(("aaaa", "wwww")) do name
+        d = joinpath(dir, "$name.mp4")
+        PT.track(file; rectification = rect, start_location = sl, target_width = 12,
+                 diagnostic_file = d)
+        read(d)
+    end
+    @test outs[1] != outs[2]
+end
+
 @testset "AprilTag calibration: failing extrinsic frame is dumped to the issues folder" begin
     # the video has four tags; asking for six fails detection at the extrinsic frame, and the frame
     # is dumped to the issues folder (pointed at a temp dir) for the user to inspect.


### PR DESCRIPTION
**Closes #22** — the last bug-labelled issue.

`Diagnose` and `DiagnoseRectified` each carry a `label`, a private `FTFont` and a `renderstring!` call. `DiagnoseApriltag` had **none of the three**.

### Why it costs something

`main` gives every run a `diagnostic_file` and concatenates them all into `results_dir/diagnostic.mp4`. A dataset containing drone recordings is **entirely AprilTag**, so every segment of the combined video was unlabelled and none of it could be attributed to a run — while `results.md` tells the user to watch that video to catch a bad track, which requires knowing which run is on screen.

Verified rather than assumed, by running a pipeline through `main`: the AprilTag run's segment does reach the concatenated file, at 540×540 like the others. (Both writers use `DIAGNOSTIC_SIZE`, which is precisely why they concatenate into one stream-copied file at all.)

### A second, separate doc error

`results.md` called the label *"the video's file name"*. It isn't — the label comes from the **diagnostic** file's name, which `main` sets to the **`run_id`**. So the docs named the wrong thing even for the two writers that always had a label. Corrected.

### The fix

Mirrors `DiagnoseRectified` exactly: `label`/`font`/`face` fields, `label = first(splitext(basename(file)))`, and one `renderstring!` before the write. The face is per-writer, not shared — see the `FONT` note in `diagnose.jl` for why (concurrently tracked runs sharing one global face can swap each other's glyphs).

### The test asserts pixels, not a field

Two diagnostics differing **only** in file name must differ in content:

```
before the fix:  5785 vs 5785 bytes — byte-identical
after the fix:   6389 vs 6685 bytes — different
```

I checked the byte-identity *before* implementing, so the assertion is known to be meaningful rather than incidentally true: the encoder is deterministic and the container embeds nothing filename-derived, so any difference is the label. A second assertion pins that the label is the diagnostic file's stem, which is what makes it the `run_id` under `main`.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **1027 passed, 0 failed** (8m16s) with `coverage = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4