### PR TITLE
Say "path is a file, not a folder" when it is

### DIFF
--- a/docs/src/calibs.md
+++ b/docs/src/calibs.md
@@ -44,7 +44,7 @@ Optional:
 | `north` | — | `"(x, y)"` pixel coordinate of a point lying due north of `center`. Rotates the real-world coordinates so that north is consistent across calibrations. Requires `center`. |
 | `blur` | `1` | Gaussian blur (sigma, in pixels) applied to frames before corner detection; helps with noisy/sharpened footage. `0` disables. |
 | `radial_parameters` | `1` | number of radial lens-distortion coefficients to fit (1–3). More isn't automatically better — use 2–3 only for strongly distorting (e.g. fisheye) lenses. Ignored without a calibration window. |
-| `path` | `.` | folder containing `file`, relative to the location of the csv file. |
+| `path` | `.` | the **folder** containing `file`, relative to the location of the csv file. Just the folder — the file name belongs in `file`, not here. |
 | `aspect` | read from video | pixel aspect ratio; only override for anamorphic footage that misreports it. |
 | `yadif` | read from video | `true` to deinterlace interlaced footage; detected automatically, override to force. |
 | `type` | `video` | see above. |
@@ -84,7 +84,7 @@ Required: `calibration_id`, `file` (the drone footage — a video where the tags
 | `checker_size` | `12` | the real-world size of a single tag **cell** (e.g. cm). The black-border square is `cells × checker_size`, where `cells` is 8 for `tag36h11`, 7 for `tag25h9`, 6 for `tag16h5`. **Track coordinates come out in this unit.** |
 | `center` | — | `"(x, y)"` pixel of the arena's origin **in the `extrinsic` frame**. Becomes the origin of the real-world coordinates. |
 | `north` | — | `"(x, y)"` pixel due north of `center` in the `extrinsic` frame; rotates the coordinates so north is consistent. Requires `center`. |
-| `path` | `.` | folder containing `file`, relative to the csv file. |
+| `path` | `.` | the **folder** containing `file`, relative to the csv file. Just the folder — the file name belongs in `file`, not here. |
 
 The tags are stationary across the whole experiment, so the reference is established once here and shared by every run — `runs.csv` therefore has no `apriltags` column (and, for an apriltag run, a run's own `start` frame is where its target search begins, not the calibration's `center`).
 

--- a/docs/src/data-folder.md
+++ b/docs/src/data-folder.md
@@ -33,6 +33,17 @@ main("path/to/my experiment"; calibs_file = "meta/my_calibs.csv", runs_file = "m
 
 And the video files can live in other folders via the `path` column in either csv file. Paths are relative to the folder the csv file itself is in; absolute paths work too.
 
+!!! warning "`path` is a folder, `file` is the file name"
+    `path` names the **folder** the video sits in — never the video itself. The file name always goes in `file`. For `my experiment/videos/beetle01.mp4`:
+
+    | `file` | `path` | |
+    | --- | --- | --- |
+    | `beetle01.mp4` | `videos` | ✔ the folder, with the file name kept separate |
+    | `videos/beetle01.mp4` | *(blank)* | ✔ also fine — `path` defaults to the csv's own folder |
+    | `beetle01.mp4` | `videos/beetle01.mp4` | ✘ `path` must not repeat the file name |
+
+    Putting the video in `path` is reported as *"path is a file, not a folder"*.
+
 ## Editing csv files
 
 A csv file is just a table saved as plain text — you can edit it in Excel, Google Sheets, LibreOffice, or any text editor. Just make sure it's saved as **.csv**, not .xlsx. Template files to copy from live in [`examples/`](https://github.com/yakir12/Fromage.jl/tree/main/examples).

--- a/docs/src/runs.md
+++ b/docs/src/runs.md
@@ -37,7 +37,7 @@ beetle03.mp4,afternoon
 | `scale` | `1` | spatial downsampling factor (0 < scale ≤ 1) applied before tracking; e.g. `0.5` tracks on half-resolution frames (faster). Returned coordinates are always in original-resolution pixels. The scaled target (`target_width × scale`) must remain at least 1 pixel wide. Lowering it costs precision: on clean footage the tracking error is a fraction of a percent of `target_width` down to about `0.25`, a few percent by `0.1`, and worse below that — so treat it as a speed knob for large frames, not a default to reduce. |
 | `background_length` | `250` | how many tracked frames form the rolling background model the target is detected against. Counted at the tracking `fps`, so the model spans `background_length / fps` seconds; memory scales with it. `0` disables background subtraction entirely — fine for clean, high-contrast scenes (and much lighter on memory), but static dark marks then compete with the target. Must be `0` or at least `25`. |
 | `run_id` | row number | identifies the run; only needed for multi-video runs (below). All-or-nothing: either every row has a `run_id`, or none does. |
-| `path` | `.` | folder containing `file`, relative to the location of the csv file. |
+| `path` | `.` | the **folder** containing `file`, relative to the location of the csv file. Just the folder — the file name belongs in `file`, not here. |
 | `comment` | — | free text, ignored. |
 
 !!! note

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -429,6 +429,11 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
     verify_unique_ids!(df)
     @transform! df :path = passmissing(joinpath).(data_path, :path)
 
+    # A path that names the video itself is the common slip, and `isdir` alone reported it as
+    # "does not exist" — which is false, and sends the user to check for a file that is
+    # plainly there (#33). This runs first; verify! nulls :path on failure, so the
+    # existence check below then skips the row rather than piling on the misleading message.
+    verify!(df, isfile, "path is a file, not a folder — it should be the folder holding the video, with the file name in the `file` column", :path)
     verify!(df, !isdir, "path does not exist", :path)
 
     verify!(df, (f, p) -> !isfile(joinpath(p, f)), "file does not exist", :file, :path)

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -116,6 +116,11 @@ function verifications!(df::AbstractDataFrame, data_path)
     # canonical absolute :file (the identity used for per-file reads and segment grouping) and drop
     # path. realpath is safe because non-existent paths were nulled to missing just above.
     @transform! df :path = passmissing(joinpath).(data_path, :path)
+    # A path that names the video itself is the common slip, and `isdir` alone reported it as
+    # "does not exist" — which is false, and sends the user to check for a file that is
+    # plainly there (#33). This runs first; verify! nulls :path on failure, so the
+    # existence check below then skips the row rather than piling on the misleading message.
+    verify!(df, isfile, "path is a file, not a folder — it should be the folder holding the video, with the file name in the `file` column", :path)
     verify!(df, !isdir, "path does not exist", :path)
     verify!(df, (f, p) -> !isfile(joinpath(p, f)), "file does not exist", :file, :path)
     @transform! df :file = passmissing(joinpath).(:path, :file)

--- a/test/VerifyRectifications/test_filesystem.jl
+++ b/test/VerifyRectifications/test_filesystem.jl
@@ -9,6 +9,15 @@
         @test flagged(df, 1, "file does not exist")
     end
 
+    @testset "a path naming the video itself says so (#33)" begin
+        # Putting the video in `path` used to be reported as "path does not exist" — false, and it
+        # sends the user looking for a file that is plainly there. The targeted message runs first
+        # and nulls :path, so the existence check does not also fire with the misleading one.
+        df = check("fs_pathisfile.csv", [videorow(path = ART.board)])
+        @test flagged(df, 1, "path is a file, not a folder")
+        @test !flagged(df, 1, "path does not exist")
+    end
+
     @testset "matlab_file does not exist" begin
         # the .mat path is resolved/checked against path just like the source video `file`
         df = check("fs_matf.csv", [matlabrow(matlab_file = "no_such_file.mat")])

--- a/test/VerifyRuns/test_filesystem.jl
+++ b/test/VerifyRuns/test_filesystem.jl
@@ -6,4 +6,13 @@
     @testset "file does not exist" begin
         @test flagged(check("fs_file.csv", [runrow(file = "no_such_file.mp4")]), 1, "file does not exist")
     end
+
+    @testset "a path naming the video itself says so (#33)" begin
+        # Putting the video in `path` used to be reported as "path does not exist" — false, and it
+        # sends the user looking for a file that is plainly there. The targeted message runs first
+        # and nulls :path, so the existence check does not also fire with the misleading one.
+        df = check("fs_pathisfile.csv", [runrow(path = ART.a)])
+        @test flagged(df, 1, "path is a file, not a folder")
+        @test !flagged(df, 1, "path does not exist")
+    end
 end


### PR DESCRIPTION
Closes #33.

## The problem, reproduced

`path` names the **folder** holding the video; the file name goes in `file`. Putting the video itself in `path` is the natural slip, and the only check on it was `isdir` — so the row came back as **"path does not exist"**, which is simply false:

```
path=videos, file=run1.mp4  (correct)     -> CLEAN
path=videos/run1.mp4, file=run1.mp4       -> path does not exist   <- the file is right there
path=videos/nope.mp4 (really absent)      -> path does not exist
path=nosuchdir                            -> path does not exist

does the mistaken path exist on disk? true   is it a dir? false
```

The message sends the user looking for a missing file when the actual problem is which column it's in.

## The fix

Check `isfile` first and name the mistake. `verify!` nulls `:path` on failure, so the `!isdir` check that follows skips the row rather than stacking the misleading message on top of the accurate one — the three cases are now distinguishable:

```
path=videos/run1.mp4, file=run1.mp4  -> path is a file, not a folder — it should be the folder
                                        holding the video, with the file name in the `file` column
path=videos/nope.mp4                 -> path does not exist
path=nosuchdir                       -> path does not exist
```

Applied to both gateways — `VerifyRuns` and `VerifyRectifications`.

## Docs

- `data-folder.md`: a warning block laying the three csv shapes side by side (folder + file ✔, full relative path in `file` ✔, video in `path` ✘), ending with the message the user will see.
- `runs.md` and `calibs.md` (×2): the `path` rows now read "the **folder** containing `file` … Just the folder — the file name belongs in `file`, not here."

## Testing

Confirmed failing first, on both gateways, with the fix reverted and the tests kept:

```
a path naming the video itself says so (#33): Test Failed at test/VerifyRuns/test_filesystem.jl:15
  Expression: flagged(df, 1, "path is a file, not a folder")
a path naming the video itself says so (#33): Test Failed at test/VerifyRectifications/test_filesystem.jl:17
  Expression: flagged(df, 1, "path is a file, not a folder")
```

Each test also asserts the old message does *not* also fire, so the suppression is pinned and not incidental.

Full suite with `coverage = true`: **1034/1034 pass** (1030 + 4 new), 8m29s. Both new source lines are hit (119× and 159×) — the patch is fully covered.

---

Noted while testing, **not** in this PR: `VerifyRectifications/verifications.jl:273` and `:342` interpolate the raw exception into `"issue with corner detection: $err"`. When that's a `ProcessFailedException` the message becomes the whole `Base.Process` dump including the environment block — the same wart `probe_failure` (`src/probing.jl:43`) already fixes for the ffprobe path. Worth a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4