### PR TITLE
Say what the failed frame read was, not 8 kB of `Cmd`

### DIFF
--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -268,8 +268,14 @@ _detection_failure(e) = e isa ProcessFailedException || e isa Base.IOError || e 
 # anyone can act on. Same reasoning, and same trade, as `Probing.probe_failure`; the wording differs
 # only because the process here is ffmpeg reading a frame rather than ffprobe reading metadata. The
 # rest (an IOError, a DimensionMismatch out of an empty seek) already print short and stay verbatim.
-_failure_message(::ProcessFailedException) = "ffmpeg could not read the frame (the file is corrupt, truncated, or not a video)"
-_failure_message(e) = sprint(showerror, e)
+#
+# One method with a branch, rather than the more idiomatic pair of methods dispatching on the
+# exception type: a method whose whole body is a string literal is const-folded away, so its
+# instrumentation never runs and coverage reports the line as missed even though the tests below
+# exercise it. An expression body is measured normally.
+_failure_message(e) = e isa ProcessFailedException ?
+    "ffmpeg could not read the frame (the file is corrupt, truncated, or not a video)" :
+    sprint(showerror, e)
 
 function extrinsic_issue(file, extrinsic, yadif, blur, width, height, n_corners)
     try

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -262,6 +262,15 @@ _unwrap_task(e) = e isa TaskFailedException ? _unwrap_task(e.task.result) :
 _detection_failure(e) = e isa ProcessFailedException || e isa Base.IOError || e isa SystemError ||
                         e isa DimensionMismatch || e isa ErrorException
 
+# How to say it once classified. The frame read spawns ffmpeg, and `showerror` on a
+# ProcessFailedException prints the whole failed `Cmd` — the env-baked PATH and LD_LIBRARY_PATH
+# included, some 8 kB — which lands verbatim in the user-facing issues report and says nothing
+# anyone can act on. Same reasoning, and same trade, as `Probing.probe_failure`; the wording differs
+# only because the process here is ffmpeg reading a frame rather than ffprobe reading metadata. The
+# rest (an IOError, a DimensionMismatch out of an empty seek) already print short and stay verbatim.
+_failure_message(::ProcessFailedException) = "ffmpeg could not read the frame (the file is corrupt, truncated, or not a video)"
+_failure_message(e) = sprint(showerror, e)
+
 function extrinsic_issue(file, extrinsic, yadif, blur, width, height, n_corners)
     try
         vf = _vf(yadif, blur)
@@ -270,7 +279,7 @@ function extrinsic_issue(file, extrinsic, yadif, blur, width, height, n_corners)
     catch e
         err = _unwrap_task(e)
         _detection_failure(err) || rethrow()
-        return "issue with corner detection: $err"
+        return "issue with corner detection: $(_failure_message(err))"
     end
 end
 
