### PR TITLE
Store the background stack as `Gray{N0f8}` (#27)

### DIFF
--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -209,9 +209,14 @@ struct Tracker
     end
 end
 
+# The stack stores raw frames exactly as they were decoded — `Gray{N0f8}`, which is what libav
+# hands us — rather than widening them to Float32. That is a 4x saving on the largest allocation in
+# the program (a 1080p frame at background_length = 250 is ~494 MB rather than ~1978 MB) and loses
+# nothing, since the values came from N0f8 in the first place. The SIGNED buffer is `Tracker.img`,
+# which receives the background-subtracted frame; see the widening in `detect` (#27).
 function build_stack(scale, sz, n_bkgd, pad_indices)
     tform = LinearMap(SDiagonal(SVector{3, Float64}(1/scale, 1/scale, 1)))
-    PaddedView(zero(Gray{Float32}), WarpedView(Array{Gray{Float32}}(undef, sz..., n_bkgd), tform; fillvalue = zero(Gray{Float32})), pad_indices)
+    PaddedView(zero(Gray{N0f8}), WarpedView(Array{Gray{N0f8}}(undef, sz..., n_bkgd), tform; fillvalue = zero(Gray{N0f8})), pad_indices)
 end
 
 # Registered variant (AprilTag mode): `tform` composes each slice's registration with the inverse
@@ -220,7 +225,7 @@ end
 # `inv` for WarpedView's autorange.
 function build_stack(tform::Transformation, canvas_sz, raw_sz, n_bkgd, pad_indices)
     inds = (Base.OneTo.(canvas_sz)..., Base.OneTo(n_bkgd))
-    PaddedView(zero(Gray{Float32}), WarpedView(Array{Gray{Float32}}(undef, raw_sz..., n_bkgd), tform, inds; fillvalue = zero(Gray{Float32})), pad_indices)
+    PaddedView(zero(Gray{N0f8}), WarpedView(Array{Gray{N0f8}}(undef, raw_sz..., n_bkgd), tform, inds; fillvalue = zero(Gray{N0f8})), pad_indices)
 end
 
 # `background_length = 0` turns background subtraction off, but the stack itself stays (it doubles
@@ -301,7 +306,12 @@ function detect(guess, stack, j, h, img, radii, buff, kernel, sz, scale, bkgd_re
     if isnothing(bkgd_reduce)      # subtraction off: the DoG runs on the raw slice
         img.data[bkgd_indices] .= slice[bkgd_indices]
     else
-        img.data[bkgd_indices] .= slice[bkgd_indices] .- bkgd_reduce(stack[bkgd_indices, :], dims = 3)
+        # Widen BEFORE subtracting. A darker target makes this difference negative, and the stack is
+        # `N0f8` — unsigned, and it wraps silently rather than erroring
+        # (Gray{N0f8}(0.2) - Gray{N0f8}(0.5) == Gray{N0f8}(0.702)), which would leave a
+        # background-matching pixel at 0 and a pixel one quantum darker near 1.0, i.e. the DoG
+        # chasing inverted noise. `img` is Float32 precisely to hold the signed result.
+        img.data[bkgd_indices] .= Gray{Float32}.(slice[bkgd_indices]) .- Gray{Float32}.(bkgd_reduce(stack[bkgd_indices, :], dims = 3))
     end
     window_indices = UnitRange.(guess .- radii, guess .+ radii)
     imfilter!(CPUThreads(Algorithm.FIR()), buff, img, kernel, NoPad(), window_indices)

--- a/test/apriltag.jl
+++ b/test/apriltag.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
 # the geometry is internal to the submodule; import the (non-exported) names directly
 using Fromage.PawsomeTracker: CANON, apply_h, homography_dlt, place_square, fit_metric,
     _worst_side, ReferenceFrame, register, ground_homography,
-    RegisteredWarp, build_stack, canvas2raw, Gray, METRIC_FIT_TOLERANCE
+    RegisteredWarp, build_stack, canvas2raw, Gray, N0f8, METRIC_FIT_TOLERANCE
 
 rot(θ) = SMatrix{2,2,Float64}(cos(θ), sin(θ), -sin(θ), cos(θ))    # proper 2D rotation
 
@@ -86,7 +86,11 @@ project(H) = [[apply_h(H, c) for c in tc] for tc in TAGS_CM]
         # same canvas index, and so must the per-pixel reduction over slices (the background model)
         # — the property the registered stack exists for. Integer translations keep the
         # interpolation exact, so the comparisons are to machine precision.
-        ground = Gray{Float32}.(rand(Float32, 100, 120))
+        # N0f8, matching what the stack actually holds: frames arrive already 8-bit from the
+        # decoder, so nothing is quantised in production. Float32-precision ground data would be
+        # rounded on write and the exactness assertions below would measure that rounding rather
+        # than the registration they are here to test (#27).
+        ground = rand(Gray{N0f8}, 100, 120)
         offs = [(0, 0), (5, 7), (10, 3)]                                   # (row, col) crop offsets
         Hc, Wc = 60, 70
         Hinv(o) = SMatrix{3,3,Float64}(1, 0, 0, 0, 1, 0, -o[2], -o[1], 1)  # ref (x,y) → frame (x,y)

--- a/test/pawsometracker.jl
+++ b/test/pawsometracker.jl
@@ -8,6 +8,8 @@ module PawsomeTrackerTests
 
 using Test
 using Fromage.PawsomeTracker: track
+using Fromage: PawsomeTracker
+const PT = PawsomeTracker
 
 include("common.jl")
 
@@ -32,6 +34,28 @@ const DATADIR = mktempdir()
         # stack built. Rejecting it at the keyword boundary names the expected type and costs nothing.
         # If it is ever reinstated it needs a get_guess method — and this test to change with it.
         @test_throws TypeError track(base_file; start_location = CartesianIndex(50, 55))
+    end
+
+    @testset "the background stack stores frames at their decoded width (#27)" begin
+        # The stack is the largest allocation in the program — a 1080p frame at background_length
+        # 250 is ~494 MB as N0f8 against ~1978 MB as Float32 — and its values come from an N0f8
+        # decode, so the wider type buys no precision. Nothing else in the suite would catch a
+        # regression here: tracking accuracy is identical either way, which is the whole point.
+        vid = PT.Video(base_file, 25, 0, 2, 1.0)
+        try
+            stack = PT.get_stack(vid, (vid.height, vid.width), (10, 10), 10)
+            @test eltype(stack) == PT.Gray{PT.N0f8}
+            @test eltype(parent(parent(stack))) == PT.Gray{PT.N0f8}
+
+            # ...while the buffer receiving the BACKGROUND-SUBTRACTED frame stays Float32, because
+            # that difference is negative for a darker target and N0f8 wraps silently rather than
+            # erroring (0.2 - 0.5 == 0.702). The tracking assertions elsewhere in this file are what
+            # fail if the widening in `detect` is dropped — the DoG then chases inverted noise.
+            tr = PT.Tracker(vid, true, 10, (21, 21), (vid.height, vid.width), true)
+            @test eltype(tr.img) == PT.Gray{Float32}
+        finally
+            close(vid.vid)
+        end
     end
 
     @testset "defaults (frame-center start)" begin


### PR DESCRIPTION
**Closes #27** — which I rewrote before implementing, because the original framing (keep frames `N0f8` so the AprilTag detector can reuse the stack) turned out to be the small half of the story and its payoff largely unreachable.

### What this buys

The stack is the largest allocation in the program, and it held raw frames widened to `Float32` — but frames arrive from libav **already 8-bit** (`AV_PIX_FMT_GRAY8`), so that width carried no precision.

| | `Float32` | `N0f8` |
|---|---|---|
| measured `@allocated`, 1920×1080×50 | 395.6 MB | **98.9 MB** |
| 1080p at `background_length = 250` | ~1978 MB | **~494 MB** |

Accuracy is unchanged, as it must be when the stored values were `N0f8` to begin with — rmse at scale 1.0 / 0.5 / 0.1 comes out **0.139 / 0.237 / 3.053** against **0.14 / 0.24 / 3.05** before.

### The hazardous line

`detect`'s subtraction is now widened **before** subtracting. A darker target makes that difference negative, and `N0f8` is unsigned — it wraps *silently* rather than erroring:

```julia
Gray{N0f8}(0.2) - Gray{N0f8}(0.5) == Gray{N0f8}(0.702)
```

which would leave a background-matching pixel at 0 and a pixel one quantum darker near 1.0 — the DoG chasing inverted noise, with nothing to indicate it. `Tracker.img` and `Tracker.buff` stay `Float32`; they hold the signed result and genuinely need it.

### What this is *not*

Detection cannot reuse the stack. Measured, the per-frame `collect` is **~4%** of frame time, and the detector rejects both views and reinterpreted arrays, so a dense copy would still be required:

| input | result |
|---|---|
| dense `Matrix{Gray{N0f8}}` | accepted |
| a view — what a stack slice is | MethodError |
| reinterpreted `UInt8` | MethodError |

### Tests

- **A regression guard on the stack's element type.** Nothing else would catch a revert to `Float32` — accuracy is identical either way, which is precisely why the wide type survived this long.
- **`apriltag.jl`'s RegisteredWarp test needed correcting.** It fed the stack `Gray{Float32}` random data and asserted a `1e-6` round trip; against `N0f8` storage that measured *its own quantisation* (`0.07058824` is exactly 18/255). It now uses `N0f8` ground data — which is what a real frame is — and **the `1e-6` tolerances stand untouched**, since the offsets are integral at scale 1.0 and 0.5 and sampling there is exact. Loosening the tolerance would have hidden a property that is genuinely exact in production.

### Testing

Full suite, `JULIA_NUM_THREADS=auto`, **1030 passed, 0 failed** (7m17s) with `coverage = true`.

An earlier run showed an additional failure in Aqua's `Persistent tasks`; it passes 15/15 in isolation and the run in question took 10m37s against the usual ~8m15s, so it was load-related flakiness rather than anything in this change.

### Worth checking against real footage

The AprilTag stack is a `WarpedView`, so slices are interpolated at lookup and with an `N0f8` backing those samples quantise to 1/255 steps. Everywhere else this change is merely narrower storage of already-8-bit values; there it is the one place `N0f8` is genuinely lossier than before. Synthetic high-contrast tags will not settle whether that matters — a real drone run will. The memory figures above are also `@allocated` rather than RSS during a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4