@@ -339,7 +348,7 @@ function intrinsic_issue(file, start, stop, temporal_step, yadif, blur, width, h
         # the original rather than a nested TaskFailedException dump
         err = _unwrap_task(e)
         _detection_failure(err) || rethrow()
-        return "issue with corner detection in the calibs window: $err"
+        return "issue with corner detection in the calibs window: $(_failure_message(err))"
     end
 end
 

--- a/test/VerifyRectifications/test_extrinsics.jl
+++ b/test/VerifyRectifications/test_extrinsics.jl
@@ -27,6 +27,15 @@
         @test length(only(filter(contains("corner detection"), df.issues[1]))) < 200
     end
 
+    @testset "failures that are not a process dump are still shown in full" begin
+        # Only the ProcessFailedException is replaced, and only because printing it means printing
+        # the whole `Cmd`. The others say something specific about this file — a DimensionMismatch
+        # is what an empty seek reshapes into — so they must keep reaching the user verbatim.
+        e = DimensionMismatch("new dimensions (640, 480) must be consistent with array length 0")
+        @test VRect._failure_message(e) == sprint(showerror, e)
+        @test occursin("array length 0", VRect._failure_message(e))
+    end
+
     @testset "a failing extrinsic frame is dumped to the issues folder" begin
         idir = mktempdir()
         # a stale file proves the folder is wiped at the start of each run

--- a/test/VerifyRectifications/test_extrinsics.jl
+++ b/test/VerifyRectifications/test_extrinsics.jl
@@ -19,6 +19,12 @@
         # extrinsic_issue throws; the catch turns that into an issue instead of aborting the load.
         df = check("e_corrupt.csv", [videorow(file = ART.corrupt)])
         @test flagged(df, 1, "issue with corner detection")
+        # ...and it says what happened, in one sentence. Interpolating the raw exception dumped the
+        # entire failed ffmpeg `Cmd` — environment block and all, ~8 kB of it — straight into the
+        # user-facing issues report (same reasoning as Probing.probe_failure).
+        @test flagged(df, 1, "ffmpeg could not read the frame")
+        @test !flagged(df, 1, "LD_LIBRARY_PATH")
+        @test length(only(filter(contains("corner detection"), df.issues[1]))) < 200
     end
 
     @testset "a failing extrinsic frame is dumped to the issues folder" begin

--- a/test/VerifyRectifications/test_intrinsics.jl
+++ b/test/VerifyRectifications/test_intrinsics.jl
@@ -30,6 +30,11 @@
         issue = VRect.intrinsic_issue(joinpath(DATADIR, ART.corrupt), 0.0, 2.0, 1.0, missing, 0.0, 640, 480, (7, 10))
         @test issue isa String
         @test occursin("issue with corner detection in the calibs window", issue)
+        # and it stays readable: the raw ProcessFailedException printed the whole ffmpeg `Cmd`,
+        # environment included, into the report
+        @test occursin("ffmpeg could not read the frame", issue)
+        @test !occursin("LD_LIBRARY_PATH", issue)
+        @test length(issue) < 200
     end
 
     @testset "rows that already failed the extrinsic check are not re-scanned" begin


### PR DESCRIPTION
Follow-up to the note on #66. Not tied to an issue.

## The problem, measured

Corner detection reported a failure by interpolating the raw exception:

```julia
return "issue with corner detection: $err"
```

When the frame read fails on an unreadable file, that exception is a `ProcessFailedException`, and `showerror` on one prints the entire failed ffmpeg `Cmd` — env-baked `PATH`, `LD_LIBRARY_PATH`, and every other environment variable. On a truncated mp4:

| | before | after |
| --- | ---: | ---: |
| `extrinsic_issue` | 7,982 chars | 109 |
| `intrinsic_issue` | 8,003 chars | 130 |

One line each, straight into the user-facing issues report. Nothing in those 8 kB is actionable, and the exit status carries nothing a user can use either.

After:

```
issue with corner detection: ffmpeg could not read the frame (the file is corrupt, truncated, or not a video)
```

## Why not just call `probe_failure`

This is the same trade `Probing.probe_failure` already makes for the ffprobe path (added in #52); these two sites predate it and were never wired up. But reusing it verbatim would print *"ffprobe could not read it"* for a failure of **ffmpeg reading a frame** — the wrong tool. So the helper is local, sitting next to `_detection_failure` where the classification already lives, with a comment pointing at the shared reasoning.

Everything else `_detection_failure` classifies — an `IOError`, the `DimensionMismatch` an empty seek reshapes into — already prints short and is still shown verbatim.

## Scope: why only these two lines

I grepped every raw-exception interpolation in `src/`. Five sites; only these two can reach a `ProcessFailedException`:

- `verifications.jl:97,116` — MAT.jl and file errors (`SystemError`/`ErrorException`/`EOFError`). No subprocess.
- `PawsomeTracker/apriltag.jl:236` — VideoIO errors. No subprocess either; measured on the same corrupt file at **137 chars**, so it is not the same wart and is left alone.

## Testing

The two existing tests that reach these paths now also assert the message is compact and free of the dump. Confirmed failing first:

```
a throwing detection is caught as an issue, never thrown: test_extrinsics.jl:27
  Expression: length(only(filter(contains("corner detection"), df.issues[1]))) < 200
   Evaluated: 7982 < 200
a throwing read is reported, not propagated: test_intrinsics.jl:37
  Expression: length(issue) < 200
   Evaluated: 8003 < 200
```

Plus one new test pinning the other half of the contract — a `DimensionMismatch` still comes through as `sprint(showerror, e)`, in full. That also closes a patch-coverage hole: the fallback method was executable but unhit on the first pass (`0` in the `.cov`), and it is now hit 2×, so every executable line of the patch is covered.

Full suite with `coverage = true`: **1038/1038 pass**, 7m40s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dan1SL399iYUHKawMujz4