### PR TITLE
Move the archaeology out of the comments (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -1,0 +1,516 @@
+# Design history
+
+Why the code looks the way it does.
+
+The comments in `src/` and `test/` describe what the code *does now*. This file holds the other
+half — the decisions, the alternatives that were tried and abandoned, and the bugs that taught us
+something — so that a future reader who wonders "why on earth is it done this way?" has somewhere
+to look before changing it.
+
+Entries cite the issue number where one exists (`#nn` → `github.com/yakir12/Fromage.jl/issues/nn`);
+`git log --grep '#nn'` finds the commit. Nothing here is required reading to work on the package.
+
+---
+
+## Pipeline
+
+### The diagnostic video is concatenated with ffmpeg's concat demuxer
+
+`main` writes one diagnostic segment per run and stream-copies them into a single
+`results_dir/diagnostic.mp4`. This works only because every segment shares one resolution, codec
+and quality — which is why `DIAGNOSTIC_SIZE` is a fixed square canvas and every writer uses the
+same encoder settings, rather than each rectification rendering at its own natural size.
+
+It used to be a pairwise tree of `concat:`-protocol calls with per-join discontinuity heuristics,
+run at `-loglevel 8` so that every warning it produced was hidden. The demuxer rewrites timestamps
+monotonically by design, so the heuristics went away with it.
+
+### An unmatched `run_ids` / `calibration_ids` filter is an error (#21)
+
+Filtering by id is a convenience for iterating on one run, so an id that matches nothing is a
+typo, not a request for less work. Unchecked, it failed twice over: a *total* miss emptied the
+pipeline and only surfaced at the very end, when `concatenate` handed ffmpeg a zero-entry list and
+ffmpeg reported "Invalid data found when processing input" — which points at the footage rather
+than at the filter. A *partial* miss was quieter and worse: fewer runs were processed than asked
+for, with no error at all. Hence the strict rule that every requested id must match.
+
+### Diagnostic playback speed is derived from the effective frame rate (#55)
+
+`fps` in `runs.csv` is a request. The sampler advances whole frames, so the only rates it can
+actually deliver are `vid_fps / skip`. The diagnostic writer originally declared its playback
+speed from the *requested* rate, which made a 20 fps request on 30 fps footage claim 2.67× real
+time. Both the sampler and the writer now derive from `frame_skip`/`effective_fps`, and keeping
+one definition is what stops them drifting apart again.
+
+Before that, the writer's framerate was left at VideoIO's default 24 while every tracked frame was
+written, so a 50 fps track played back at 0.48× speed. Hence `DIAGNOSTIC_SPEEDUP`/`DIAGNOSTIC_FPS`
+and the frame decimation.
+
+### Diagnostics are `.mp4`, not `.ts`
+
+The old `.ts` segments defaulted to MPEG-2 at libavcodec's default *average* bitrate — constant
+bits per second, which turned to mush as the tracking fps rose. `.mp4` selects H.264, whose `crf`
+option gives constant quality instead.
+
+---
+
+## Concurrency
+
+### Reads through a share are the bottleneck, and the limit is global
+
+`Rectifications.READ_SEM` bounds simultaneous ffmpeg opens against the (CIFS/network) share. A
+burst of nested `tmap` tasks otherwise trips EAGAIN ("Resource temporarily unavailable"). The
+limiter is a single process-global semaphore rather than a per-call `ntasks` because the read
+sites are nested — per-call limits would multiply. Benchmarks against the CIFS mount plateau
+around 12–24 concurrent reads, hence the default of 12.
+
+`_read_frame` additionally retries transient failures with exponential backoff, since EAGAIN is
+transient by definition and a few retries ride out residual blips even under the limit.
+
+**If the threading is ever flattened to one level per stage, the semaphore becomes an ordinary
+`tmap(...; ntasks = n)` and can go away — but measure against the real share, not the test
+suite.**
+
+### ffmpeg commands bake their environment into the `Cmd`
+
+Commands interpolate the *called* `FFMPEG.ffmpeg()` / `FFMPEG.ffprobe()` (the non-do-block form),
+each of which returns a `Cmd` with the absolute executable path and an adjusted
+`PATH`/`LD_LIBRARY_PATH` baked in via `setenv`; that environment survives interpolation into the
+surrounding `Cmd`.
+
+The deprecated `ffmpeg() do ... end` form mutates the process-global `ENV` instead. Under nested
+`tmap` concurrency that raced: `LD_LIBRARY_PATH` grew without bound until a spawn died with
+`E2BIG`. The snapshot/`addenv` machinery that worked around it is gone.
+
+### `VideoIO.openvideo` is not thread-safe
+
+Concurrent opens race — badly so on a cold network share, where the open path is slow enough to
+widen the window — and the symptom is silently garbled or simply wrong frames, not an error.
+Decoding independent streams *is* safe, so `OPENVIDEO_LOCK` serializes only the open. The open is
+fast; the decode that follows stays concurrent.
+
+### The AprilTag C detector is not reentrant
+
+`apriltag_detector_detect` has global/static state that concurrent calls corrupt, and under enough
+pressure it segfaults. This was verified three ways — fresh-per-task detectors, pre-created
+per-frame detectors, and pooled-per-thread detectors all fail concurrently, while serial detection
+is clean. Every detection call therefore goes through `APRILTAG_LOCK`. Reads and decoding stay
+concurrent; only the (comparatively cheap) detect is serial.
+
+Reference-frame building serializes the whole read + detect, because it also faces the one-shot
+`VideoIO` read race above. It is one-time setup over a handful of calibrations, so the cost is
+negligible.
+
+---
+
+## Rectifications
+
+### The extrinsics-only rectification is selected by absence, and never flagged
+
+Which constructor a rectification gets is decided *solely* by whether the calibs row has an
+intrinsic window: both `start` and `stop` blank ⇒ the single-frame fit, where pose and focal
+length come from the extrinsic frame alone with every lens-distortion coefficient fixed at zero.
+
+A row that omits the window but still fills `temporal_step` / `radial_parameters` is deliberately
+**not** flagged as inconsistent; those two are silently ignored. Leaving both window bounds out is
+too large an action to happen by mistake, so it expresses intent, and stray leftover parameters
+should not override that intent with an error. (A filled column belonging to a different `type`
+*is* flagged — that is a different situation.) Filling only one of the two bounds is rejected
+upstream.
+
+### A single planar view needs its principal point fixed
+
+One planar view leaves focal length + principal point + pose underdetermined by one degree of
+freedom. `fit_model` therefore adds `CALIB_FIX_PRINCIPAL_POINT` when there is exactly one view,
+pinning it at the image centre (OpenCV's default without an intrinsic guess), which makes the
+single-frame fit well-posed.
+
+### Lens distortion is inverted by bisection on the monotone branch
+
+The forward radial map `g(r) = r·f(r)` is invertible only up to its first critical point — beyond
+that the distortion "folds" and the inverse is ill-posed. `_first_critical` locates that fold as
+the smallest positive root of `g'`, and the inverse is solved by bracketed bisection inside it. A
+point beyond the fold (the peripheral "donut" region) has no physical preimage, so its radius is
+clamped to the fold with a warning.
+
+`inv_lens_distortion` runs per pixel, inside the warp of every diagnostic frame — which is why it
+is a bisection rather than a general root solve, despite the equation being a degree-7 polynomial
+that `Polynomials` could root directly. If that is ever revisited, benchmark it.
+
+### `n_corners` must be at least 3 in both dimensions
+
+OpenCV's `findChessboardCorners` rejects anything smaller ("Both width and height of the pattern
+should have bigger than 2"), so `(2, n)` used to pass validation and then throw out of the
+detector. Checking the precondition in the gateway beats catching the failure in the detector.
+It also subsumes a degenerate case of its own: `checker_size_pixel`'s `2·prod(n) − sum(n)` divisor
+is zero at `(1, 1)`.
+
+---
+
+## Tracking
+
+### `fps` is a request, not a promise (#15, #17)
+
+The sampler advances whole frames, so the deliverable rates are `vid_fps / skip`. The sample count
+and every timestamp are derived from that **effective** rate. Deriving them from the request
+instead made a non-divisor `fps` either overrun the video, or label the track with times its
+frames were never taken at.
+
+Relatedly, sample *i* is raw frame `(i-1)·skip`, i.e. `start + (i-1)/effective_fps`. Spreading the
+samples evenly over `[start, stop]` instead pinned the last one to `stop`, stretching every
+timestamp by up to a frame period even when `fps` divided the rate evenly (#17).
+
+### The background stack stores `Gray{N0f8}`, and `detect` widens before subtracting (#27)
+
+The stack is the largest allocation in the program: a 1080p frame at `background_length = 250` is
+~494 MB as `N0f8` against ~1978 MB as `Float32`. The values came from an `N0f8` decode, so the
+wider type buys no precision.
+
+The subtraction, however, must be widened first. A darker target makes the difference negative,
+and `N0f8` is unsigned and wraps silently rather than erroring
+(`Gray{N0f8}(0.2) - Gray{N0f8}(0.5) == Gray{N0f8}(0.702)`), which would leave a background-matching
+pixel at 0 and a pixel one quantum darker near 1.0 — the DoG chasing inverted noise. `Tracker.img`
+is `Float32` precisely to hold the signed result.
+
+### The target is kept out of its own background model
+
+The stack doubles as the background model and as `detect`'s source of the current frame, so the
+frame must enter whole (detect has to see the target) and the protection happens *after*
+detection: once the position is known, the target's search window in that slice is restored to the
+pre-target background the evicted frame held there. By induction the history never contains the
+target.
+
+Without it, a target that sits still for longer than the rolling window is absorbed by the
+per-pixel max/min, erased from the subtracted image, and the tracker wanders off. (The prefill in
+`collect_stack` is deliberately unprotected: absorption needs the stationary spell to exceed the
+whole background window within the rolling phase.)
+
+The reduction is `maximum` for a darker target and `minimum` for a lighter one: a darker target
+never raises the per-pixel maximum over time, so `maximum` sees through it, whereas a lighter
+target *is* the maximum wherever it ever passed and would erase itself, leaving a ghost swath
+along its own trajectory.
+
+### `collect_stack` is sequential on purpose
+
+`next!(vid)` decodes into the single shared `vid.img` buffer, so copying slice *i* must complete
+before the next read. A spawned copy raced the following `next!` and nondeterministically
+corrupted background slices with (parts of) the wrong frame.
+
+### The confidence gate
+
+When the window's peak DoG response falls below `GATE_FRACTION` of the running response level, the
+frame is treated as "target not seen" (occlusion, glare, washout) and the tracker holds its last
+position instead of chasing the weighted mean of noise. The level is an exponential moving average
+of accepted peaks — self-normalized, so there is no per-video threshold to tune — and it decays
+slowly while holding, so a genuine lasting drop in contrast eventually re-opens the gate.
+
+### `background_length = 0` keeps a 2-slice stack
+
+Zero turns background subtraction off, but the stack itself stays, because it is also `detect`'s
+source of the current frame. It holds 2 slices rather than 1: a single-slice stack has no valid
+linear-interpolation stencil along the slice axis.
+
+### `start_location`'s declared type is exactly what is supported (#18)
+
+`CartesianIndex{2}` sat in the keyword's `Union` with no `get_guess` method behind it, so a call
+type-checked and then died with a `MethodError` once the video was already open and the background
+stack built. The union now names only what works. `RowCol` is absent on purpose despite having a
+method: that is the internal form a *later* segment's start takes in the vector method, carried
+over from the previous segment's last coordinate, not something a caller supplies.
+
+### A `MultiRun`'s imputed start location must not mutate the run (#23)
+
+Assigning the resolved first-segment location back into `r.start_locations` meant the first
+`track` call wrote its `center` into the run, so a later call with a *different* `center` silently
+kept the first one — and the frame-centre fallback became unreachable too. A `Run` describes what
+the CSV said; tracking it leaves it alone.
+
+### Anamorphic video
+
+The stored frame is squeezed horizontally by the sample aspect ratio (`stored x = display x / sar`).
+Window sizes arrive in display pixels and their column extent is converted to stored pixels,
+otherwise an anamorphic (sar < 1) target fills its own search window. `start_location` and a
+rectification's `center`/`north` are likewise display-pixel conventions and are bounds-checked
+against the display width, `width × sar`.
+
+### Diagnostic label fonts are per-writer
+
+FreeType faces are stateful (one glyph slot per face) and FreeTypeAbstraction's per-face lock is
+not held across load → read → copy, so concurrently tracked runs sharing one global face can swap
+each other's label glyphs — a run briefly labelled with another run's id. Each writer therefore
+loads its own private face.
+
+### The AprilTag diagnostic carries a label too (#22)
+
+`main` concatenates every run's diagnostic into one video, so without a label no segment can be
+told from the next — and a dataset of drone runs is *all* AprilTag, so previously none of them
+carried a label at all.
+
+---
+
+## AprilTag rectification
+
+### Geometry decisions, verified against a real drone frame (1080×1920, four tag36h11 tags)
+
+* A homography from all 16 tag corners registers frames robustly. A single tag's homography leaves
+  3.5–13.4 cm of skew on distant tags (error grows with distance from the tag), so every fit uses
+  every corner.
+* The metric map is fit from all four tags jointly, each contributing its known square. Consensus
+  drives the worst square error below 1 cm, against 13 cm for a single tag.
+* The hand-written normalized-DLT homography is both more accurate (Float64 throughout, against
+  OpenCV's Float32 marshalling) and faster (~28 µs against ~41 µs) than `OpenCV.findHomography`,
+  so no OpenCV dependency is needed for it.
+
+### The metric fit tries every tag as its bootstrap
+
+The gauge-pinned iteration has convergence basins, and which bootstrap tag lands in the good one
+is sensitive to sub-pixel corner noise — a 0.1 px difference flipped a real frame from 0.5 cm to
+35 cm of error. So every tag is tried and the globally best result kept. On real footage at least
+one bootstrap reaches sub-centimetre. It is a one-time few-millisecond cost per reference frame,
+not a per-frame one.
+
+The gauge pin itself (rigidly mapping tag 1's square back onto the canonical square each iteration)
+is essential: without it the iteration's cm frame drifts in scale and pose, and diverges under
+strong perspective.
+
+### Registration happens in the stack's index pipe, not per guess
+
+Every background-stack slice is lazily warped through that slice's own registration, so the DoG
+tracker works in the shared reference frame — a static scene — with a stable background model and
+no per-frame guess compensation. The cost is one homography apply per lookup.
+
+Frames missing any tag yield `missing` (their true registration is unknown) and borrow the nearest
+known registration for the background model, which misaligns them only by that brief unknown drone
+motion. The previous native-space stack was misaligned by *all* drone motion.
+
+`RegisteredWarp.Hinvs` is typed `SMatrix{3, 3, Float64, 9}` with its length parameter spelled out:
+the abstract `SMatrix{3, 3, Float64}` boxes every per-lookup load and costs two orders of magnitude
+in `detect`'s background reduce.
+
+### Tags are found by expanding local search
+
+Detection cost scales with pixels, so after the reference frame each tag is searched in a small box
+around where it was last seen. Detecting on a crop reproduces the full-frame corners to better than
+0.1 px (verified), so this is a pure speedup; the box grows and re-searches until the tag is found
+or spans the whole frame, which degrades gracefully to full-frame detection when the drone jumps.
+
+Detection is sequential rather than one task per tag, because `APRILTAG_LOCK` serializes every
+detect anyway — parallel tasks would only contend on it.
+
+The first frame of a run uses a full-frame scan, not an ROI around the reference positions: a run's
+`start` can be far from the calibration's extrinsic frame, so the (stationary) tags may sit
+anywhere in it.
+
+### Segments do not chain their start locations
+
+Each AprilTag segment relocates on its own from its own `start_location`, and a missing one falls
+back to the frame-centre search. Now that tracking happens in shared reference space, chaining a
+segment's metric end position into the next segment's guess via `inv(ref.M)` would be possible —
+it is deliberately not done yet.
+
+For the same reason an AprilTag run ignores the calibration's `center` as a start fallback: that is
+a pixel in the (moved) extrinsic frame, not in the run frame.
+
+---
+
+## The gateways
+
+### Failures are reported, not thrown
+
+A calibration whose extrinsic frame yields no corners, a `.mat` missing a required field, an
+unreadable video — these are facts about the files the user gave us, not exceptional conditions.
+They accumulate as issue strings on the row and are reported together, so one run of the gateway
+tells the user everything that is wrong with their CSV.
+
+`reference_frame` returns a `String` rather than throwing for exactly this reason; the two callers
+that have nowhere to put a message (`ApriltagRectification`, and direct `ReferenceFrame`
+construction) turn it back into a throw themselves.
+
+### A failed check nulls its own field
+
+`verify!` sets the offending field to `missing` after recording the issue, which makes every later
+check skip that row rather than pile on. It is what keeps an inverted calibs window from also
+reporting "temporal_step too short", and a bad `path` from also reporting "file does not exist".
+The ordering of the checks in `verifications!` is therefore load-bearing.
+
+### Every read happens once per physical file
+
+`:file` and `:matlab_file` are collapsed to canonical absolute paths (`joinpath` then `realpath`,
+so `./x`, `a/../x` and symlinks all collapse to one key) before any reading. Grouping on that key
+means one ffprobe per video and one `matread` per `.mat`, no matter how many rows or spellings
+reference them. The same canonical path is the identity used for duplicate detection.
+
+### Duplicate detection compares only clean rows
+
+A row that already failed a check has had its offending field nulled to `missing`, which can make
+two genuinely distinct rows collapse into a spurious "duplicate". Such rows are already reported,
+so nothing is lost by excluding them.
+
+What counts as a duplicate is type-dependent: `matlab` and `only_scale` rows must match on every
+field; `video` rows match on an identity key (file, window, extrinsic, centre, north), since one
+video can legitimately carry several rectifications differing in, say, `blur` — but two rows with
+the same identity that disagree on the remaining parameters also get a conflicting-parameters
+issue.
+
+### `comment` is exempt from the irrelevant-column check (#16)
+
+A filled cell in a column the row's `type` never reads is flagged, because it usually means the
+`type` is wrong. `comment` is consumed by no parser by design — it is free text and the docs
+promise it is ignored — which made it look exactly like a wrong-type column and turned a filled
+comment into a hard error under the default strict mode. It is the only column no type reads, so
+exempting it closes the case completely.
+
+### `run_id` is all-or-nothing
+
+Either every row names its run (enabling multi-segment runs) or no row does, in which case each row
+becomes its own single-segment run identified by its row number. A mixed file is rejected: under
+partial numbering a blank row's auto-generated id could silently merge with an explicit one (say,
+"3") into a bogus multi-segment run, so there is no safe way to honour it.
+
+### `white_point` was removed rather than implemented (#19)
+
+It was accepted, validated and plumbed through the gateway, and then never read by the tracker.
+A CSV that still carries it is now rejected by name as an unrecognized column; since the value
+never reached the tracker, deleting it changes nothing about tracking.
+
+### The `scale` lower bound is a real limit, not a style rule (#24)
+
+`scale` is a downsampling factor and the tracker works in the scaled frame, so it is the *scaled*
+target width that must span at least a pixel — each factor can be individually fine while the
+product is degenerate. Measured on a clean synthetic disc, accuracy decays smoothly as the scaled
+target shrinks (~0.3% of `target_width` at scale 1, 0.7% at 0.25, 4% at 0.1), and below a scaled
+width of roughly half a pixel the tracker stops finding the target at all, reporting positions
+hundreds of pixels away — without throwing. The check uses the *declared* `target_width`, so
+over-declaring it permits a scale too small for the real target; one more reason `target_width` is
+worth measuring.
+
+### "path is a file, not a folder" (#33)
+
+Putting the video itself in `path` is the common slip, and `isdir` alone reported it as "path does
+not exist" — false, and it sends the user looking for a file that is plainly there. The targeted
+check runs first and nulls `:path`, so the existence check does not also fire.
+
+### The issues folder is wiped each run
+
+`results_dir/issues` reflects only the current verification run, so it is removed up front and
+recreated lazily the first time a frame fails to detect.
+
+---
+
+## Error handling
+
+### No bare `catch` (#34, #25)
+
+Every `catch` in the package names the exceptions it can actually handle and rethrows the rest.
+Two things drove this: a bare `catch` around a retry loop ate `Ctrl-C` for the whole backoff
+sequence, and a bare `catch` around a parse relabelled genuine bugs (`MethodError`, `BoundsError`)
+as user-facing "bad file" messages.
+
+Where the narrowing looks suspiciously broad, it is because the library underneath signals
+everything the same way — `MAT.jl` reports essentially every corruption through a generic
+`error(...)`, and OpenCV reports every C++ error as a plain `ErrorException`. `ErrorException` is
+then as narrow as it can honestly get, and it still excludes the `MethodError`/`BoundsError` of a
+bug on our side and the `InterruptException` a bare catch would swallow.
+
+Where a check can replace a catch, it does: `matlab_dimension` and `matlab_extrinsic_count`
+validate the shape and element type of the `Any` they read instead of catching the `InexactError`
+that a malformed value would eventually cause.
+
+### Exceptions from `tmap` need unwrapping
+
+Errors raised inside a `tmap` come back wrapped in a `TaskFailedException` — but only when the
+scheduler actually spawned a task, so the same failure arrives bare when the work ran inline (a
+single-element batch, say). Both shapes must be unwrapped before classifying, or the narrowing
+silently stops catching under the threaded path.
+
+### Process failures print what happened, not the `Cmd` (#67)
+
+`showerror` on a `ProcessFailedException` prints the whole failed `Cmd`, including the env-baked
+`PATH` and `LD_LIBRARY_PATH` — some 7–8 kB — and that message goes straight into the user-facing
+issues report. The exit status carries nothing a user can act on either. So ffmpeg and ffprobe
+failures get a sentence saying the file is corrupt, truncated, or not a video, and everything else
+still prints in full.
+
+`_failure_message` is deliberately one method with a branch rather than a pair of methods
+dispatching on the exception type: a method whose whole body is a string literal is const-folded
+away, so its instrumentation never runs and coverage reports the line as missed even though the
+tests exercise it.
+
+### A successful ffprobe that describes no video is still "unreadable"
+
+Reaching the field parsing means ffprobe *succeeded* and still could not describe a video: it
+opened the file but `-select_streams v:0` matched nothing (an audio-only file), or it recognised
+some container in what is really junk. Both mean the same thing to the user, so they join the
+"issue reading from video file" family rather than getting a message of their own — which would
+suggest our parsing broke rather than their file being bad.
+
+---
+
+## CSV cell parsing
+
+### `mytryparse`, not `Base.tryparse`
+
+Defining our own avoids type piracy on `Base.tryparse` for types we do not own (`String`,
+`NTuple`). The generic fallback delegates to `Base` for the standard types.
+
+### Cells are trimmed, and a blank cell is an absent cell
+
+A stray space must not turn `" file.mp4"` into a missing file, or `"id "` versus `"id"` into a
+missed duplicate. A present-but-blank cell is treated exactly like an absent one, so a required
+field reports "is missing" rather than silently becoming an empty string, and an optional field
+falls back to its default.
+
+### `resolve_defaults` catches exactly two exceptions (#34)
+
+`convert` has no non-throwing counterpart, so validating caller-supplied defaults stays a caught
+exception. Over every whitelisted target type a rejected value fails as either a `MethodError` (no
+such conversion: `"yes"` → `Bool`) or an `InexactError` (a lossy one: `1.5` → `Int`, `2` → `Bool`).
+Anything else is not a rejected default and propagates.
+
+### What may be set globally, and what may not
+
+The `defaults` kwarg whitelists exactly the tuning parameters. Identities and anchors
+(`calibration_id`, `file`, `extrinsic`, `matlab_file`, `extrinsic_index`, `path`), scene points
+(`center`, `north`), the temporal windows, `aspect`, and `only_scale`'s `scale` are all inherently
+per-row. A default of `missing` means "imputed from the probed video", so a caller-supplied value
+still beats the probe on every row whose cell is blank.
+
+---
+
+## Testing
+
+### The corrupt-video fixture is deterministic
+
+It used to be `rand(UInt8, 500)`, which made every corrupt-video test a dice roll: roughly one
+random blob in 300 is recognised by ffprobe as some container, whereupon it exits 0 and reports
+nothing usable rather than failing. That input is real and the code must handle it, but it has no
+business arriving at random — it is now covered deliberately by the audio-only case in
+`test/probing.jl`, while the fixture always exercises the outright-unreadable path.
+
+### Ground truth is analytic
+
+The tracking fixtures render a disc following a closed-form trajectory with ffmpeg's `geq`, encoded
+losslessly (`-qp 0`) so the analytic ground truth stays exact with no encoder noise around the
+disc. Tests assert RMSE against that closure rather than against recorded output.
+
+The same principle runs through the pure unit tests: they assert invariants (`image2real` and
+`real2image` are mutual inverses; a north point lands on the negative x-axis; a regular grid
+measures its own spacing) rather than hard-coded matrices.
+
+### Each suite runs in its own wrapper module
+
+Their helper constants — `DATADIR`, `ART`, `HEADER`, `make_video` — would otherwise collide.
+Testsets nest fine across module boundaries, since they use the task's dynamic scope rather than
+lexical scope.
+
+### JET runs only on the pinned Julia minor
+
+JET couples to compiler internals, so a new Julia release must not be able to break the suite
+through it.
+
+### The precompile workloads are excluded from coverage
+
+They run during precompilation, which the coverage run does not instrument, so they can never be
+hit by the test suite no matter how well the package is tested. Both workloads point at
+nonexistent files, so they exercise the full parse + verification path but bail before any
+ffprobe, `matread` or corner detection — no bundled media, fast and deterministic.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ pkg> add https://github.com/yakir12/Fromage.jl
 
 ## Development
 
+Comments in `src/` and `test/` describe what the code does now. The reasoning behind the
+non-obvious choices — the alternatives that were tried, and the bugs that ruled them out — lives in
+[DESIGN-HISTORY.md](DESIGN-HISTORY.md). Read it before changing anything that looks gratuitously
+complicated; it is usually load-bearing.
+
 Releases are automatic: every push to `main` that passes CI is patch-bumped, tagged, and
 released, and the stable docs advance with it. Put `#minor` or `#major` in the commit message
 to bump more than a patch. There is nothing to do manually — see [RELEASING.md](RELEASING.md)

--- a/src/Fromage.jl
+++ b/src/Fromage.jl
@@ -1,9 +1,9 @@
 module Fromage
 
 # The four packages of the tracking ecosystem, consolidated as submodules (one repo, one version,
-# one test suite; see the README). Order matters: Rectifications is used by VerifyRectifications,
-# PawsomeTracker by VerifyRuns, and Parsing (the shared CSV-cell machinery) and Probing (the shared
-# ffprobe plumbing) by both gateways.
+# one test suite; see the README). Include order matters: Rectifications is used by
+# VerifyRectifications, PawsomeTracker by VerifyRuns, and Parsing (the shared CSV-cell machinery)
+# and Probing (the shared ffprobe plumbing) by both gateways.
 include("Rectifications/Rectifications.jl")
 include("PawsomeTracker/PawsomeTracker.jl")
 include("parsing.jl")

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -37,22 +37,19 @@ const DEFAULT_BACKGROUND_LENGTH = 250
 
 export track, ApriltagRectification
 
-# VideoIO.openvideo (libav's demuxer/codec open) is not thread-safe: concurrent opens race — badly so
-# on a cold network share, where the open path is slow enough to widen the window (it silently yields
-# garbled/wrong frames, not an error). Decoding independent streams IS safe, so we serialize only the
-# open and let every seek/read/decode run concurrently. This guards both the extrinsic-frame reads
-# (`read_frame_at`, run under `tmap` in verification and rectification building) and the per-run
-# tracking opens (the `Video` constructor); the open is fast, so serializing it costs essentially
-# nothing against the decode that follows.
+# VideoIO.openvideo (libav's demuxer/codec open) is not thread-safe: concurrent opens race, and
+# yield garbled or simply wrong frames rather than an error. Decoding independent streams IS safe,
+# so only the open is serialized — every seek/read/decode stays concurrent. Guards both the
+# extrinsic-frame reads (`read_frame_at`, run under `tmap`) and the per-run tracking opens (the
+# `Video` constructor).
 const OPENVIDEO_LOCK = ReentrantLock()
 open_gray_video(file) = lock(() -> openvideo(file; target_format = AV_PIX_FMT_GRAY8), OPENVIDEO_LOCK)
 
 # The AprilTag C detector (`apriltag_detector_detect`) is not reentrant: it has global/static state
-# that concurrent calls corrupt — even distinct, per-thread detectors on distinct frames race
-# (verified: fresh-per-task, pre-created-per-frame, and pooled-per-thread all fail concurrently while
-# serial detection is clean), and under enough pressure it segfaults. So every detection call is
-# serialized process-wide through this lock (see `detect_locked`); this covers both the calibration
-# reference building AND per-run tracking. Reads/decode stay concurrent — only the detect is serial.
+# that concurrent calls corrupt, even across distinct per-thread detectors on distinct frames, and
+# under enough pressure it segfaults. Every detection call is therefore serialized process-wide
+# through this lock (see `detect_locked`), covering both calibration reference building and per-run
+# tracking. Reads and decoding stay concurrent — only the detect is serial.
 const APRILTAG_LOCK = ReentrantLock()
 
 include("diagnose.jl")
@@ -66,11 +63,9 @@ function get_framerate(file)
 end
 
 # The sampler advances whole frames, so the only rates it can deliver are `vid_fps / skip`; this is
-# the stride nearest a request, and the rate it therefore yields. Both the sampler (`Video`) and the
-# diagnostic writer derive from these — the writer declares a playback speed in terms of the rate its
-# frames actually arrive at, and computing that from the *requested* fps instead made the diagnostic
-# claim 2.67x real time at fps = 20 on 30 fps footage (#55). Keeping one definition is also what
-# stops the two drifting apart again.
+# the stride nearest a request, and the rate it therefore yields. The single definition both the
+# sampler (`Video`) and the diagnostic writer derive from — the writer must declare a playback speed
+# in terms of the rate its frames actually arrive at, not the rate that was requested (#55).
 frame_skip(vid_fps, requested) = max(1, round(Int, vid_fps / min(requested, vid_fps)))
 effective_fps(vid_fps, requested) = vid_fps / frame_skip(vid_fps, requested)
 
@@ -130,9 +125,7 @@ struct Video
 
     # `fps` is a request, not a promise: the sampler advances whole frames, so the only rates it can
     # deliver are `vid_fps / skip`. The sample count and every timestamp are derived from that
-    # EFFECTIVE rate, never from the request. Deriving them from the request instead is what made a
-    # non-divisor `fps` either overrun the video or label the track with times its frames were never
-    # taken at (issues #15 and #17).
+    # EFFECTIVE rate, never from the request (#15, #17).
     function Video(file, fps, start, stop, scale)
         vid = open_gray_video(file)          # serialized open (openvideo isn't thread-safe); see OPENVIDEO_LOCK
         vid_fps = framerate(vid)
@@ -148,8 +141,7 @@ struct Video
         # Sample i reads raw frame (i-1)*skip, and `cld` is exactly the count keeping that index
         # inside the window — cld(n, s) == fld(n - 1, s) + 1 — so the reads cannot run off the end.
         # The epsilon absorbs a duration that computes to 59.999999996 rather than 60; the `max`
-        # keeps a window shorter than one frame period yielding the single frame `seek` lands on,
-        # as it did before.
+        # makes a window shorter than one frame period yield the single frame `seek` lands on.
         navailable = max(1, floor(Int, (stop - start) * vid_fps + 1e-9))
         nframes = cld(navailable, skip)
         sar = aspect_ratio(vid)
@@ -209,11 +201,10 @@ struct Tracker
     end
 end
 
-# The stack stores raw frames exactly as they were decoded — `Gray{N0f8}`, which is what libav
-# hands us — rather than widening them to Float32. That is a 4x saving on the largest allocation in
-# the program (a 1080p frame at background_length = 250 is ~494 MB rather than ~1978 MB) and loses
-# nothing, since the values came from N0f8 in the first place. The SIGNED buffer is `Tracker.img`,
-# which receives the background-subtracted frame; see the widening in `detect` (#27).
+# The stack stores raw frames as decoded, `Gray{N0f8}`, rather than widening them to Float32: a 4x
+# saving on the largest allocation in the program (a 1080p frame at background_length = 250 is
+# ~494 MB rather than ~1978 MB), losing nothing, since the values came from N0f8 to begin with. The
+# SIGNED buffer is `Tracker.img`, which receives the background-subtracted frame — see `detect` (#27).
 function build_stack(scale, sz, n_bkgd, pad_indices)
     tform = LinearMap(SDiagonal(SVector{3, Float64}(1/scale, 1/scale, 1)))
     PaddedView(zero(Gray{N0f8}), WarpedView(Array{Gray{N0f8}}(undef, sz..., n_bkgd), tform; fillvalue = zero(Gray{N0f8})), pad_indices)
@@ -251,10 +242,8 @@ populate_slice!(stack, i, vid) = copy!(selectdim(parent(parent(stack)), 3, i), v
 # AFTER detection: the frame enters the stack whole (detect must see the target), and once the
 # position is known the target's search window (the same guess ± radii rectangle detect scans) in
 # that slice is restored to the pre-target background the evicted frame held there. By induction
-# the history never contains the target — a target that sits still for longer than the rolling
-# window would otherwise be absorbed by the per-pixel max/min, erased from the subtracted image,
-# and the tracker set wandering. (The prefill in collect_stack is unprotected: absorption needs
-# the stationary spell to exceed the whole background window within the rolling phase.)
+# the history never contains the target. (The prefill in collect_stack is unprotected: absorption
+# needs the stationary spell to exceed the whole background window within the rolling phase.)
 function protect_target(stack, j, guess, radii, scale)
     slice = selectdim(parent(parent(stack)), 3, j)
     protect = CartesianIndices(UnitRange.(round.(Int, (guess .- radii) ./ scale),
@@ -263,11 +252,11 @@ function protect_target(stack, j, guess, radii, scale)
 end
 
 # Registered variant (AprilTag mode): the search window lives in canvas (reference-space)
-# coordinates, so its four corners cross `canvas2raw` — the slice's registration composed with
-# the inverse scaling — before the protected region is taken as their bounding box in the raw
-# frame. `pad` (raw px) absorbs the scheme's approximations: the box is computed under the
-# INCOMING frame's registration while `keep` holds the EVICTED frame's raw values at those same
-# indices, each off by up to one frame of drone motion. Padding only widens the protected area.
+# coordinates, so its four corners cross `canvas2raw` — the slice's registration composed with the
+# inverse scaling — before the protected region is taken as their bounding box in the raw frame.
+# `pad` (raw px) absorbs the approximation: the box is computed under the INCOMING frame's
+# registration while `keep` holds the EVICTED frame's raw values at those indices, each off by up
+# to one frame of drone motion. Padding only widens the protected area.
 function protect_target(stack, j, guess, radii, canvas2raw::Function, pad::Int)
     slice = selectdim(parent(parent(stack)), 3, j)
     corners = (canvas2raw(guess .- radii), canvas2raw(guess .+ radii),
@@ -285,8 +274,7 @@ function restore_background!(stack, j, protect, keep)
 end
 
 # Sequential on purpose: next!(vid) decodes into the single shared vid.img buffer, so copying
-# slice i must complete before the next read — a spawned copy raced the following next! and
-# nondeterministically corrupted background slices with (parts of) the wrong frame.
+# slice i must complete before the next read.
 function collect_stack(vid, sz, h, n_bkgd)
     stack = get_stack(vid, sz, h, n_bkgd)
     for i in axes(stack, 3)
@@ -306,10 +294,9 @@ function detect(guess, stack, j, h, img, radii, buff, kernel, sz, scale, bkgd_re
     if isnothing(bkgd_reduce)      # subtraction off: the DoG runs on the raw slice
         img.data[bkgd_indices] .= slice[bkgd_indices]
     else
-        # Widen BEFORE subtracting. A darker target makes this difference negative, and the stack is
-        # `N0f8` — unsigned, and it wraps silently rather than erroring
-        # (Gray{N0f8}(0.2) - Gray{N0f8}(0.5) == Gray{N0f8}(0.702)), which would leave a
-        # background-matching pixel at 0 and a pixel one quantum darker near 1.0, i.e. the DoG
+        # Widen BEFORE subtracting. A darker target makes this difference negative, and the stack's
+        # `N0f8` is unsigned and wraps silently rather than erroring
+        # (Gray{N0f8}(0.2) - Gray{N0f8}(0.5) == Gray{N0f8}(0.702)), which would leave the DoG
         # chasing inverted noise. `img` is Float32 precisely to hold the signed result.
         img.data[bkgd_indices] .= Gray{Float32}.(slice[bkgd_indices]) .- Gray{Float32}.(bkgd_reduce(stack[bkgd_indices, :], dims = 3))
     end
@@ -329,9 +316,7 @@ function detect(guess, stack, j, h, img, radii, buff, kernel, sz, scale, bkgd_re
     if any(isnan, coord)
         return RowCol(guess) / scale, guess
     end
-    # coord = min.(max.(coord, (1, 1)), sz)
     guess = Tuple(round.(Int, coord))
-    # return scaleit(coord, scale), guess
     return coord / scale, guess
 end
 
@@ -365,9 +350,7 @@ function track_one(file, start, stop, target_width, start_location, window_size,
         coords = Vector{RowCol}(undef, vid.nframes)
         guess = get_guess(start_location, stack, vid, darker_target, target_width, initial_search_factor, subtract)
         track!(coords, stack, guess, tr, vid, dia)
-        # sample i is raw frame (i-1)*skip, i.e. start + (i-1)/effective_fps. Spreading the
-        # samples over [start, stop] instead pinned the last one to `stop`, stretching every
-        # timestamp by up to a frame period even when `fps` divided the rate evenly (#17).
+        # sample i is raw frame (i-1)*skip, i.e. start + (i-1)/effective_fps (#17)
         return (range(start; step = 1 / vid.fps, length = vid.nframes), coords)
     end
 end
@@ -403,12 +386,9 @@ function track(
         start::Real = 0,
         stop::Real = get_duration(file),
         target_width::Real = 25,
-        # `CartesianIndex{2}` was in this union with no `get_guess` method behind it, so it
-        # type-checked at the call and then failed with a MethodError once the video was already
-        # open (#18). The union is now exactly what is supported. `RowCol` is absent on purpose
-        # despite having a method: that is the internal form a *later* segment's start takes in the
-        # vector method, carried over from the previous segment's last coordinate — not something a
-        # caller supplies here.
+        # The union is exactly what is supported (#18). `RowCol` is absent on purpose despite having
+        # a method: that is the internal form a *later* segment's start takes in the vector method,
+        # carried over from the previous segment's last coordinate, not something a caller supplies.
         start_location::Union{Missing, NTuple{2, Int}} = missing,
         window_size::Union{Missing, Int, NTuple{2, Int}} = round(Int, 2target_width),
         darker_target::Bool = true,
@@ -424,9 +404,8 @@ function track(
     # `Missing` never reaches fix_window_size (which has no method for it).
     window_size = ismissing(window_size) ? round(Int, 2target_width) : window_size
 
-    # The diagnostic must declare the rate its frames actually arrive at, not the one requested: a
-    # non-divisor `fps` otherwise makes it claim the wrong playback speed (#55). The rate is only
-    # knowable from the video, hence the probe; `Video` derives the same stride from the same rule.
+    # The diagnostic declares the rate its frames actually arrive at, which is knowable only from
+    # the video — hence the probe; `Video` derives the same stride from the same rule (#55).
     dia_fps = effective_fps(get_framerate(file), fps)
 
     # AprilTag mode (drone footage): the rectification carries the shared reference and detector
@@ -492,11 +471,8 @@ function track(
     # `missing` means "use the default", like a blank csv cell (see the single-file method).
     window_size = ismissing(window_size) ? round(Int, 2target_width) : window_size
 
-    # The diagnostic must declare the rate its frames actually arrive at, not the one requested: a
-    # non-divisor `fps` otherwise makes it claim the wrong playback speed (#55). The rate is only
-    # knowable from the video, hence the probe; `Video` derives the same stride from the same rule.
-    # Segments are assumed to share one native frame rate (see the note in runs.md), so the first
-    # one's is representative — as it already is for the `fps` default in this method's signature.
+    # As in the single-file method (#55). Segments are assumed to share one native frame rate (see
+    # runs.md), so the first one's is representative — as it is for the `fps` default above.
     dia_fps = effective_fps(get_framerate(files[1]), fps)
 
     nfiles = length(files)
@@ -504,11 +480,9 @@ function track(
     args = zip(files, start, stop, start_location)
 
     # AprilTag mode: every segment registers to the SAME shared reference (the tags are stationary
-    # across the whole run). Segments are tracked independently — each uses its own start_location
-    # (a missing one falls back to the frame-centre search; now that tracking happens in shared
-    # reference space, chaining a segment's metric end position into the next segment's guess via
-    # `inv(ref.M)` would be possible, but is deliberately not done yet). One diagnostic spans all
-    # segments.
+    # across the whole run) and is tracked independently from its own start_location, a missing one
+    # falling back to the frame-centre search. Segments do not chain (see DESIGN-HISTORY.md). One
+    # diagnostic spans all of them.
     if rectification isa ApriltagRectification
         segs = Vector{Vector{Union{Missing, RowCol}}}(undef, nfiles)
         dia = diagnose_apriltag(diagnostic_file, rectification.reference, darker_target, dia_fps)

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -1,18 +1,10 @@
-# AprilTag-based tracking for drone footage: register out drone motion and rectify the beetle
-# track into metric ground-plane coordinates (cm), in a single pass, using four coplanar tags as
-# landmarks. Built in phases, all present in this file: PHASE 1 the ground-plane geometry (pure
-# and unit-tested), PHASE 2 detection and the tracking loop, PHASE 4 the ROI local search.
-# Registration is folded into the background stack's lazy index pipe (RegisteredWarp), so the
-# tracker works in the shared reference frame — a static scene — rather than native image space.
-#
-# Geometry, verified against a real drone frame (1080×1920, four tag36h11 tags):
-#   * A homography from all 16 tag corners registers frames robustly; a single tag's homography
-#     leaves 3.5–13.4 cm of skew on distant tags (error grows with distance from the tag), so
-#     every fit uses all corners.
-#   * The metric map (image → cm) is fit from all four tags jointly, each contributing its known
-#     96 cm square; consensus drives the worst square error to < 1 cm (vs. 13 cm single-tag).
-#   * Our normalized-DLT homography is both more accurate (Float64 vs OpenCV's Float32 marshalling)
-#     and faster (~28 µs vs ~41 µs) than OpenCV.findHomography, so no OpenCV dependency is needed.
+# AprilTag-based tracking for drone footage: register out drone motion and rectify the beetle track
+# into metric ground-plane coordinates (cm), in a single pass, using four coplanar tags as
+# landmarks. This file holds the ground-plane geometry (pure and unit-tested), the detection and
+# tracking loop, and the ROI local search. Registration is folded into the background stack's lazy
+# index pipe (RegisteredWarp), so the tracker works in the shared reference frame — a static scene
+# — rather than in native image space. Every fit uses all 16 tag corners, and the metric map is fit
+# from all four tags jointly; see DESIGN-HISTORY.md for the measurements behind both.
 
 using StaticArrays: SVector, SMatrix
 using LinearAlgebra: svd, det, norm
@@ -104,20 +96,16 @@ function rigid_align(A, B)
 end
 
 # Fit the metric map `M : image → ground cm` from all tags jointly. Bootstrap from one tag's
-# corners, then alternate: place a true 96 cm square on each tag's current cm estimate (Procrustes),
-# pin the global gauge by rigidly mapping tag 1's square back onto the canonical square, and refit
-# `M` from all 16 corners to those pinned squares (DLT). The gauge pin is essential — without it the
-# iteration's cm frame drifts in scale/pose and diverges under strong perspective.
-#
-# The gauge-pinned iteration still has convergence basins: which bootstrap tag lands in the good
-# basin is sensitive to sub-pixel corner noise (a 0.1 px difference flipped a real frame from 0.5 cm
-# to 35 cm), so we try EVERY tag as the bootstrap and keep the globally best result. On real footage
-# at least one bootstrap reaches sub-cm. Fit once per reference frame — the whole thing is a
-# one-time few ms, not a per-frame cost.
+# corners, then alternate: place a true square on each tag's current cm estimate (Procrustes), pin
+# the global gauge by rigidly mapping tag 1's square back onto the canonical square, and refit `M`
+# from all 16 corners to those pinned squares (DLT). The gauge pin is essential; without it the
+# iteration diverges under strong perspective. EVERY tag is tried as the bootstrap and the globally
+# best result kept, since the convergence basin is sensitive to sub-pixel corner noise. Fit once per
+# reference frame — a one-time few ms, not a per-frame cost.
 #
 # Returns `(M, worst_error)`: it computes, it does not decide. Whether that error is acceptable is
-# the caller's policy (see METRIC_FIT_TOLERANCE) — which is what lets `reference_frame` report a
-# non-converged fit as an issue string rather than having to catch a throw from in here.
+# the caller's policy (see METRIC_FIT_TOLERANCE), which lets `reference_frame` report a
+# non-converged fit as an issue string rather than catch a throw from in here.
 function fit_metric(tag_corners; canon = CANON, maxiter = 1000, tol = 1e-9)
     side = norm(canon[1] - canon[2])
     flat = reduce(vcat, tag_corners)
@@ -213,22 +201,17 @@ end
 # Returns the `ReferenceFrame`, or a `String` describing why one could not be built — an unsupported
 # family, an unreadable frame, too few tags, corners that could not be re-read, or a metric fit that
 # did not converge. Every one of those is a fact about the calibration the user gave us, not an
-# exceptional condition, so it is reported rather than thrown: `apriltag_extrinsic_issue` can then
-# pass it straight to the gateway with no catch at all, while `ApriltagRectification` — which has
-# nowhere to put a message — turns it back into a throw.
+# exceptional condition, so it is reported rather than thrown.
 function reference_frame(file, extrinsic, ntags, family, checker_size)
     valid_apriltag_family(family) ||
         return "unknown AprilTag family \"$family\" (supported: $(join(APRIL_FAMILY_NAMES, ", ")))"
-    # Serialize the WHOLE read + detect. Two separate hazards, both under the verification /
-    # rectification-building `tmap` at high thread counts on a cold network share: the one-shot VideoIO
-    # read (open+seek+read) races and returns garbled/wrong frames, and the AprilTag detector is not
-    # reentrant. Reference building is one-time setup over a handful of calibs, so serializing it costs
-    # essentially nothing. (Per-run tracking keeps concurrent decode; only its detection is serialized.)
+    # Serialize the WHOLE read + detect: the one-shot VideoIO read races under the callers' `tmap`,
+    # and the AprilTag detector is not reentrant. Reference building is one-time setup over a handful
+    # of calibs, so this costs essentially nothing.
     lock(APRILTAG_LOCK) do
-        # The only genuinely exceptional step: VideoIO reports an unreadable/corrupt file, and a
-        # seek past the end, as a plain ErrorException ("Could not open …: Invalid data found when
-        # processing input"), so that is as narrow as this gets — it still excludes the
-        # MethodError/BoundsError of a bug here and the InterruptException a bare catch would eat.
+        # VideoIO reports an unreadable/corrupt file, and a seek past the end, as a plain
+        # ErrorException, so that is as narrow as this gets — it still excludes the
+        # MethodError/BoundsError of a bug here, and InterruptException.
         img = try
             read_frame_at(file, extrinsic)
         catch e
@@ -300,9 +283,8 @@ valid_apriltag_family(family) = haskey(APRIL_FAMILIES, family)
 
 # Does the extrinsic frame support a shared reference? Returns `nothing` on success or an issue
 # string (unreadable frame, too few tags, non-coplanar / mis-detected tags), so it composes with the
-# gateway's other checks. `reference_frame` already reports those as strings, so this is a plain
-# type test rather than a catch: what used to be exception-driven control flow is now the ordinary
-# return path, and a genuine error propagates instead of being reformatted as a calibration issue.
+# gateway's other checks. A plain type test, since `reference_frame` already reports those as
+# strings — a genuine error propagates rather than being reformatted as a calibration issue.
 function apriltag_extrinsic_issue(file, extrinsic, ntags, family, checker_size)
     ref = reference_frame(file, extrinsic, ntags, family, checker_size)
     return ref isa String ? ref : nothing
@@ -315,17 +297,17 @@ register(ref::ReferenceFrame, corners) = homography_dlt(corners, ref.corners)
 ground_homography(ref::ReferenceFrame, corners) = ref.M * register(ref, corners)
 
 # The lazy registration warp: the background stack's index transform, composing each slice's
-# registration with the tracker's inverse scaling, so every slice is sampled in the SHARED
-# REFERENCE frame's coordinates. Drone motion is thereby removed at lookup time — the per-pixel
-# max/min background model sees a static scene — at the cost of one homography apply per lookup.
-# `Hinvs[k]` maps reference (x, y) px → frame-k (x, y) px (i.e. `inv(register(...))`) and is
-# mutated in place as the rolling window replaces slices; the WarpedView holds this same vector,
-# so updates are visible immediately. Coordinate bridge: the stack works in scaled (row, col)
-# ("canvas"), the homographies in (x, y) = (col, row) stored px — hence the flips.
+# registration with the tracker's inverse scaling, so every slice is sampled in the SHARED REFERENCE
+# frame's coordinates. Drone motion is thereby removed at lookup time — the per-pixel max/min
+# background model sees a static scene — at the cost of one homography apply per lookup.
+# `Hinvs[k]` maps reference (x, y) px → frame-k (x, y) px (i.e. `inv(register(...))`) and is mutated
+# in place as the rolling window replaces slices; the WarpedView holds this same vector, so updates
+# are visible immediately. Coordinate bridge: the stack works in scaled (row, col) ("canvas"), the
+# homographies in (x, y) = (col, row) stored px — hence the flips.
 struct RegisteredWarp <: Transformation
     scale::Float64
-    # NB the length parameter: `SMatrix{3, 3, Float64}` (abstract) would box every per-lookup
-    # load and cost two orders of magnitude in detect's background reduce
+    # NB the length parameter: the abstract `SMatrix{3, 3, Float64}` boxes every per-lookup load,
+    # costing two orders of magnitude in detect's background reduce
     Hinvs::Vector{SMatrix{3, 3, Float64, 9}}
 end
 function (w::RegisteredWarp)(x::SVector{3})
@@ -357,11 +339,8 @@ function set_detector!(det; nthreads = 1)
     return det
 end
 
-# `apriltag_detector_detect` (the C detector) is NOT reentrant: it has global/static state that
-# concurrent calls corrupt — even distinct, per-thread detectors on distinct frames race (verified
-# three ways), and under enough pressure it segfaults. So EVERY detection call goes through this,
-# which serializes them process-wide via APRILTAG_LOCK. Reads/decode stay concurrent; only the
-# (comparatively cheap) detect is serial.
+# Every detection call goes through this, serializing them process-wide: the C detector is not
+# reentrant (see APRILTAG_LOCK).
 detect_locked(det, img) = lock(() -> det(img), APRILTAG_LOCK)
 
 # Detect and return the 16 corners grouped per tag, aligned to `ids` order (each tag's `.p` corners
@@ -393,10 +372,10 @@ end
 
 # ---- PHASE 4: local ROI search ----------------------------------------------------------------
 # AprilTag detection cost scales with pixels, so after the reference frame each tag is searched in a
-# small box around where it was last seen instead of over the whole 1080×1920 frame. Detecting on a
-# crop reproduces the full-frame corners to < 0.1 px (verified), so this is a pure speedup. The box
-# grows and re-searches until the tag is found or it spans the whole frame — a graceful fallback to
-# full-frame detection when the drone jumps, never worse than it.
+# small box around where it was last seen rather than over the whole frame. Detecting on a crop
+# reproduces the full-frame corners to better than 0.1 px, so this is a pure speedup. The box grows
+# and re-searches until the tag is found or spans the whole frame, degrading gracefully to
+# full-frame detection when the drone jumps.
 const ROI_MARGIN = 40      # px padded around a tag's corners to form its search box
 const ROI_GROW = 250       # px the box expands on each side when the tag isn't found
 
@@ -425,9 +404,8 @@ function find_tag_roi(det, img, id, box, sz)
 end
 
 # detect all tags by per-tag local search, updating `boxes` in place; corners aligned to `ids`
-# order, or `nothing` if any tag is not found anywhere in the frame. Detection is SEQUENTIAL: the
-# AprilTag C detector is not reentrant (see detect_locked), so every detect is serialized process-
-# wide anyway — spawning one task per tag would only contend on that lock, for no gain.
+# order, or `nothing` if any tag is not found anywhere in the frame. Sequential, because
+# `detect_locked` serializes every detect anyway — one task per tag would only contend on the lock.
 function detect_tags_roi!(dets, img, ids, boxes, sz)
     corners = Vector{Vector{SVector{2, Float64}}}(undef, length(ids))
     newboxes = similar(boxes)
@@ -507,9 +485,8 @@ function (d::DiagnoseApriltag)(frame, beetle, H)
         draw!(wimg, Path(d.trace), d.color)
     end
     out = parent(wimg)
-    # Stamp the run's name, as the other two writers do. `main` concatenates every run's diagnostic
-    # into one video, so without it no segment can be told from the next — and a dataset of drone
-    # runs is *all* AprilTag, so previously none of them carried a label at all (#22).
+    # Stamp the run's name, as the other two writers do: `main` concatenates every run's diagnostic
+    # into one video, so without it no segment can be told from the next (#22).
     renderstring!(out, d.label, d.face, d.font, d.font, d.font, halign = :hleft, valign = :vtop)
     write(d.writer, out)
     return nothing
@@ -518,21 +495,20 @@ diagnose_apriltag(::Nothing, _, _, _) = Dont()
 diagnose_apriltag(file::AbstractString, ref, darker_target, fps) = DiagnoseApriltag(file, ref, darker_target, fps)
 (::Dont)(_, _, _) = nothing                                     # 3-arg no-op for the apriltag callback
 
-# Track the beetle across drone footage in a single pass, in the REFERENCE frame's coordinates:
-# the background stack lazily warps every slice through that slice's own registration (a
-# RegisteredWarp composed into the same index pipe as the scaling), so drone motion is removed at
-# lookup time and the DoG tracker sees a static scene — a stable background model, and no
-# per-frame guess compensation (the guess simply persists, as in the plain tracker). Per frame:
-# detect the tags (on the raw `vid.img`), fit the registration, roll the raw frame plus its
-# registration into the stack, run the DoG detection in reference space, and map the result
-# through the FIXED metric map `ref.M` to ground cm. Frames missing any tag yield `missing`
-# (their true registration is unknown; the slice borrows the nearest known one — misaligned only
-# by that brief unknown drone motion, where the old native-space stack was misaligned by ALL
-# drone motion) and the tracker holds its last reference-space position. The reference is
-# established once, from the calibration's extrinsic frame (the tags are stationary across every
-# run), and shared here; `family` is the detector family it was built with; `ref_sz` is the
-# reference frame's (rows, cols) — the run may have a different resolution. `dia` is a
-# `DiagnoseApriltag`/`Dont` created (and closed) by the caller — shared across a run's segments.
+# Track the beetle across drone footage in a single pass, in the REFERENCE frame's coordinates: the
+# background stack lazily warps every slice through that slice's own registration (a RegisteredWarp
+# composed into the same index pipe as the scaling), so drone motion is removed at lookup time and
+# the DoG tracker sees a static scene — a stable background model, and no per-frame guess
+# compensation. Per frame: detect the tags (on the raw `vid.img`), fit the registration, roll the
+# raw frame plus its registration into the stack, run the DoG detection in reference space, and map
+# the result through the FIXED metric map `ref.M` to ground cm. Frames missing any tag yield
+# `missing` — their true registration is unknown, so the slice borrows the nearest known one and the
+# tracker holds its last reference-space position.
+#
+# The reference is established once, from the calibration's extrinsic frame, and shared here;
+# `family` is the detector family it was built with; `ref_sz` is the reference frame's (rows, cols),
+# which the run's own resolution may differ from. `dia` is a `DiagnoseApriltag`/`Dont` created and
+# closed by the caller, shared across a run's segments.
 function track_apriltag(file, start, stop, target_width, start_location, window_size, darker_target,
                         fps, dia, ref::ReferenceFrame, family, ref_sz, initial_search_factor, scale, background_length)
     ids = ref.ids
@@ -555,14 +531,13 @@ function track_apriltag(file, start, stop, target_width, start_location, window_
             seedR = SMatrix{3, 3, Float64}(I)              # the seed frame's registration (start_location crosses it)
             lastHinv = SMatrix{3, 3, Float64}(I)           # nearest known inv(registration), borrowed by tag-less slices
 
-            # fill the background stack: each frame enters raw, PLUS its registration in
+            # Fill the background stack: each frame enters raw, PLUS its registration in
             # `warp.Hinvs`, which is what places it in reference space. The run's `start` can be far
             # from the calibration's extrinsic frame, so the (stationary) tags may sit anywhere in
             # the first frame: locate them by a full-frame scan, NOT an ROI around their reference
-            # positions. Once found, subsequent frames use per-tag local search seeded from each
-            # tag's last box — a graceful fall back to full-frame when the drone jumps. Frames
-            # missing any tag borrow the nearest known registration (pre-seed slices are backfilled
-            # with the seed's once it is found).
+            # positions. Subsequent frames then use per-tag local search seeded from each tag's last
+            # box. Frames missing any tag borrow the nearest known registration (pre-seed slices are
+            # backfilled with the seed's once it is found).
             for i in 1:n_bkgd
                 next!(vid)
                 populate_slice!(stack, i, vid)

--- a/src/PawsomeTracker/diagnose.jl
+++ b/src/PawsomeTracker/diagnose.jl
@@ -7,15 +7,13 @@ const DIAGNOSTIC_VIDEO_SIZE = (360, 640)
 const DIAGNOSTIC_SIZE = 540
 const TRACE_BUFFER_SIZE = 100
 # Diagnostic videos play back at DIAGNOSTIC_SPEEDUP × real time, decimated to roughly
-# DIAGNOSTIC_FPS frames per second of playback — so long runs skim quickly and a high tracking
-# fps no longer slows playback down (the writer's framerate used to be left at VideoIO's default
-# 24 while every tracked frame was written, playing a 50 fps track at 0.48× speed).
+# DIAGNOSTIC_FPS frames per second of playback, so long runs skim quickly and a high tracking fps
+# doesn't slow playback down.
 const DIAGNOSTIC_SPEEDUP = 2
 const DIAGNOSTIC_FPS = 24
 # FreeType faces are stateful (one glyph slot per face) and FreeTypeAbstraction's per-face lock is
-# not held across load → read → copy, so concurrently tracked runs sharing one global face can
-# swap each other's label glyphs (a run briefly labeled with another run's id). Each writer
-# therefore loads its own private face from this font file.
+# not held across load → read → copy, so concurrently tracked runs sharing one global face swap
+# each other's label glyphs. Each writer loads its own private face from this font file.
 const FONT = @path joinpath(@__DIR__, "assets", "TeXGyreHerosMakie-Regular.otf")
 
 # Write every `skip`-th tracked frame, and declare the playback framerate that makes the segment
@@ -23,9 +21,7 @@ const FONT = @path joinpath(@__DIR__, "assets", "TeXGyreHerosMakie-Regular.otf")
 diagnostic_stride(fps) = max(1, round(Int, DIAGNOSTIC_SPEEDUP * fps / DIAGNOSTIC_FPS))
 diagnostic_framerate(fps, skip) = DIAGNOSTIC_SPEEDUP * fps / skip
 # Constant-quality H.264 encoding. Diagnostic files must be .mp4: that container's default codec
-# is H.264, whose crf option these settings configure (the old .ts segments defaulted to MPEG-2
-# at libavcodec's default *average bitrate* — constant bits per second that turned into mush as
-# the tracking fps rose).
+# is H.264, whose crf option these settings configure.
 const DIAGNOSTIC_ENCODER = (crf = 23, preset = "veryfast")
 
 abstract type Diagnosis end
@@ -94,7 +90,6 @@ end
 
 struct DiagnoseRectified <: Diagnosis
     label::String
-    # buffer::OffsetMatrix{Gray{N0f8}, Matrix{Gray{N0f8}}}
     indices
     color::Gray{N0f8}
     writer::VideoWriter
@@ -109,10 +104,8 @@ struct DiagnoseRectified <: Diagnosis
 
     function DiagnoseRectified(file::AbstractString, darker_target, rect, fps)
         label = first(splitext(basename(file)))
-        # Fixed canvas: the zoom adapts so the frame's smaller dimension always spans the canvas.
-        # For a 1080p source this is exactly the former half-resolution view (the old
-        # m = min(w, h) ÷ 2 with a hardcoded 2× zoom is the special case m = DIAGNOSTIC_SIZE when
-        # min(w, h) = 1080) — detail stays discernible while every segment is the same size.
+        # Fixed canvas, with the zoom adapting so the frame's smaller dimension always spans it:
+        # detail stays discernible while every segment comes out the same size.
         m = DIAGNOSTIC_SIZE
         D = LinearMap(SDiagonal{2}((min(rect.width, rect.height) / m) * rect.ratio * I))
         real2image = rect.real2image ∘ D

--- a/src/Rectifications/Rectifications.jl
+++ b/src/Rectifications/Rectifications.jl
@@ -20,9 +20,9 @@ const CRITERIA = OpenCV.TermCriteria(OpenCV.TERM_CRITERIA_EPS + OpenCV.TERM_CRIT
 # Global limiter on concurrent ffmpeg reads, shared by every `_frame_at` call (and thus by
 # VerifyRectifications, which reads through `Rectifications.get_corners`). Bounds simultaneous
 # opens against the (CIFS/network) share so a burst of nested `tmap` tasks can't trip EAGAIN
-# ("Resource temporarily unavailable"). A single global limiter is what composes across the
-# nested tmaps — per-call `ntasks` limits would multiply. Tune via `set_read_limit!` or the
-# `RECTIFICATIONS_READ_LIMIT` env var (read at `__init__`).
+# ("Resource temporarily unavailable"). One global limiter, because per-call `ntasks` limits would
+# multiply across the nesting. Tune via `set_read_limit!` or the `RECTIFICATIONS_READ_LIMIT` env
+# var (read at `__init__`).
 const READ_SEM = Ref{Base.Semaphore}()
 set_read_limit!(n::Integer) = (READ_SEM[] = Base.Semaphore(n); Int(n))
 read_limit() = READ_SEM[].sem_size
@@ -30,14 +30,11 @@ read_limit() = READ_SEM[].sem_size
 # ffmpeg/ffprobe commands are built by interpolating the *called* `FFMPEG.ffmpeg()` /
 # `FFMPEG.ffprobe()` (the non-do-block form): each returns a `Cmd` with the absolute executable
 # path and the adjusted `PATH`/`LD_LIBRARY_PATH` baked in via `setenv`, and that env survives
-# interpolation into the surrounding `Cmd`. Unlike the deprecated `ffmpeg() do ... end` form it
-# never mutates the process-global `ENV`, so it composes safely under the nested `tmap`
-# concurrency — no snapshot, no `addenv`, no env race (which previously grew `LD_LIBRARY_PATH`
-# without bound until a spawn died with E2BIG). See `_cmd`.
+# interpolation into the surrounding `Cmd` without ever touching the process-global `ENV` — which
+# is what makes it safe under the nested `tmap` concurrency. See `_cmd`.
 
 function __init__()
-    # Concurrency is bounded only by the share itself; benchmarks against the CIFS mount plateau
-    # around 12-24 concurrent reads (vs ~6 here historically).
+    # The share itself is the bound; benchmarks against the CIFS mount plateau at 12-24 reads.
     set_read_limit!(parse(Int, get(ENV, "RECTIFICATIONS_READ_LIMIT", "12")))
 end
 

--- a/src/Rectifications/center_north.jl
+++ b/src/Rectifications/center_north.jl
@@ -8,7 +8,6 @@ function i2r_northing(image2real, centering, n)
     fc = centering ∘ image2real
     p = fc(n)
     LinearMap(Angle2d(π - atan(p[2], p[1])))
-    # LinearMap(Angle2d(π/2 - atan(p[2], p[1])))
 end
 
 function i2r_centering_northing(image2real, c, n)

--- a/src/Rectifications/detect_fit.jl
+++ b/src/Rectifications/detect_fit.jl
@@ -7,8 +7,6 @@ function _detect_corners(img, n_corners)
     corners = Matrix{RowCol}(undef, n_corners)
     ret, _ = OpenCV.findChessboardCorners(gry, OpenCV.Size{Int32}(n_corners...), OpenCV.Mat(reshape(reinterpret(Float32, corners), 2, 1, prod(n_corners))), OpenCV.CALIB_CB_ADAPTIVE_THRESH + OpenCV.CALIB_CB_NORMALIZE_IMAGE + OpenCV.CALIB_CB_FAST_CHECK)
     return ret ? corners : missing
-    # ref_corners = OpenCV.cornerSubPix(gry, cv_corners, OpenCV.Size{Int32}(11,11), OpenCV.Size{Int32}(-1,-1), CRITERIA)
-    # corners = reshape(RowCol.(eachslice(ref_corners, dims = 3)), n_corners)
 end
 
 """
@@ -25,7 +23,6 @@ function fit_model(sz, objpoints, imgpointss, n_corners, radial_parameters, aspe
     # radial_parameters = 0 fixes ALL radial coefficients at zero (distortionless fit, used by the
     # extrinsics-only Rectification): setdiff(1:3, 1:0) selects every CALIB_FIX_K.
     CALIB_FIX_K = sum([OpenCV.CALIB_FIX_K1, OpenCV.CALIB_FIX_K2, OpenCV.CALIB_FIX_K3][setdiff(1:3, 1:radial_parameters)])
-    # @show Int(CALIB_FIX_K)
     flags = OpenCV.CALIB_ZERO_TANGENT_DIST + CALIB_FIX_K + OpenCV.CALIB_FIX_ASPECT_RATIO
     # a single planar view leaves focal + principal point + pose underdetermined by one DOF; fixing
     # the principal point (at the image centre, OpenCV's default without an intrinsic guess) makes

--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -10,12 +10,11 @@ An alias for a static vector of three, x, y, and z, indicating a real-world coor
 """
 const XYZ = SVector{3, <: Real}
 
-# `yadif` marks interlaced footage: `true` ⇒ deinterlace, `false`/`missing` ⇒ progressive, leave as
-# is. `blur` is a gblur sigma; `missing` *and* `0` mean no blur (VerifyRectifications always sends a
-# number, with 0 as its "no blur", so a sigma-0 no-op filter must not be built). Returns the ffmpeg
-# `-vf` filter string, or `missing` when no filtering is needed. `missing` (not `nothing`) is the
-# absent-value sentinel for every optional here, matching the structs VerifyRectifications feeds into
-# `Rectification`.
+# The ffmpeg `-vf` filter string, or `missing` when no filtering is needed. `yadif` marks interlaced
+# footage: `true` ⇒ deinterlace, `false`/`missing` ⇒ progressive, leave as is. `blur` is a gblur
+# sigma, where `missing` *and* `0` mean no blur (VerifyRectifications always sends a number, using 0
+# as its "no blur", and a sigma-0 no-op filter must not be built). `missing` rather than `nothing`
+# is the absent-value sentinel throughout, matching the structs fed into `Rectification`.
 function _vf(yadif, blur)
     filters = String[]
     coalesce(yadif, false) && push!(filters, "yadif=1")
@@ -27,12 +26,10 @@ _cmd(file, t, ::Missing) = `$(FFMPEG.ffmpeg()) -hide_banner -loglevel error -ss 
 _cmd(file, t, vf) = `$(FFMPEG.ffmpeg()) -hide_banner -loglevel error -ss $t -i $file -frames:v 1 -vf $vf -f rawvideo -pix_fmt gray pipe:1`
 
 
-# The failures `_read_frame` retries, i.e. everything a flaky share can plausibly do to a frame
-# read: ffmpeg exiting nonzero (`ProcessFailedException` — how an EAGAIN against the share surfaces,
-# since it is ffmpeg itself that fails), and the Julia-side spawn/pipe failures (`IOError`,
-# `SystemError`). Everything else is not transient and retrying it is wrong: an `InterruptException`
-# above all — a bare `catch` ate Ctrl-C for the whole backoff sequence — but equally a caller's bug,
-# which should surface at once instead of after four attempts.
+# What `_read_frame` retries: everything a flaky share can plausibly do to a frame read. ffmpeg
+# exiting nonzero (`ProcessFailedException` — how an EAGAIN against the share surfaces, since it is
+# ffmpeg itself that fails), and the Julia-side spawn/pipe failures (`IOError`, `SystemError`).
+# Everything else is not transient, and must surface at once rather than after four attempts.
 _transient(e) = e isa ProcessFailedException || e isa Base.IOError || e isa SystemError
 
 # Read one frame, retrying transient failures. EAGAIN ("Resource temporarily unavailable") from
@@ -47,7 +44,7 @@ function _read_frame(cmd; tries = 4)
             sleep(0.2 * 2^(i - 1))          # 0.2s, 0.4s, 0.8s backoff
         end
     end
-    return read(cmd)   # last attempt outside the try: the real error propagates, and the
+    return read(cmd)   # last attempt outside the try, so the real error propagates and the
 end                    # function provably never returns `nothing`
 
 function _frame_at(file, t, vf, w, h)
@@ -99,9 +96,10 @@ Lens distortion for up to 3 radial coefficients.
 """
 lens_distortion(v, k) = v * lens_distortion_factor(norm(v), k)
 
-# End of the invertible (monotone) branch of the forward radial map g(r) = r·f(r): the smallest positive `r` where
-# g'(r) = 1 + 3k₁r² + 5k₂r⁴ + 7k₃r⁶ = 0 (beyond it the distortion "folds" and the inverse is ill-posed). `Inf` if
-# g is monotone everywhere (e.g. pincushion). Depends only on `k`, so compute once per calibration.
+# End of the invertible (monotone) branch of the forward radial map g(r) = r·f(r): the smallest
+# positive `r` where g'(r) = 1 + 3k₁r² + 5k₂r⁴ + 7k₃r⁶ = 0 — beyond it the distortion "folds" and
+# the inverse is ill-posed. `Inf` if g is monotone everywhere (e.g. pincushion). Depends only on
+# `k`, so it is computed once per calibration.
 function _first_critical(k)
     h = Polynomial([1.0; [(2i + 1) * ki for (i, ki) in enumerate(k)]])   # in s = r²
     ss = roots(h)
@@ -175,10 +173,10 @@ function checker_size_pixel(extrinsic_corners::AbstractMatrix, n_corners)
     return s
 end
 
-# Rectification assumes that the pixel coodrinates it rectifies have a `aspect` aspect-ratio. 
-# `center` and `north` are assumed to have been manually retrieved (from some GUI like Gimp or Photoshop) and as such:
+# The pixel coordinates being rectified have an `aspect` aspect-ratio. `center` and `north`,
+# however, are read off a GUI (Gimp, Photoshop) by hand, so they are:
 # 1. pixel coordinates with width first and height second, (w, h)
-# 2. their aspect ratio is 1, regardless of the aspect ratio specified by `aspect`
+# 2. at an aspect ratio of 1, whatever `aspect` says
 function Rectification(file, extrinsic, start, stop, temporal_step, yadif, blur, width, height, n_corners, checker_size, aspect, radial_parameters, center, north; diagnostic = nothing)
     vf = _vf(yadif, blur)
     intrinsic_task = Threads.@spawn extract_intrinsics(file, start, stop, temporal_step, vf, width, height, n_corners)
@@ -195,20 +193,11 @@ Extrinsics-only rectification: no intrinsic-calibration window exists, so the ca
 focal length) are fit from the single extrinsic frame with every lens-distortion coefficient fixed
 at zero — the map is effectively the board-plane homography, disregarding lens aberrations.
 
-# Design note: selected by the absence of the calibs window, never flagged
-
-Which constructor a rectification gets is decided *solely* by whether the CSV row has a calibs
-window: both `start` and `stop` blank ⇒ this single-frame fit. A row that omits the
-window but still fills the intrinsic-window parameters (`temporal_step`, `radial_parameters`) is
-NOT flagged as inconsistent — those two parameters are silently ignored (they only make sense when
-a window of frames is sampled; everything else — `yadif`, `blur`, `n_corners`, `checker_size`,
-`aspect`, `center`, `north` — is honored as usual).
-
-We chose this simplification deliberately. Leaving *both* window time stamps out of a row is too
-large an "action" to plausibly happen by mistake — the user must have intended an extrinsics-only
-rectification — so stray leftover parameters shouldn't override that intent with an error (unlike a
-filled column that belongs to a different `type`, which VerifyRectifications does flag). Filling only
-one of the two bounds is still rejected upstream ("both present or both missing").
+Selected *solely* by the CSV row having no calibs window (both `start` and `stop` blank). Such a
+row may still carry `temporal_step`/`radial_parameters`, which are then silently ignored rather
+than flagged; everything else (`yadif`, `blur`, `n_corners`, `checker_size`, `aspect`, `center`,
+`north`) is honoured as usual. Filling only one of the two bounds is rejected upstream. See
+DESIGN-HISTORY.md for why this asymmetry is deliberate.
 """
 function Rectification(file, extrinsic, yadif, blur, width, height, n_corners, checker_size, aspect, center, north; diagnostic = nothing)
     vf = _vf(yadif, blur)

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -74,8 +74,8 @@ function load_rectifications(data_path, file; strict = true, defaults = (;), iss
         end
     end
 
-    # The comprehension pins the element type to the abstract `Vector{RectificationMethod}`
-    # (mirrors load_runs), so the clean-path return type doesn't vary with the mix of kinds.
+    # The comprehension pins the element type to the abstract `Vector{RectificationMethod}` (as in
+    # load_runs), so the clean-path return type doesn't vary with the mix of kinds.
     return RectificationMethod[RectificationMethod(r) for r in eachrow(df)]
 end
 

--- a/src/VerifyRectifications/parsers.jl
+++ b/src/VerifyRectifications/parsers.jl
@@ -2,14 +2,12 @@
 # live in the shared ..Parsing module; this file holds what is gateway-specific — the defaults
 # whitelist and the per-type row parsers and row-level checks.
 
-# The globally overridable defaults: exactly the video-type tuning parameters — not identities
-# or anchors (`calibration_id`/`file`/`extrinsic`/`matlab_file`/`extrinsic_index`/`path`), not the
-# scene points (`center`/`north`), not `aspect`, not the intrinsic window (`start`/`stop`), and
-# not only_scale's `scale` (a global pixels-per-unit makes no sense), which are all inherently
-# per-row. The caller replaces any of these via `load_rectifications`' `defaults` kwarg (in
-# Fromage: `main`'s `rectification_defaults`); a csv cell always wins over the replaced default
-# (see parseto!). `yadif = missing` means "imputed from the probed video", so a caller-supplied
-# yadif beats the probe on every row whose cell is blank.
+# The globally overridable defaults: exactly the video-type tuning parameters. Everything else —
+# identities and anchors, the scene points, `aspect`, the intrinsic window, only_scale's `scale` —
+# is inherently per-row. The caller replaces any of these via `load_rectifications`' `defaults`
+# kwarg (in Fromage: `main`'s `rectification_defaults`), and a csv cell always wins over the
+# replaced default (see parseto!). `yadif = missing` means "imputed from the probed video", so a
+# caller-supplied yadif beats the probe on every row whose cell is blank.
 const DEFAULTS = (;
     checker_size = 4.0,
     n_corners = (7, 10),
@@ -110,18 +108,15 @@ function verify_center2north(dict)
     end
 end
 
-# A filled cell in a column the row's type never reads would otherwise be silently ignored — and
-# usually means the `type` itself is wrong (e.g. a `scale` on a video row). The type-specific
-# parser has already put every column it consumed into `dict`, so anything non-blank left in the
-# row is irrelevant to this type. Blank cells are fine: mixed-type CSVs share one header, so
-# irrelevant *columns* must be allowed to exist, just not filled. Must run before the COLUMNS
-# back-fill (which adds every column to `dict`).
+# A filled cell in a column the row's type never reads is flagged: it would otherwise be silently
+# ignored, and it usually means the `type` itself is wrong (e.g. a `scale` on a video row). The
+# type-specific parser has already put every column it consumed into `dict`, so anything non-blank
+# left in the row is irrelevant to this type. Blank cells are fine — mixed-type CSVs share one
+# header, so irrelevant *columns* must be allowed to exist, just not filled. Must run before the
+# COLUMNS back-fill, which adds every column to `dict`.
 #
-# `type` and `comment` are exempt, for different reasons. `type` is what selects the parser, so it
-# is consumed by definition. `comment` is consumed by NO parser, by design — it is free text, and
-# the docs promise it is ignored — which made it look exactly like a wrong-type column and turned a
-# filled comment into a hard error under the default strict mode. It is the only column no type
-# reads, so this exemption closes that case completely.
+# `type` is exempt because it selects the parser, and so is consumed by definition; `comment` is
+# exempt because it is free text that no parser reads by design (#16).
 function verify_irrelevant(dict, row)
     ismissing(dict[:type]) && return          # wrong type: already reported, no field list to check
     for k in Tables.columnnames(row)
@@ -134,7 +129,7 @@ end
 
 function parse_row(row, defaults = DEFAULTS)
     dict = Dict{Symbol, Any}(:issues => String[])
-    # trim whitespace (as for the other string fields) and treat a now-empty cell as the default.
+    # trim whitespace (as for the other string fields); a now-empty cell takes the default
     type = String(strip(coalesce(get(row, :type, "video"), "video")))
     isempty(type) && (type = "video")
     dict[:type] = type

--- a/src/VerifyRectifications/precompile.jl
+++ b/src/VerifyRectifications/precompile.jl
@@ -1,13 +1,11 @@
-# Build-time precompilation scaffolding, kept in its own file so it can be excluded from coverage
-# (see codecov.yml): these lines run during precompilation, which the coverage run does not
-# instrument, so they can never be hit by the test suite no matter how well the package is tested.
+# Build-time precompilation scaffolding, in its own file so it can be excluded from coverage (see
+# codecov.yml): it runs during precompilation, which the coverage run does not instrument.
 
-# Precompile the parse → verify → report pipeline at build time. The bulk of first-call latency is the
-# DataFrames/DataFramesMeta/Chain macro machinery (column-typed `@transform!`/`@chain`/`subset`/`verify!`
-# specializations), which a single `load_rectifications` run compiles. The workload CSV points at
-# nonexistent files (one row per type), so the run exercises the full pipeline for all three types but
-# bails before any ffprobe/matread/corner detection — no bundled media needed, fast deterministic
-# precompile. (The video-read/corner-detection paths are left to compile on first real use.)
+# Precompile the parse → verify → report pipeline. The bulk of first-call latency is the
+# DataFrames/DataFramesMeta/Chain macro machinery (column-typed
+# `@transform!`/`@chain`/`subset`/`verify!` specializations) a single `load_rectifications` run
+# compiles. The workload CSV points at nonexistent files, one row per type, so the run exercises the
+# full pipeline for every type but bails before any ffprobe/matread/corner detection.
 @setup_workload begin
     dir = mktempdir()
     csv = joinpath(dir, "precompile.csv")
@@ -25,9 +23,8 @@
             try
                 load_rectifications(dir, csv; strict = false)
             catch e
-                # Deliberately broad: precompilation must not fail because the workload did. An
-                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
-                # absorbed here.
+                # Deliberately broad: precompilation must not fail because the workload did. Ctrl-C
+                # during precompile should still stop it.
                 e isa InterruptException && rethrow()
             end
         end

--- a/src/VerifyRectifications/types.jl
+++ b/src/VerifyRectifications/types.jl
@@ -71,10 +71,9 @@ Rectification(c::Video; kwargs...) = Rectification(c.source.file, c.source.extri
 
 # A Video without a calibs window (both bounds blank ⇒ Video{Missing}) is an extrinsics-only
 # rectification: the pose and focal length come from the single extrinsic frame and lens aberrations
-# are disregarded (zero distortion) — temporal_step/radial_parameters play no role and are
-# deliberately NOT flagged when filled anyway (omitting both window bounds is too large an action
-# to be a mistake, so it expresses intent; see the extrinsics-only Rectification docstring in
-# Rectifications for the full rationale). Only one bound filled is still an error (verify_pair).
+# are disregarded. temporal_step/radial_parameters play no role and are deliberately NOT flagged
+# when filled anyway (see the extrinsics-only Rectification docstring); only one bound filled is
+# still an error (verify_pair).
 Rectification(c::Video{Missing}; kwargs...) = Rectification(c.source.file, c.source.extrinsic, c.yadif, c.blur, c.source.width, c.source.height, c.n_corners, c.checker_size, c.source.aspect, c.source.center, c.source.north; kwargs...)
 
 # A MATLAB rectification reads the camera model (intrinsics, distortion, and the pose picked by
@@ -85,7 +84,7 @@ Rectification(c::MATLAB; kwargs...) = Rectification(c.source.file, c.source.extr
 Rectification(c::Scale; kwargs...) = Rectification(c.source.file, c.source.extrinsic, c.scale, c.source.aspect, c.source.center, c.source.north, c.source.width, c.source.height; kwargs...)
 
 # An AprilTag rectification builds its shared reference from the extrinsic frame (detecting the tags
-# and fitting the metric map) and carries the centre/north gauge; there is no diagnostic image to
-# render at build time (the top-down diagnostic is produced per-run during tracking), so `kwargs`
+# and fitting the metric map) and carries the centre/north gauge. There is no diagnostic image to
+# render at build time — the top-down diagnostic is produced per-run during tracking — so `kwargs`
 # (e.g. `diagnostic`) are ignored.
 Rectification(c::Apriltag; kwargs...) = ApriltagRectification(c.source.file, c.source.extrinsic, c.apriltags, c.family, c.checker_size, c.source.center, c.source.north, c.source.width, c.source.height)

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -4,12 +4,11 @@ function verify_unique_ids!(df::AbstractDataFrame)
     push!.(df.issues[tf], "calibration_id must not repeat")
 end
 
-# One ffprobe call per physical video file yields width, height, duration, sample (pixel) aspect ratio
-# and field order (interlacing). These fill the intermediate :duration/:dimension columns, set the
-# video :width/:height (always taken from the file — they are the frame size used to decode it) and
-# impute :aspect/:yadif. Grouping on the canonical resolved :file reads one physical file once, not
-# once per spelling. (Replaces the former pair of VideoIO opens — aspect, then duration+dimension —
-# and folds in the new ffprobe columns.)
+# One ffprobe call per physical video file yields width, height, duration, sample (pixel) aspect
+# ratio and field order (interlacing). These fill the intermediate :duration/:dimension columns, set
+# the video :width/:height (always taken from the file — they are the frame size used to decode it)
+# and impute :aspect/:yadif. Grouping on the canonical resolved :file reads one physical file once,
+# not once per spelling.
 function read_video_metadata!(df::AbstractDataFrame)
     # :width/:height have no CSV column (they are not user-supplied); create them here so the probe
     # can fill them, alongside the intermediate :duration/:dimension columns.
@@ -18,7 +17,7 @@ function read_video_metadata!(df::AbstractDataFrame)
         dropmissing([:file, :type], view = true)
         groupby([:file, :type])
     end
-    # Every type now carries a source video (:file), so every group is probed once: the read fills
+    # Every type carries a source video (:file), so every group is probed once: the read fills
     # :duration/:dimension/:width/:height for all, plus imputes :aspect (and :yadif for video).
     groups = collect(gs)
     metas = @showprogress desc = "Reading calibration videos..." tmap(g -> probe_video(g.file[1]), groups)
@@ -67,11 +66,10 @@ function matlab_dimension(dict)
         return "matlab file does not contain any image size; file might not be a calibration file"
     end
     imagesize = last(res)
-    # Every assumption about this `Any` is checked up front rather than by catching its failure:
-    # a two-element collection whose entries are exact integers (matlab stores them as Float64).
-    # The eltype guard is what makes `Int(width)` total — an InexactError on 1.5 was the throw the
-    # old catch existed for, and a two-character String would otherwise have destructured into
-    # character codepoints and returned a silently wrong dimension.
+    # Every assumption about this `Any` is checked up front rather than by catching its failure: a
+    # two-element collection whose entries are exact integers (matlab stores them as Float64). The
+    # eltype guard is what makes `Int(width)` total, and what stops a two-character String
+    # destructuring into character codepoints and returning a silently wrong dimension.
     imagesize isa Union{AbstractArray, Tuple} || return "matlab ImageSize is malformed (expected two values)"
     length(imagesize) == 2 || return "matlab ImageSize is malformed (expected two values)"
     all(x -> x isa Real && isinteger(x), imagesize) || return "matlab ImageSize is malformed (expected two integers)"
@@ -84,12 +82,11 @@ const MATLAB_REQUIRED_KEYS = ("TranslationVectors", "RotationVectors", "RadialDi
 
 # A genuine MAT-file (v5/v7) begins with the ASCII text "MATLAB" in its header. Reading just the
 # first 6 bytes is a cheap, specific guard: a non-mat file gets this clear issue instead of matread's
-# opaque error. `read(file, 6)` opens the file and returns up to 6 bytes (fewer if the file is
-# shorter), so a too-short file simply fails the comparison.
+# opaque error. `read(file, 6)` returns up to 6 bytes, so a too-short file simply fails the
+# comparison.
 function matlab_magic_issue(file)
-    # Existence was already checked upstream, so what remains is a race or a permission problem:
-    # `read` reports both as SystemError/IOError. Anything else is not an unreadable file and is
-    # not this function's to describe.
+    # Existence was checked upstream, so what remains is a race or a permission problem, both of
+    # which `read` reports as SystemError/IOError. Anything else is not an unreadable file.
     magic = try
         read(file, 6)
     catch e
@@ -108,10 +105,9 @@ function read_matlab(file)
         matread(file)
     catch e
         # MAT.jl signals essentially every corruption through a generic `error(...)`: a truncated
-        # file, a valid header followed by garbage, and an absent file all arrive as
-        # ErrorException, a directory as EOFError (all verified). ErrorException is therefore as
-        # narrow as this can honestly get — but it still excludes the MethodError/BoundsError that
-        # would mean a bug on our side, and the InterruptException a bare catch used to swallow.
+        # file, a valid header followed by garbage and an absent file all arrive as ErrorException,
+        # a directory as EOFError. ErrorException is therefore as narrow as this can honestly get,
+        # and it still excludes the MethodError/BoundsError of a bug on our side.
         e isa ErrorException || e isa EOFError || e isa SystemError || e isa Base.IOError || rethrow()
         return "error opening matlab file: $e"
     end
@@ -181,8 +177,7 @@ function matlab_extrinsic_count(dict)
     for k in ("TranslationVectors", "RotationVectors")
         vecs = last(findfirstkey(dict, k))
         # `size(vecs, 1)` is only meaningful for an array; a scalar, a string or a nested dict is a
-        # malformed field. Checking that up front is what the catch was standing in for — and it
-        # keeps the accepted shapes exactly as they were, since `size(v, 1)` worked for any array.
+        # malformed field, and is rejected up front rather than caught.
         vecs isa AbstractArray || return "matlab $k is malformed (expected an N×3 matrix)"
         push!(counts, size(vecs, 1))   # N×3 -> N poses
     end
@@ -208,14 +203,10 @@ end
 function probe_video(file)
     fields = probe_fields(file, "stream=width,height,sample_aspect_ratio,field_order:format=duration")
     fields isa String && return fields                 # unreadable file: pass the issue straight on
-    # The three fields nothing downstream can proceed without. `tryparse` reports an absent or
-    # unparseable one as `nothing`.
-    #
-    # Reaching here means ffprobe *succeeded* and still could not describe a video: it opened the
-    # file but `-select_streams v:0` matched nothing (an audio-only file), or it recognised some
-    # container in what is really junk. Both mean the same thing to the user — this is not a usable
-    # video — so it joins the "issue reading from video file" family rather than getting a message
-    # of its own, which would suggest our parsing broke rather than their file being bad.
+    # The three fields nothing downstream can proceed without; `tryparse` reports an absent or
+    # unparseable one as `nothing`. A miss here means ffprobe *succeeded* and still could not
+    # describe a video (an audio-only file, or junk it recognised a container in), which is not a
+    # usable video either — hence the same "issue reading from video file" wording.
     width    = tryparse(Int, get(fields, "width", ""))
     height   = tryparse(Int, get(fields, "height", ""))
     duration = tryparse(Float64, get(fields, "duration", ""))
@@ -237,42 +228,30 @@ function verify!(df::AbstractDataFrame, predicate, msg, args...)
     end
 end
 
-# function extract(extrinsic, file, to, blur)
-#     if blur == 0
-#         ffmpeg_exe(` -loglevel 8 -ss $extrinsic -i $file -vf yadif=1 -vframes 1 $to`)
-#     else
-#         ffmpeg_exe(` -loglevel 8 -ss $extrinsic -i $file -vf yadif=1,gblur=sigma=$blur -vframes 1 $to`)
-#     end
-# end
-
 # Errors raised inside a `tmap` come back wrapped in a TaskFailedException — but only when the
 # scheduler actually spawned a task, so the same failure arrives bare when the work ran inline (a
-# single-element batch, say). Both shapes have to be unwrapped to the original before classifying;
-# a narrowing that skipped this would silently stop catching under the threaded path.
+# single-element batch, say). Both shapes must be unwrapped before classifying, or the narrowing
+# silently stops catching under the threaded path.
 _unwrap_task(e) = e isa TaskFailedException ? _unwrap_task(e.task.result) :
                   e isa CompositeException ? _unwrap_task(first(e.exceptions)) : e
 
-# What corner detection can legitimately fail with, as opposed to a bug here. Verified against the
-# real pipeline: the frame read raises ProcessFailedException/IOError/SystemError (see
-# Rectifications._read_frame, which already retried the transient ones); a seek that yields no frame
-# raises DimensionMismatch out of the reshape ("new dimensions … must be consistent with array
-# length 0"); and OpenCV reports every C++ error as a plain ErrorException. ErrorException is
-# therefore as narrow as this can honestly get — but it still excludes the MethodError/BoundsError
-# of a bug on our side, and the InterruptException a bare catch used to swallow.
+# What corner detection can legitimately fail with, as opposed to a bug here: the frame read raises
+# ProcessFailedException/IOError/SystemError (see Rectifications._read_frame, which already retried
+# the transient ones); a seek that yields no frame raises DimensionMismatch out of the reshape; and
+# OpenCV reports every C++ error as a plain ErrorException. ErrorException is therefore as narrow as
+# this can honestly get, and it still excludes the MethodError/BoundsError of a bug on our side.
 _detection_failure(e) = e isa ProcessFailedException || e isa Base.IOError || e isa SystemError ||
                         e isa DimensionMismatch || e isa ErrorException
 
-# How to say it once classified. The frame read spawns ffmpeg, and `showerror` on a
-# ProcessFailedException prints the whole failed `Cmd` — the env-baked PATH and LD_LIBRARY_PATH
-# included, some 8 kB — which lands verbatim in the user-facing issues report and says nothing
-# anyone can act on. Same reasoning, and same trade, as `Probing.probe_failure`; the wording differs
-# only because the process here is ffmpeg reading a frame rather than ffprobe reading metadata. The
-# rest (an IOError, a DimensionMismatch out of an empty seek) already print short and stay verbatim.
+# How to say it once classified. `showerror` on a ProcessFailedException prints the whole failed
+# `Cmd` — env-baked PATH and LD_LIBRARY_PATH included, some 8 kB — which lands verbatim in the
+# user-facing issues report and says nothing anyone can act on (as in `Probing.probe_failure`; the
+# wording differs only because this process is ffmpeg reading a frame). The rest (an IOError, a
+# DimensionMismatch out of an empty seek) print short and stay verbatim.
 #
-# One method with a branch, rather than the more idiomatic pair of methods dispatching on the
-# exception type: a method whose whole body is a string literal is const-folded away, so its
-# instrumentation never runs and coverage reports the line as missed even though the tests below
-# exercise it. An expression body is measured normally.
+# One method with a branch, rather than a pair dispatching on the exception type: a method whose
+# whole body is a string literal is const-folded away, so its instrumentation never runs and
+# coverage reports the line as missed even though the tests exercise it.
 _failure_message(e) = e isa ProcessFailedException ?
     "ffmpeg could not read the frame (the file is corrupt, truncated, or not a video)" :
     sprint(showerror, e)
@@ -289,10 +268,9 @@ function extrinsic_issue(file, extrinsic, yadif, blur, width, height, n_corners)
     end
 end
 
-# Save the frame that failed detection into `issues_dir` (created on demand) for the user to inspect,
-# named by the video and extrinsic timestamp — e.g. `board_t1.0s.png`. `get_frame` reads the frame
-# lazily; the whole thing is best effort (if the frame itself can't be re-read, e.g. a corrupt file,
-# saving is skipped and `nothing` is returned).
+# Save the frame that failed detection into `issues_dir` (created on demand) for the user to
+# inspect, named by the video and extrinsic timestamp — e.g. `board_t1.0s.png`. `get_frame` reads
+# the frame lazily; best effort throughout, returning `nothing` if anything goes wrong.
 function save_issue_frame(issues_dir, file, extrinsic, get_frame)
     try
         image = get_frame()
@@ -303,7 +281,7 @@ function save_issue_frame(issues_dir, file, extrinsic, get_frame)
     catch e
         # Deliberately broad: saving a diagnostic frame must never break verification, and the
         # three steps above (frame read, mkpath, encode+write) fail in too many ways to enumerate
-        # usefully. An interrupt is not one of those failures — Ctrl-C must not be absorbed here.
+        # usefully. Ctrl-C is not one of those failures.
         e isa InterruptException && rethrow()
         return nothing
     end
@@ -334,11 +312,11 @@ function verify_extrinsics!(df::AbstractDataFrame, issues_dir)
 end
 
 # The camera-model fit needs at least 3 frames with detectable corners sampled from the
-# [start, stop] window (the "temporal_step too short" check above only guarantees 3
-# *sampled* frames, not 3 *detectable* ones). Detection stops as soon as 3 frames succeed, so a
-# good window costs ~3 frame reads and only a genuinely bad one scans through to its end. Frames
-# are read in small parallel batches; the global read semaphore in Rectifications bounds the
-# concurrent opens exactly as in the real rectification.
+# [start, stop] window — the "temporal_step too short" check only guarantees 3 *sampled* frames, not
+# 3 *detectable* ones. Detection stops as soon as 3 succeed, so a good window costs ~3 frame reads
+# and only a genuinely bad one scans to the end. Frames are read in small parallel batches, with the
+# global read semaphore in Rectifications bounding the concurrent opens as in the real
+# rectification.
 function intrinsic_issue(file, start, stop, temporal_step, yadif, blur, width, height, n_corners)
     vf = _vf(yadif, blur)
     found = 0
@@ -376,10 +354,10 @@ function verify_intrinsics!(df::AbstractDataFrame)
     end
 end
 
-# The AprilTag analog of verify_extrinsics!: at the extrinsic frame, ≥ `apriltags` tags of `family`
-# must be detectable and their metric fit must converge (coplanar, not mis-detected). Reads real
-# frames, so it runs on the reduced set of otherwise-clean apriltag rows, grouped so a physical file
-# reached via different spellings is checked once per (extrinsic, apriltags, family, checker_size).
+# The AprilTag analogue of verify_extrinsics!: at the extrinsic frame, ≥ `apriltags` tags of
+# `family` must be detectable and their metric fit must converge (coplanar, not mis-detected). Reads
+# real frames, so it runs only on otherwise-clean apriltag rows, grouped so one physical file is
+# checked once per (extrinsic, apriltags, family, checker_size).
 function verify_apriltag_extrinsics!(df::AbstractDataFrame, issues_dir)
     gs = @chain df begin
         subset(:type => ByRow(passmissing(==("apriltag"))), view = true, skipmissing = true)
@@ -400,18 +378,18 @@ end
 function verify_unique_calibrations!(df::AbstractDataFrame)
     # What makes two rectifications "the same" is type-dependent, so partition by :type:
     #   * matlab / only_scale: identical on *every* field (calibration_id and issues aside).
-    #   * video: identical on the identity key below. The remaining parameters are NOT part of identity
-    #     (one video can carry several rectifications differing only in, say, blur), but two same-identity
-    #     rows still *should* agree on them — when they don't, the duplicate also gets a
-    #     conflicting-parameters issue.
-    # :file is already the canonical resolved path, so equivalent spellings / path splits compare equal
-    # with no per-call realpath. The throwaway :_row column carries each row's index in `df` so flags
+    #   * video: identical on the identity key below. The remaining parameters are NOT part of
+    #     identity (one video can carry several rectifications differing only in, say, blur), but
+    #     two same-identity rows still *should* agree on them — when they don't, the duplicate also
+    #     gets a conflicting-parameters issue.
+    # :file is already the canonical resolved path, so equivalent spellings compare equal with no
+    # per-call realpath. The throwaway :_row column carries each row's index in `df`, so flags
     # written through the type-partitioned views land on the right rows.
     cmp = select(df, Not(:calibration_id, :issues))
     cmp._row = collect(axes(cmp, 1))
-    # Compare only rows that are otherwise valid. A row that already failed an earlier check has had its
-    # offending field(s) nulled to `missing`, which can make two genuinely-distinct rows collapse into a
-    # spurious "duplicate" — and such rows are already reported, so there's nothing to gain by comparing them.
+    # Compare only rows that are otherwise valid: a row that failed an earlier check has had its
+    # offending field nulled to `missing`, which can collapse two genuinely distinct rows into a
+    # spurious "duplicate". Such rows are already reported anyway.
     ok = isempty.(df.issues)
     isvideo = ok .& coalesce.(cmp.type .== "video", false)
 
@@ -437,17 +415,16 @@ end
 
 function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath("results_dir", "issues"))
 
-    # The issues folder is fully transient: it reflects only the current verification run, so wipe it
-    # up front (it is recreated lazily by save_issue_frame the first time a frame fails to detect).
+    # The issues folder is fully transient: it reflects only the current verification run, so it is
+    # wiped up front and recreated lazily by save_issue_frame.
     rm(issues_dir; recursive = true, force = true)
 
     verify_unique_ids!(df)
     @transform! df :path = passmissing(joinpath).(data_path, :path)
 
-    # A path that names the video itself is the common slip, and `isdir` alone reported it as
-    # "does not exist" — which is false, and sends the user to check for a file that is
-    # plainly there (#33). This runs first; verify! nulls :path on failure, so the
-    # existence check below then skips the row rather than piling on the misleading message.
+    # A path naming the video itself is the common slip, and it must be reported as such rather
+    # than as "does not exist" (#33). Runs first, and verify! nulls :path on failure, so the
+    # existence check below skips the row rather than piling on.
     verify!(df, isfile, "path is a file, not a folder — it should be the folder holding the video, with the file name in the `file` column", :path)
     verify!(df, !isdir, "path does not exist", :path)
 
@@ -457,12 +434,11 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
     # skips missing, so non-matlab rows (matlab_file === missing) are untouched.
     verify!(df, (f, p) -> !isfile(joinpath(p, f)), "matlab_file does not exist", :matlab_file, :path)
 
-    # Collapse data_path/path/file into one canonical absolute path stored in :file (and do the
-    # same for :matlab_file), then drop path — it has done its job (the isdir/isfile checks
-    # above) and the resolved paths now subsume it. The single resolved :file is the identity used by
-    # every later step (the read passes, duplicate detection) and :matlab_file groups the .mat reads.
-    # realpath is safe because non-existent paths were nulled just above; passmissing leaves those
-    # missing. (realpath, not bare joinpath, so "./x", "a/../x" and symlinks collapse to one key.)
+    # Collapse data_path/path/file into one canonical absolute path stored in :file (and the same
+    # for :matlab_file), then drop :path, whose job the isdir/isfile checks above have finished. The
+    # resolved :file is the identity used by every later step (the read passes, duplicate detection)
+    # and :matlab_file groups the .mat reads. realpath is safe because non-existent paths were nulled
+    # just above, and is what collapses "./x", "a/../x" and symlinks onto one key.
     @transform! df :file = passmissing(joinpath).(:path, :file)
     @transform! df :file = passmissing(realpath).(:file)
     @transform! df :matlab_file = passmissing(joinpath).(:path, :matlab_file)
@@ -470,10 +446,8 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
     select!(df, Not(:path))
 
     # One read per physical file: ffprobe on the source video (every type) and matread on the .mat
-    # (matlab). These fill the intermediate :duration/:dimension/:n_extrinsics columns, set the video
-    # :width/:height from the probe and impute :aspect (and :yadif for video). read_video_metadata!
-    # creates :duration/:dimension/:width/:height and sets the video frame size used to bounds-check
-    # center/north and to cross-check the matlab ImageSize, so it runs before read_matlab_metadata!.
+    # (matlab). read_video_metadata! must run first: it sets the frame size that bounds-checks
+    # center/north and cross-checks the matlab ImageSize.
     read_video_metadata!(df)
 
     read_matlab_metadata!(df)
@@ -497,19 +471,16 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
     verify!(df, f -> !PawsomeTracker.valid_apriltag_family(f), "family is not a supported AprilTag family (" * join(PawsomeTracker.APRIL_FAMILY_NAMES, ", ") * ")", :family)
     verify!(df, ∉(1:3), "radial_parameters must be 1, 2, or 3", :radial_parameters)
     verify!(df, <(0), "blur must be larger than or equal to zero", :blur)
-    # OpenCV's findChessboardCorners requires both pattern dimensions to be strictly bigger than 2
-    # ("(-211:One of the arguments' values is out of range) Both width and height of the pattern
-    # should have bigger than 2"), so the bound is ≥ 3. It was ≥ 2, which let an n_corners of
-    # (2, n) pass validation and then throw out of the detector below — a precondition worth
-    # checking here instead of catching there. (checker_size_pixel's 2·prod(n) − sum(n) divisor is
-    # also 0 at (1, 1), which this subsumes.)
+    # OpenCV's findChessboardCorners requires both pattern dimensions to be strictly bigger than 2,
+    # so the bound is ≥ 3 — a precondition worth checking here instead of catching out of the
+    # detector. (It also subsumes checker_size_pixel's 2·prod(n) − sum(n) divisor being 0 at (1, 1).)
     verify!(df, x -> any(<(3), x), "n_corners must all be at least 3", :n_corners)
     verify!(df, <(0), "extrinsic must be larger than or equal to zero", :extrinsic)
     # strictly before: seeking at exactly the duration yields no frame at all
     verify!(df, (e, d) -> e ≥ d, "extrinsic must come before the video duration", :extrinsic, :duration)
     # The intrinsic-calibration window must be sane and lie within the video. These run before the
-    # temporal_step checks and null start/stop on failure, so a bad window does not also
-    # trip the misleading "temporal_step too short" message (which is skipped once either bound is missing).
+    # temporal_step checks and null start/stop on failure, so a bad window does not also trip the
+    # misleading "temporal_step too short" message (skipped once either bound is missing).
     verify!(df, <(0), "start must be larger than or equal to zero", :start)
     verify!(df, (a, o) -> a ≥ o, "start must come before stop", :start, :stop)
     verify!(df, (o, d) -> o > d, "stop can not come after video duration", :stop, :duration)
@@ -517,7 +488,8 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
     verify!(df, ≤(0), "temporal_step must be larger than zero", :temporal_step)
     verify!(df, (t, a, o) -> (o - a) ÷ t + 1 < 3, "temporal_step too short (results in less than 3 intrinsic images)", :temporal_step, :start, :stop)
 
-    # verify that the extrinsic time stamp works (should only be done after extrinsic time-stamps have been verified
+    # the extrinsic time stamp must actually yield a detectable frame; only meaningful once the
+    # time stamp itself has been range-checked above
     verify_extrinsics!(df, issues_dir)
 
     # the calibs window must actually contain ≥ 3 detectable-corner frames; runs after

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -57,15 +57,14 @@ function load_runs(data_path, file; strict = true, defaults = (;))
     df = DataFrame(Tables.dictrowtable(cs))
     allowmissing!(df)
 
-    # run_id is all-or-nothing (see resolve_run_ids!): all blank ⇒ every row is its own
-    # single-segment run, numbered by row; all named ⇒ used as-is; mixed ⇒ the blank rows are
-    # flagged. Done before verification/grouping so :run_id is concrete on the clean path.
+    # run_id is all-or-nothing (see resolve_run_ids!). Done before verification and grouping, so
+    # :run_id is concrete on the clean path.
     resolve_run_ids!(df)
 
     verifications!(df, data_path)
 
     if any(!isempty, df.issues)
-        # a run_id that is missing (mixed-numbering case) or equal to the row number (auto-assigned)
+        # a run_id that is missing (mixed numbering) or equal to the row number (auto-assigned)
         # adds nothing over "row $i", so it is only mentioned when the csv named the run itself
         msg = join([string(ismissing(rid) || rid == string(i) ? "row $i" : "row $i (run_id: $rid)", ": ", join(issues, ", "))
                     for (i, (rid, issues)) in enumerate(zip(df.run_id, df.issues)) if !isempty(issues)], '\n')

--- a/src/VerifyRuns/parsers.jl
+++ b/src/VerifyRuns/parsers.jl
@@ -12,12 +12,11 @@ function mytryparse(::Type{MyWindow}, s)
     return mytryparse(NTuple{2, Int}, s)
 end
 
-# The globally overridable defaults: exactly the tracking tuning parameters — not identities
-# (`run_id`/`calibration_id`/`file`/`path`) and not the temporal window (`start`/`stop`/
-# `start_location`), which are inherently per-row. The caller replaces any of these via
-# `load_runs`' `defaults` kwarg (in Fromage: `main`'s `tracking_defaults`); a csv cell always
-# wins over the replaced default (see parseto!). `fps = missing` means "imputed from the probed
-# video", so a caller-supplied fps beats the probe on every row whose cell is blank.
+# The globally overridable defaults: exactly the tracking tuning parameters. Identities and the
+# temporal window are inherently per-row. The caller replaces any of these via `load_runs`'
+# `defaults` kwarg (in Fromage: `main`'s `tracking_defaults`), and a csv cell always wins over the
+# replaced default (see parseto!). `fps = missing` means "imputed from the probed video", so a
+# caller-supplied fps beats the probe on every row whose cell is blank.
 const DEFAULTS = (;
     target_width = 25.0,
     window_size = missing,
@@ -40,11 +39,10 @@ const DEFAULT_TYPES = (;
 
 resolve_defaults(overrides) = Parsing.resolve_defaults(overrides, DEFAULTS, DEFAULT_TYPES, "tracking")
 
-# Every column maps to one `track` keyword (plus `run_id`/`path` for identity & path resolution).
-# The hardcoded defaults (see DEFAULTS) mirror `PawsomeTracker.track`'s own so a blank cell behaves
-# exactly as omitting the argument would. `stop`/`fps` are left missing here and imputed from the
-# probed video (duration / framerate); `window_size`/`start_location` stay missing and are simply
-# omitted from the `track` call.
+# Every column maps to one `track` keyword (plus `run_id`/`path` for identity and path resolution).
+# The hardcoded defaults mirror `PawsomeTracker.track`'s own, so a blank cell behaves exactly as
+# omitting the argument would. `stop`/`fps` are left missing here and imputed from the probed video;
+# `window_size`/`start_location` stay missing and are omitted from the `track` call.
 function parse_run!(dict, row, defaults)
     parseto!(dict, row, :run_id, String, missing)               # all-or-nothing: blank only allowed when every row is blank (then imputed from the row number); see resolve_run_ids!
     parseto!(dict, row, :calibration_id, String)                # required: Fromage joins runs to rectifications on it
@@ -71,12 +69,11 @@ function parse_row(row, defaults = DEFAULTS)
     return dict
 end
 
-# run_id is all-or-nothing: either every row names its run (enabling multi-segment runs), or no
-# row does (column absent, or present with every cell blank) and each row becomes its own
-# single-segment run, identified by its 1-based row number. A mixed file is rejected — under
-# partial numbering a blank row's auto-generated id could silently merge with an explicit one
-# (e.g. "3") into a bogus multi-segment run, so there is no safe way to honor it. In the mixed
-# case the blanks stay missing: Run construction only happens on the issue-free path, and
+# run_id is all-or-nothing: either every row names its run (enabling multi-segment runs), or no row
+# does (column absent, or present with every cell blank) and each row becomes its own single-segment
+# run identified by its 1-based row number. A mixed file is rejected, since a blank row's
+# auto-generated id could silently merge with an explicit one into a bogus multi-segment run. In
+# that case the blanks stay missing: Run construction only happens on the issue-free path, and
 # verify_run_consistency! skips missing-id groups.
 function resolve_run_ids!(df)
     if all(ismissing, df.run_id)

--- a/src/VerifyRuns/precompile.jl
+++ b/src/VerifyRuns/precompile.jl
@@ -1,12 +1,10 @@
-# Build-time precompilation scaffolding, kept in its own file so it can be excluded from coverage
-# (see codecov.yml): these lines run during precompilation, which the coverage run does not
-# instrument, so they can never be hit by the test suite no matter how well the package is tested.
+# Build-time precompilation scaffolding, in its own file so it can be excluded from coverage (see
+# codecov.yml): it runs during precompilation, which the coverage run does not instrument.
 
-# Precompile the parse → verify → report pipeline at build time. The bulk of first-call latency is the
+# Precompile the parse → verify → report pipeline. The bulk of first-call latency is the
 # DataFrames/DataFramesMeta/Chain macro machinery a single `load_runs` run compiles. The workload CSV
-# points at a nonexistent file, so the run exercises the full parse + verification path but bails (file
-# does not exist) before any ffprobe — no bundled media needed, fast and deterministic. (The video-read
-# path is left to compile on first real use.)
+# points at a nonexistent file, so the run exercises the full parse + verification path but bails
+# before any ffprobe — no bundled media, fast and deterministic.
 @setup_workload begin
     dir = mktempdir()
     csv = joinpath(dir, "precompile.csv")
@@ -19,9 +17,8 @@
             try
                 load_runs(dir, csv; strict = false)
             catch e
-                # Deliberately broad: precompilation must not fail because the workload did. An
-                # interrupt is the exception — Ctrl-C during precompile should stop it, not be
-                # absorbed here.
+                # Deliberately broad: precompilation must not fail because the workload did. Ctrl-C
+                # during precompile should still stop it.
                 e isa InterruptException && rethrow()
             end
         end

--- a/src/VerifyRuns/types.jl
+++ b/src/VerifyRuns/types.jl
@@ -1,19 +1,19 @@
 # A verified run: everything `PawsomeTracker.track` needs, guaranteed not to error. A run's arity —
-# a single video, or several segment videos sharing a `run_id` — is materialized in the *type* so
-# `track` dispatches on it with no runtime branch, and grouping yields a `Vector{Run}` of the right
-# concrete types directly. Identity lives on the concrete run types themselves (the convention
-# shared with VerifyRectifications, whose method types carry `calibration_id`): `run_id` names the
-# run, and `calibration_id` names the rectification this run uses (Fromage joins runs to
-# rectifications on it — so a run without one has nothing to rectify against); neither is
-# forwarded to `track`. The run-level *values* shared by both arities live in `Source`: the
-# `track` parameters (`target_width`…`scale`) and the video's stored-pixel `width`/`height` plus
-# sample aspect ratio `sar` as probed by ffprobe (segments of a multi-segment run are verified to
-# agree on them; display width = `width × sar`). The per-segment fields stay in the concrete run
-# types: `SingleRun` carries scalars; `MultiRun` carries aligned per-segment vectors (one entry
-# per segment, in CSV order), where a non-first segment's `start_location` may be `missing` (the
-# target continues from where the previous segment ended). `stop`/`fps` are concrete (imputed from
-# the probed video); `window_size` stays `missing` when the CSV omitted it, and `track(::Run)`
-# imputes it (impute_window_size) from `target_width`/`fps`/duration.
+# a single video, or several segment videos sharing a `run_id` — is materialized in the *type*, so
+# `track` dispatches on it with no runtime branch and grouping yields a `Vector{Run}` of concrete
+# types directly.
+#
+# `run_id` names the run and `calibration_id` names the rectification it uses (Fromage joins the two
+# on it, so a run without one has nothing to rectify against); neither is forwarded to `track`. The
+# run-level values shared by both arities live in `Source`: the `track` parameters
+# (`target_width`…`scale`) plus the video's stored-pixel `width`/`height` and sample aspect ratio
+# `sar` as probed by ffprobe, which segments of a multi-segment run are verified to agree on
+# (display width = `width × sar`). The per-segment fields stay in the concrete types: `SingleRun`
+# carries scalars, `MultiRun` aligned per-segment vectors in CSV order, where a non-first segment's
+# `start_location` may be `missing` (the target continues from where the previous one ended).
+#
+# `stop`/`fps` are concrete, imputed from the probed video. `window_size` stays `missing` when the
+# CSV omitted it, and `track(::Run)` imputes it from `target_width`/`fps`/duration.
 abstract type Run end
 
 struct Source
@@ -59,12 +59,11 @@ function Source(g::AbstractDataFrame)
         g.background_length[1], width, height, g.sar[1])
 end
 
-# Build the typed run for one `run_id` group (rows in CSV order): one row → `SingleRun` (scalar
-# fields), several → `MultiRun` (aligned per-segment vectors). The type is decided here, once, from
-# the group size. The identity columns are read off the first row (verify_run_consistency!
-# guaranteed the segments agree on :calibration_id). The `collect(T, …)` narrows the per-segment
-# columns from the `allowmissing!`-widened `Union{Missing, T}` back to `T` — safe because only
-# issue-free rows reach here — and materializes the group's column views into owned vectors.
+# Build the typed run for one `run_id` group (rows in CSV order): one row → `SingleRun`, several →
+# `MultiRun`. The identity columns are read off the first row, which verify_run_consistency!
+# guaranteed the segments agree on. The `collect(T, …)` narrows the per-segment columns from the
+# `allowmissing!`-widened `Union{Missing, T}` back to `T` — safe because only issue-free rows reach
+# here — and materializes the group's column views into owned vectors.
 function Run(g::AbstractDataFrame)
     source = Source(g)
     if nrow(g) == 1
@@ -85,15 +84,16 @@ function shared_kw(r::Run)
     (; s.target_width, s.darker_target, s.fps, s.initial_search_factor, s.scale, s.background_length)
 end
 
-# Drive `PawsomeTracker.track` from a verified run — the scalar method for a one-segment `SingleRun`,
-# the vector method for a multi-segment `MultiRun`. Concrete-type dispatch, no runtime length check.
-# The returned coordinates are (row, col) in *stored*-frame pixels of the original (unscaled) video;
-# for an anamorphic video the display-space x is col × sar.
-# The run's (or first segment's) start_location falls back to `center` (e.g. the rectification's scene
-# center) and then to the frame's center — (x, y) in *display* pixels, matching start_location's
-# convention, so x is half the display width, width × sar (`track` maps x back to stored columns) —
-# so `track` always gets a concrete starting point. `center` defaults to `missing` (not `nothing`):
-# coalesce only skips `missing`, so a `nothing` would leak through to `track` as-is.
+# Drive `PawsomeTracker.track` from a verified run — the scalar method for a one-segment
+# `SingleRun`, the vector method for a multi-segment `MultiRun`. The returned coordinates are
+# (row, col) in *stored*-frame pixels of the original (unscaled) video; for an anamorphic video the
+# display-space x is col × sar.
+#
+# The run's (or first segment's) start_location falls back to `center` (e.g. the rectification's
+# scene centre) and then to the frame's centre, so `track` always gets a concrete starting point.
+# Both are (x, y) in *display* pixels, matching start_location's convention, so x is half of
+# width × sar and `track` maps it back to stored columns. `center` defaults to `missing` rather than
+# `nothing` because coalesce only skips `missing`.
 frame_center(r::Run) = (round(Int, r.source.width * r.source.sar / 2), r.source.height ÷ 2)
 
 function get_window(target_width, fps, m, duration)
@@ -116,9 +116,9 @@ function impute_window_size(r)
 end
 
 # For an AprilTag run the calibration's `center` is a pixel in the (moved) extrinsic frame, not the
-# run frame, so it can't seed the tracker's start: fall straight back to the run's own start_location
-# (a missing one becomes the frame-centre search inside `track`). Every other rectification shares the
-# run frame, so its centre is a valid start fallback.
+# run frame, so it can't seed the tracker's start: fall straight back to the run's own
+# start_location, a missing one becoming the frame-centre search inside `track`. Every other
+# rectification shares the run frame, so its centre is a valid fallback.
 function track(r::SingleRun; center = missing, rectification = nothing, kwargs...)
     start_location = if rectification isa ApriltagRectification
         r.start_location
@@ -128,12 +128,9 @@ function track(r::SingleRun; center = missing, rectification = nothing, kwargs..
     track(r.file; start = r.start, stop = r.stop, start_location, window_size = impute_window_size(r), shared_kw(r)..., rectification, kwargs...)
 end
 
-# The per-segment start locations with the first segment's fallbacks applied, as a vector `track` can
-# take. The `copy` is what makes this a query rather than an edit: assigning into `r.start_locations`
-# meant the first `track` wrote its `center` into the run, so a later call with a *different* `center`
-# silently kept the first one — the coalesce then saw a non-missing first element, and the
-# frame-centre fallback was unreachable too (#23). A `Run` describes what the csv said; tracking it
-# must leave it alone.
+# The per-segment start locations with the first segment's fallbacks applied, as a vector `track`
+# can take. The `copy` is what makes this a query rather than an edit: a `Run` describes what the
+# csv said, and tracking it must leave it alone (#23).
 function impute_start_location(r::MultiRun, center)
     sls = copy(r.start_locations)
     sls[1] = @coalesce sls[1] center frame_center(r)

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -1,7 +1,7 @@
 # Reduce ffprobe's "num/den" r_frame_rate to a Float64, or `nothing` when the field is absent or
-# unparseable (tryparse semantics, so the caller reports it as malformed output rather than having
-# a `parse` throw out of the probe). A zero denominator (undefined rate) falls back to the
-# numerator so the value stays finite and the fps checks below behave sanely.
+# unparseable (tryparse semantics, so the caller reports it as malformed output rather than a
+# `parse` throwing out of the probe). A zero denominator (undefined rate) falls back to the
+# numerator, keeping the value finite for the fps checks below.
 function parse_framerate(s)
     occursin('/', s) || return tryparse(Float64, s)
     parts = split(s, '/')
@@ -32,13 +32,10 @@ function probe_video(file)
     fields = probe_fields(file, "stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration")
     fields isa String && return fields                 # unreadable file: pass the issue straight on
     # The four fields nothing downstream can proceed without (`fps` imputes the run's tracking rate
-    # when the csv leaves it blank). `tryparse` reports an absent or unparseable one as `nothing`.
-    #
-    # Reaching here means ffprobe *succeeded* and still could not describe a video: it opened the
-    # file but `-select_streams v:0` matched nothing (an audio-only file), or it recognised some
-    # container in what is really junk. Both mean the same thing to the user — this is not a usable
-    # video — so it joins the "issue reading from video file" family rather than getting a message
-    # of its own, which would suggest our parsing broke rather than their file being bad.
+    # when the csv leaves it blank); `tryparse` reports an absent or unparseable one as `nothing`. A
+    # miss here means ffprobe *succeeded* and still could not describe a video (an audio-only file,
+    # or junk it recognised a container in), which is not a usable video either — hence the same
+    # "issue reading from video file" wording.
     width    = tryparse(Int, get(fields, "width", ""))
     height   = tryparse(Int, get(fields, "height", ""))
     duration = tryparse(Float64, get(fields, "duration", ""))
@@ -90,18 +87,17 @@ function verify!(df::AbstractDataFrame, predicate, msg, args...)
     end
 end
 
-# Run-level fields, as opposed to the per-segment file/start/stop/start_location: the whole run shares
-# one value (they end up in the run's `Source`), so segments of one run must agree on them (checked by
-# verify_run_consistency! via `allequal`, which treats all-missing as agreeing — isequal(missing,
-# missing) is true). All but `calibration_id` (run metadata) and `dimension`/`sar` (the ffprobe-read
-# pixel width/height and sample aspect ratio, not CSV columns) feed `track`.
+# Run-level fields, as opposed to the per-segment file/start/stop/start_location: the whole run
+# shares one value (they end up in the run's `Source`), so segments of one run must agree on them —
+# checked by verify_run_consistency! via `allequal`, which treats all-missing as agreeing. All but
+# `calibration_id` and `dimension`/`sar` (ffprobe-read, not CSV columns) feed `track`.
 const SHARED_PARAMS = (:target_width, :window_size, :darker_target, :fps,
     :initial_search_factor, :scale, :background_length, :calibration_id, :dimension, :sar)
 
 # A run may be split across several CSV rows (one per segment video) sharing a :run_id. Those rows
-# must agree on every run-level parameter — only file/start/stop/start_location may vary. Compared
-# only among otherwise-clean rows: a field nulled by an earlier failed check would read as a spurious
-# disagreement, and that row is already reported.
+# must agree on every run-level parameter; only file/start/stop/start_location may vary. Compared
+# only among otherwise-clean rows, since a field nulled by an earlier failed check would read as a
+# spurious disagreement.
 function verify_run_consistency!(df::AbstractDataFrame)
     for g in groupby(df, :run_id)
         (nrow(g) > 1 && !ismissing(g.run_id[1]) && all(isempty, g.issues)) || continue
@@ -112,14 +108,13 @@ function verify_run_consistency!(df::AbstractDataFrame)
 end
 
 function verifications!(df::AbstractDataFrame, data_path)
-    # Resolve path against data_path, check existence, then collapse path/file into one
-    # canonical absolute :file (the identity used for per-file reads and segment grouping) and drop
-    # path. realpath is safe because non-existent paths were nulled to missing just above.
+    # Resolve path against data_path, check existence, then collapse path/file into one canonical
+    # absolute :file (the identity used for per-file reads and segment grouping) and drop path.
+    # realpath is safe because non-existent paths were nulled to missing just above.
     @transform! df :path = passmissing(joinpath).(data_path, :path)
-    # A path that names the video itself is the common slip, and `isdir` alone reported it as
-    # "does not exist" — which is false, and sends the user to check for a file that is
-    # plainly there (#33). This runs first; verify! nulls :path on failure, so the
-    # existence check below then skips the row rather than piling on the misleading message.
+    # A path naming the video itself is the common slip, and must be reported as such rather than as
+    # "does not exist" (#33). Runs first, and verify! nulls :path on failure, so the existence check
+    # below skips the row rather than piling on.
     verify!(df, isfile, "path is a file, not a folder — it should be the folder holding the video, with the file name in the `file` column", :path)
     verify!(df, !isdir, "path does not exist", :path)
     verify!(df, (f, p) -> !isfile(joinpath(p, f)), "file does not exist", :file, :path)
@@ -131,9 +126,9 @@ function verifications!(df::AbstractDataFrame, data_path)
     read_video_metadata!(df)
 
     # start_location is optional (missing rows skipped). It is (x, y) = (horizontal, vertical) in
-    # *display* pixels — like a rectification's center/north — while ffprobe's width is in stored
-    # pixels, so x is bounds-checked against the display width, width × sar (they only differ for
-    # anamorphic videos); y against height, which sar does not affect.
+    # *display* pixels, like a rectification's center/north, while ffprobe's width is in stored
+    # pixels — so x is bounds-checked against the display width, width × sar, and y against height,
+    # which sar does not affect.
     verify!(df, x -> any(<(1), x), "start_location cannot be smaller than 1", :start_location)
     verify!(df, (sl, dim, sar) -> sl[1] > dim[1] * sar || sl[2] > dim[2], "start_location is outside the frame", :start_location, :dimension, :sar)
 
@@ -149,28 +144,23 @@ function verifications!(df::AbstractDataFrame, data_path)
     verify!(df, >(1), "scale cannot be larger than one", :scale)
     # The tracker works in the scaled frame, so it is the *scaled* target width that must span at
     # least one pixel — each factor can be individually fine while their product is degenerate.
-    #
-    # This bound is what keeps a low `scale` from failing rather than merely coarsening. Measured on
-    # a clean synthetic disc (issue #24): accuracy decays smoothly as the scaled target shrinks —
-    # around 0.3% of target_width at scale 1, 0.7% at 0.25, 4% at 0.1 — and below a scaled width of
-    # roughly half a pixel the tracker stops finding the target at all, reporting positions hundreds
-    # of pixels away. It does NOT throw, so without this check the result would be a plausible-looking
-    # track of nothing. Note the check uses the *declared* target_width: over-declaring it permits a
-    # scale that is too small for the real target, which is one more reason target_width is the
-    # parameter worth measuring.
+    # Below roughly half a pixel the tracker stops finding the target at all, and does NOT throw, so
+    # without this check the result is a plausible-looking track of nothing (#24). The check uses
+    # the *declared* target_width, so over-declaring it permits a scale too small for the real
+    # target.
     verify!(df, (tw, sc) -> tw * sc < 1, "scaled target width (target_width × scale) is smaller than one pixel", :target_width, :scale)
-    # 0 is a real mode (no background subtraction); 1–24 would make a background model too short
-    # to model anything, and negatives are nonsense — the predicate covers both.
+    # 0 is a real mode (no background subtraction); 1–24 is a background model too short to model
+    # anything, and negatives are nonsense — the predicate covers both.
     verify!(df, b -> b != 0 && b < 25, "background_length must be 0 (disables background subtraction) or at least 25", :background_length)
 
-    # Temporal window must be sane and lie within the video. start ≥ 0 runs first and nulls :start on
-    # failure, so a negative start does not also trip the "start must come before stop" message.
+    # Temporal window must be sane and lie within the video. start ≥ 0 runs first and nulls :start
+    # on failure, so a negative start does not also trip "start must come before stop".
     verify!(df, <(0), "start must be larger than or equal to zero", :start)
     verify!(df, (a, o) -> a ≥ o, "start must come before stop", :start, :stop)
     verify!(df, (o, d) -> o > d, "stop can not come after video duration", :stop, :duration)
     verify!(df, (a, d) -> a > d, "start can not come after video duration", :start, :duration)
     # PawsomeTracker reads round(Int, fps × (stop − start)) frames, so a window shorter than half a
-    # frame period reads none at all (and a zero-frame segment crashes the multi-segment track).
+    # frame period reads none at all, and a zero-frame segment crashes the multi-segment track.
     verify!(df, (o, a, f) -> round(Int, f * (o - a)) < 1, "temporal window is too short to contain a single frame at this fps", :stop, :start, :fps)
 
     # Cross-row: segments of one run (shared :run_id) must agree on the run-level parameters.

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,9 +1,7 @@
 const results_dir = "results_dir"
 
 # Every segment shares one resolution, codec and quality (see diagnose.jl), so a single ffmpeg
-# concat-demuxer call stream-copies them into the final video. The demuxer rewrites timestamps
-# monotonically by design — unlike the former pairwise "concat:"-protocol tree, which leaned on
-# per-join discontinuity heuristics with every warning hidden at -loglevel 8.
+# concat-demuxer call stream-copies them into the final video, rewriting timestamps monotonically.
 function concatenate(path, files)
     list = joinpath(path, "list.txt")
     open(list, "w") do io
@@ -13,15 +11,13 @@ function concatenate(path, files)
     ffmpeg_exe(` -y -loglevel error -f concat -safe 0 -i $list -c copy $out`)
 end
 
-# Save one run's track to results_dir/<run_id>.csv: one row per detected coordinate, with the
-# `time` stamp (seconds into the video) and the `x`/`y` real-world coordinates. `track` already
-# returns real-world coordinates: it applied the run's rectification's `image2real` — for the video
-# kinds a pixel→real map, for AprilTag a metric ground map carrying the same centre/north gauge — so
-# the origin is at `center`, north-aligned when `north` was given, in `checker_size`/`scale` units.
-# Axis orientation follows the image — x rightward, y downward — as
-# `(y-direction, x-direction)`, so we unpack `y, x`. AprilTag tracking reports `missing` for a frame
-# whose target couldn't be localized (e.g. a tag was momentarily lost); such a row keeps its `time`
-# with empty `x`/`y`, so the time axis stays intact and the gaps are explicit.
+# Save one run's track to results_dir/<run_id>.csv: one row per coordinate, with the `time` stamp
+# (seconds into the video) and the `x`/`y` real-world coordinates. `track` returns coordinates the
+# rectification's `image2real` has already been applied to, so the origin is at `center`,
+# north-aligned when `north` was given, in `checker_size`/`scale` units. Axis orientation follows
+# the image — x rightward, y downward — as `(y-direction, x-direction)`, hence the `y, x` unpack.
+# A `missing` coordinate (AprilTag tracking, where a frame's target couldn't be localized) keeps its
+# `time` with empty `x`/`y`, so the time axis stays intact and the gaps are explicit.
 function save2csv(run_id, (ts, coords))
     open(joinpath(results_dir, string(run_id, ".csv")), "w") do io
         println(io, "time,x,y")
@@ -38,12 +34,7 @@ end
 
 # Keep only the entries whose `id` field was asked for, and reject any requested id that matched
 # nothing. Filtering by id is a convenience for iterating on one run or calibration, so an id that
-# matches nothing is a typo rather than a request for less — and left unchecked it failed in two
-# unhelpful ways (#21). A total miss emptied the pipeline and only surfaced at the very end, when
-# `concatenate` handed ffmpeg's concat demuxer a zero-entry list: reported as "Error opening input:
-# Invalid data found when processing input", which points at the footage rather than at the filter.
-# A PARTIAL miss was quieter and worse — it simply processed fewer runs than asked for, with no error
-# at all, so nothing prompted the user to look. Hence the strict rule: every requested id must match.
+# matches nothing is a typo rather than a request for less: every requested id must match (#21).
 function filter_ids!(xs, requested, id, what)
     isnothing(requested) && return xs
     available = [getfield(x, id) for x in xs]
@@ -65,9 +56,9 @@ function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.c
 
     mkpath(results_dir)
 
-    # The loaders return the annotated DataFrame instead only under `strict = false`; on the
-    # default strict path they provably return the run/rectification vectors — assert it so the
-    # union doesn't leak downstream (JET flags e.g. `length(::DataFrame)` otherwise).
+    # The loaders return the annotated DataFrame only under `strict = false`; on the default strict
+    # path they return the run/rectification vectors — asserted so the union doesn't leak
+    # downstream (JET flags e.g. `length(::DataFrame)` otherwise).
     cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults, issues_dir = joinpath(results_dir, "issues"))::Vector{RectificationMethod}
     rs = load_runs(joinpath(data_path, runs_file); defaults = tracking_defaults)::Vector{Run}
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -6,16 +6,16 @@ module Parsing
 
 using Dates: Dates, Second, Time, TimePeriod
 
-# Local parse helper mirroring Base.tryparse semantics (returns the parsed value or `nothing` on
-# failure). Defining our own avoids type piracy on Base.tryparse for types we don't own (String,
-# NTuple). The generic fallback delegates to Base for the standard types (Int, Float64, Bool, ...).
+# Local parse helper mirroring Base.tryparse semantics (the parsed value, or `nothing` on failure).
+# Ours, rather than Base.tryparse, to avoid type piracy on types we don't own (String, NTuple); the
+# generic fallback delegates to Base for the standard types (Int, Float64, Bool, ...).
 mytryparse(::Type{T}, x) where {T} = tryparse(T, x)
 
 function mytryparse(::Type{NTuple{2, Int}}, s)
     m = match(r"^\s*[\(\[]?\s*(-?\d+)\s*,\s*(-?\d+)\s*[\)\]]?\s*$", s)
     isnothing(m) && return nothing
-    a = tryparse(Int, m.captures[1])      # tryparse (not parse): a > Int64 value overflows ->
-    b = tryparse(Int, m.captures[2])      # nothing -> "wrong format" issue, not an uncaught throw
+    a = tryparse(Int, m.captures[1])      # tryparse, not parse: an over-Int64 value becomes
+    b = tryparse(Int, m.captures[2])      # `nothing` (a "wrong format" issue), not a throw
     (isnothing(a) || isnothing(b)) && return nothing
     return (a, b)
 end
@@ -33,10 +33,9 @@ function mytryparse(::Type{MyTemporal}, x)
     return nothing
 end
 
-# Trim surrounding whitespace from hand-edited CSV cells: a stray space must not turn " file.mp4"
-# into a missing file, or "id " vs "id" into a missed duplicate. (The numeric and tuple/time
-# parsers already tolerate surrounding whitespace.) `String(...)` (not just `strip`) because strip
-# returns a SubString and the struct fields are typed `::String`, which won't accept a SubString.
+# Trim surrounding whitespace from hand-edited CSV cells; the numeric and tuple/time parsers
+# tolerate it already. `String(...)` and not just `strip`, whose SubString the `::String` fields
+# won't accept.
 mytryparse(::Type{String}, x) = String(strip(string(x)))
 
 function set!(dict, y, k, _)
@@ -50,9 +49,8 @@ end
 
 function parseto!(dict, row, k, ::Type{T}, default = nothing) where {T}
     raw = haskey(row, k) ? row[k] : missing
-    # A present-but-blank cell (whitespace only) is treated exactly like an absent one: a required
-    # field then reports "is missing" instead of silently becoming an empty string, and an optional
-    # field falls back to its default.
+    # A present-but-blank cell (whitespace only) counts as absent: a required field reports "is
+    # missing" rather than becoming an empty string, and an optional one takes its default.
     if !ismissing(raw) && !(raw isa AbstractString && isempty(strip(raw)))
         y = mytryparse(T, raw)
         set!(dict, y, k, "wrong $k format")
@@ -64,18 +62,15 @@ end
 # Validate and normalize caller-supplied global defaults against a gateway's whitelist: only keys
 # of `defaults` may be set, each value must convert to its column's type (`types`), and `what`
 # names the kwarg in the error message ("rectification"/"tracking"). Fails fast, before any
-# parsing; values are otherwise not pre-checked — an out-of-range default flows into the normal
+# parsing. Values are not otherwise pre-checked: an out-of-range default flows into the normal
 # verifications and is flagged on every row that used it.
 function resolve_defaults(overrides, defaults, types, what)
     unknown = setdiff(keys(overrides), keys(defaults))
     isempty(unknown) || throw(ArgumentError("unknown $what default(s): $(join(unknown, ", ")) (settable: $(join(keys(defaults), ", ")))"))
     isempty(overrides) && return defaults
-    # `convert` has no non-throwing counterpart, so this failure stays a caught exception — but only
-    # the two it can actually be. Over every whitelisted target type (Float64, Int, Bool,
-    # NTuple{2,Int}, Union{Int,NTuple{2,Int}}) a rejected value fails as either a `MethodError` (no
-    # such conversion: "yes" -> Bool) or an `InexactError` (a conversion that would lose
-    # information: 1.5 -> Int, 2 -> Bool). Anything else is not a rejected default and must not be
-    # relabelled as one — it propagates.
+    # `convert` has no non-throwing counterpart, so this stays a caught exception — but only the two
+    # a rejected value can raise over the whitelisted types: `MethodError` (no such conversion:
+    # "yes" -> Bool) or `InexactError` (a lossy one: 1.5 -> Int). Anything else propagates.
     converted = NamedTuple{keys(overrides)}(map(keys(overrides)) do k
         try
             convert(types[k], overrides[k])

--- a/src/probing.jl
+++ b/src/probing.jl
@@ -1,10 +1,9 @@
-# The ffprobe plumbing shared by the two gateways (VerifyRectifications and VerifyRuns). Both need
-# the same thing from a video file — spawn one ffprobe, read its `key=value` output, report an
-# unreadable file as an issue string — and differ only in which entries they ask for and what they
-# derive from them. That difference stays in the gateways; only the plumbing lives here.
+# The ffprobe plumbing shared by the two gateways (VerifyRectifications and VerifyRuns): spawn one
+# ffprobe, read its `key=value` output, report an unreadable file as an issue string. Which entries
+# to ask for, and what to derive from them, stays in the gateways.
 #
-# It is its own module rather than part of `Parsing` because `Parsing` is CSV-cell machinery that
-# depends on nothing but Dates, and spawning ffprobe has no business widening that.
+# Its own module rather than part of `Parsing`, which is CSV-cell machinery depending on nothing
+# but Dates — spawning ffprobe has no business widening that.
 module Probing
 
 using FFMPEG: ffprobe
@@ -14,10 +13,9 @@ using FFMPEG: ffprobe
 #
 # Only the spawn is fallible in a way worth catching: ffprobe exiting nonzero on an unreadable or
 # corrupt file (ProcessFailedException), or the spawn/pipe itself failing (IOError, SystemError).
-# Anything else is not an unreadable video and propagates. Uses the non-do-block `ffprobe()` (an
-# env-baked Cmd, so its adjusted PATH/LD_LIBRARY_PATH survive interpolation and the process-global
-# ENV is never mutated — which is what makes this safe under the callers' nested tmaps); stderr is
-# dropped so ffmpeg's diagnostics don't leak into the program output.
+# Anything else is not an unreadable video and propagates. The non-do-block `ffprobe()` gives an
+# env-baked Cmd, safe to interpolate under the callers' nested tmaps; stderr is dropped so ffmpeg's
+# diagnostics don't leak into the program output.
 function probe_fields(file, entries)
     exe = ffprobe()
     out = try
@@ -36,10 +34,10 @@ function probe_fields(file, entries)
     return fields
 end
 
-# `showerror` on a ProcessFailedException prints the whole failed `Cmd` — including the env-baked
-# PATH and LD_LIBRARY_PATH, some 7 kB of it — and this message goes straight into the user-facing
-# issues report. The exit status carries no information a user can act on either, so say what
-# actually happened instead. Other failures are rare and worth printing in full.
+# These messages go straight into the user-facing issues report, and `showerror` on a
+# ProcessFailedException prints the whole failed `Cmd` — env-baked PATH and LD_LIBRARY_PATH
+# included, some 7 kB of it — with an exit status nobody can act on. Say what happened instead.
+# Other failures are rare and worth printing in full.
 probe_failure(::ProcessFailedException) = "ffprobe could not read it (the file is corrupt, truncated, or not a video)"
 probe_failure(e) = sprint(showerror, e)
 

--- a/test/Rectifications/test_ffmpeg_cmd.jl
+++ b/test/Rectifications/test_ffmpeg_cmd.jl
@@ -8,7 +8,7 @@
         @test R._vf(true, missing) == "yadif=1"                          # deinterlace only
         @test R._vf(true, 2.0) == "yadif=1,gblur=sigma=2.0"              # both, in order
         # yadif = false means progressive footage: it must NOT deinterlace (VerifyRectifications
-        # probes yadif as a Bool, so false is the common case — it used to hit the yadif branch)
+        # probes yadif as a Bool, so false is the common case)
         @test R._vf(false, missing) === missing
         @test R._vf(false, 2.0) == "gblur=sigma=2.0"
         # blur = 0 means no blur (VerifyRectifications' convention): no sigma-0 no-op filter
@@ -38,8 +38,8 @@
 
     @testset "_cmd bakes ffmpeg env without mutating global ENV" begin
         # The non-do-block `FFMPEG.ffmpeg()` bakes PATH/LD_LIBRARY_PATH into the Cmd via setenv and
-        # never touches the process-global ENV — this is what makes the builders race-free under the
-        # nested tmap concurrency (replacing the old snapshot/addenv machinery).
+        # never touches the process-global ENV, which is what makes the builders race-free under the
+        # nested tmap concurrency.
         keys_before = Set(keys(ENV))
         ldpath_before = get(ENV, "LD_LIBRARY_PATH", nothing)
         c = R._cmd("video.mp4", 1.5, missing)

--- a/test/Rectifications/test_module_state.jl
+++ b/test/Rectifications/test_module_state.jl
@@ -1,6 +1,5 @@
-# Module-level state set up in __init__: the read-concurrency semaphore.
-# (The ffmpeg runtime env is no longer snapshotted — `_cmd` gets it straight from the
-# env-baked `FFMPEG.ffmpeg()`/`ffprobe()` Cmds; see test_ffmpeg_cmd.jl.)
+# Module-level state set up in __init__: the read-concurrency semaphore. (The ffmpeg runtime env is
+# not module state — `_cmd` gets it from the env-baked Cmds; see test_ffmpeg_cmd.jl.)
 
 @testset "module state" begin
 

--- a/test/VerifyRectifications/test_filesystem.jl
+++ b/test/VerifyRectifications/test_filesystem.jl
@@ -10,9 +10,8 @@
     end
 
     @testset "a path naming the video itself says so (#33)" begin
-        # Putting the video in `path` used to be reported as "path does not exist" — false, and it
-        # sends the user looking for a file that is plainly there. The targeted message runs first
-        # and nulls :path, so the existence check does not also fire with the misleading one.
+        # The targeted message runs first and nulls :path, so the existence check does not also
+        # fire with the misleading "path does not exist".
         df = check("fs_pathisfile.csv", [videorow(path = ART.board)])
         @test flagged(df, 1, "path is a file, not a folder")
         @test !flagged(df, 1, "path does not exist")

--- a/test/VerifyRectifications/test_reading.jl
+++ b/test/VerifyRectifications/test_reading.jl
@@ -48,7 +48,7 @@
 
     @testset "unreadable only_scale file is now always opened (no lazy skip)" begin
         # Every row now reads its source video to fill the shared Source width/height/aspect, so a
-        # corrupt only_scale video is flagged even when center/north are absent (the former lazy-skip
+        # corrupt only_scale video is flagged even when center/north are absent (a lazy skip
         # optimization is gone).
         df = check("r_corrupt_skip.csv", [scalerow(file = ART.corrupt, center = missing, north = missing)])
         @test flagged(df, 1, "issue reading from video file")
@@ -144,7 +144,7 @@
 
     @testset "single-type CSV (no per-type fillers) loads" begin
         # parse_row back-fills every COLUMNS entry with missing, so a video-only CSV (which never
-        # creates the :scale column) no longer makes verifications! throw `column :scale not found`.
+        # creates the :scale column) must not make verifications! throw `column :scale not found`.
         csv = write_csv(joinpath(DATADIR, "videoonly.csv"), [videorow()])   # no fillers
         @test (VRect.load_rectifications(DATADIR, csv; strict = false); true)
     end

--- a/test/VerifyRectifications/test_structural.jl
+++ b/test/VerifyRectifications/test_structural.jl
@@ -103,7 +103,7 @@
 
     @testset "no false duplicate from rows nulled by earlier checks" begin
         # two DISTINCT matlab rows (different centers) that are both out of bounds: each center gets
-        # nulled by the bounds check, which would otherwise make the rows look identical. Uniqueness
+        # nulled by the bounds check, which would make the rows look identical. Uniqueness
         # skips rows that already carry issues, so neither gets a spurious "duplicate rectification".
         df = check("s_nodup_nulled.csv", [matlabrow(calibration_id = "a", center = (600, 600), north = missing),
                                           matlabrow(calibration_id = "b", center = (700, 700), north = missing)])

--- a/test/VerifyRectifications/test_values.jl
+++ b/test/VerifyRectifications/test_values.jl
@@ -38,8 +38,8 @@
         @test flagged(check("v_radial.csv", [videorow(radial_parameters = 4)]),   1, "radial_parameters must be 1, 2, or 3")
         @test flagged(check("v_radial0.csv",[videorow(radial_parameters = 0)]),   1, "radial_parameters must be 1, 2, or 3")
         @test flagged(check("v_blur.csv",   [videorow(blur = -1)]),               1, "blur must be larger than or equal to zero")
-        # OpenCV's findChessboardCorners requires both pattern dimensions strictly bigger than 2, so
-        # the bound is ≥ 3. (2, n) used to pass validation and then throw out of the detector.
+        # OpenCV's findChessboardCorners requires both pattern dimensions strictly bigger than 2,
+        # so the bound is ≥ 3 — checked here rather than caught out of the detector.
         @test flagged(check("v_ncorn.csv",  [videorow(n_corners = (0, 5))]),      1, "n_corners must all be at least 3")
         @test flagged(check("v_ncorn1.csv", [videorow(n_corners = (1, 5))]),      1, "n_corners must all be at least 3")
         @test flagged(check("v_ncorn11.csv",[videorow(n_corners = (1, 1))]),      1, "n_corners must all be at least 3")
@@ -69,7 +69,7 @@
                       1, "start must be larger than or equal to zero")
         @test flagged(check("v_winv.csv", [videorow(start = "00:00:04", stop = "00:00:01")]),
                       1, "start must come before stop")
-        # a window that runs past the end of the video is caught (was silently accepted before)
+        # a window that runs past the end of the video is caught
         @test flagged(check("v_wdur.csv", [videorow(start = "00:00:01", stop = "00:10:00")]),
                       1, "stop can not come after video duration")
         # an inverted window must NOT also emit the misleading "temporal_step too short"

--- a/test/VerifyRuns/test_filesystem.jl
+++ b/test/VerifyRuns/test_filesystem.jl
@@ -8,9 +8,8 @@
     end
 
     @testset "a path naming the video itself says so (#33)" begin
-        # Putting the video in `path` used to be reported as "path does not exist" — false, and it
-        # sends the user looking for a file that is plainly there. The targeted message runs first
-        # and nulls :path, so the existence check does not also fire with the misleading one.
+        # The targeted message runs first and nulls :path, so the existence check does not also
+        # fire with the misleading "path does not exist".
         df = check("fs_pathisfile.csv", [runrow(path = ART.a)])
         @test flagged(df, 1, "path is a file, not a folder")
         @test !flagged(df, 1, "path does not exist")

--- a/test/VerifyRuns/test_parsing.jl
+++ b/test/VerifyRuns/test_parsing.jl
@@ -34,7 +34,7 @@
         @test flagged(df, 2, "either every row has a run_id or none does")
         @test !flagged(df, 3, "either every row has a run_id or none does")
 
-        # the collision this rule forecloses: an explicit "3" plus a blank row can no longer merge
+        # the collision this rule forecloses: an explicit "3" plus a blank row must not merge
         # into a bogus multi-segment run — the mixed file is rejected outright
         df2 = check("p_id_collide.csv", [runrow(run_id = "3", file = ART.a),
                                          runrow(run_id = missing, file = ART.b)])

--- a/test/VerifyRuns/test_segments.jl
+++ b/test/VerifyRuns/test_segments.jl
@@ -54,7 +54,7 @@
         @test only(runs) isa VR.MultiRun
         @test only(runs).calibration_id == "cal_1"
 
-        # omitting it is no longer allowed: every such segment row is flagged at parse time
+        # omitting it is not allowed: every such segment row is flagged at parse time
         df0 = check("seg_cal_none.csv", [runrow(run_id = "s", file = ART.a, calibration_id = missing),
                                          runrow(run_id = "s", file = ART.b, calibration_id = missing)])
         @test flagged(df0, 1, "calibration_id is missing")

--- a/test/VerifyRuns/test_tracking.jl
+++ b/test/VerifyRuns/test_tracking.jl
@@ -78,13 +78,11 @@
     end
 
     @testset "the smallest permitted scale still finds the target (#24)" begin
-        # The `target_width × scale ≥ 1` guard exists to stop a scale so low that the tracker loses
-        # the target silently — measured, it reports positions hundreds of pixels off without ever
-        # throwing. The rejection side is covered in test_values.jl; this is the guarantee the guard
-        # is *for*: right at the boundary the target is still found. base is a 10 px disc, so scale
-        # 0.1 is the smallest legal value (a 10×10 working frame). The tolerance is deliberately
-        # loose — precision at the boundary is inherently about 1/scale — so this asserts the track
-        # stays within the target's own radius, i.e. still on the disc rather than wandering.
+        # The rejection side of the `target_width × scale ≥ 1` guard is covered in test_values.jl;
+        # this is the guarantee it is *for*: right at the boundary the target is still found. base
+        # is a 10 px disc, so scale 0.1 is the smallest legal value (a 10×10 working frame). The
+        # tolerance is loose because precision at the boundary is inherently about 1/scale — the
+        # assertion is that the track stays within the target's own radius rather than wandering.
         runs = check("t_scale_min.csv", [runrow(file = only(base), target_width = "10", scale = "0.1")])
         @test clean(runs)
         _, ij = VR.track(only(runs))

--- a/test/VerifyRuns/test_video_metadata.jl
+++ b/test/VerifyRuns/test_video_metadata.jl
@@ -29,7 +29,7 @@
         @test VR.parse_framerate("25/1") == 25.0
         @test VR.parse_framerate("25/0") == 25.0        # undefined rate: fall back to the numerator
         # Anything unparseable is `nothing`, so probe_video reports malformed output rather than
-        # letting a `parse` throw into its catch. "N/A" is the case that used to throw: it contains
+        # letting a `parse` throw into its catch. "N/A" is the interesting case: it contains
         # a '/', so it took the fraction branch and split into ("N", "A").
         @test VR.parse_framerate("N/A") === nothing
         @test VR.parse_framerate("")    === nothing

--- a/test/apriltag.jl
+++ b/test/apriltag.jl
@@ -59,7 +59,7 @@ project(H) = [[apply_h(H, c) for c in tc] for tc in TAGS_CM]
     @testset "non-coplanar / mis-detected tags fail loudly, not silently" begin
         bad = project(HMILD)                                         # tag 4 is a 150 cm square,
         bad[4] = [apply_h(HMILD, CENTERS[4] + rot(ANGLES[4]) * (c * 150/96)) for c in CANON]  # not 96
-        # fit_metric computes and reports; it no longer decides. The error it returns is well past
+        # fit_metric computes and reports; it does not decide. The error it returns is well past
         # the tolerance, and the direct constructor still turns that into a throw.
         @test last(fit_metric(bad)) > METRIC_FIT_TOLERANCE
         @test_throws ErrorException ReferenceFrame([0,1,2,3], bad)

--- a/test/common.jl
+++ b/test/common.jl
@@ -25,11 +25,9 @@ function make_checkerboard_video(path, png; duration = 5)
 end
 
 # A file ffprobe reliably refuses: the leading bytes of a real mp4, with the moov atom and all the
-# media data cut off. This used to be `rand(UInt8, 500)`, which made every corrupt-video test a dice
-# roll — roughly 1 random blob in 300 is recognised by ffprobe as some container, whereupon it exits
-# 0 and reports nothing usable rather than failing. That input is real and the code must handle it,
-# but it has no business arriving at random: it is now covered deliberately by the audio-only case
-# in test/probing.jl, while this fixture always exercises the outright-unreadable path.
+# media data cut off. Deterministic on purpose — the "ffprobe exits 0 but reports nothing usable"
+# case is covered deliberately by the audio-only fixture in test/probing.jl, so this one always
+# exercises the outright-unreadable path.
 function make_corrupt_video(path)
     mktempdir() do dir
         whole = joinpath(dir, "whole.mp4")
@@ -44,10 +42,9 @@ end
 # pixels, then squeezed to (width/sar)×height stored pixels with setsar=sar — a genuinely
 # anamorphic file when sar ≠ 1. `nsegments > 1` splits the same trajectory into several files on
 # forced keyframes (a segmented run). `pause = (t1, t2)` freezes the trajectory between those
-# seconds (the disc sits perfectly still, then resumes where it left off) — the long-stationary
-# target that used to be absorbed into the tracker's background model. Writes into `dir`; returns
-# the basename(s) and the ground-truth closure `expected(i; skip, offset)`: the stored-frame
-# 1-based (row, col) of the disc center at sample i, where sample i reads global frame
+# seconds — a long-stationary target, which the background model must not absorb. Writes into
+# `dir`; returns the basename(s) and the ground-truth closure `expected(i; skip, offset)`: the
+# stored-frame 1-based (row, col) of the disc center at sample i, where sample i reads global frame
 # `offset + (i − 1)·skip` (skip = video fps ÷ requested fps).
 function make_target_video(dir, name; width = 100, height = 100, sar = 1//1, fps = 25, duration = 2,
         target_width = 10, darker_target = true, row = 50, col = 55, nsegments = 1, pause = nothing)
@@ -103,7 +100,7 @@ function write_csv(path, rows, header)
     path
 end
 
-# A kwarg not in `header` would otherwise be dropped silently, quietly testing nothing.
+# A kwarg not in `header` would be dropped silently, quietly testing nothing.
 function buildrow(header; kw...)
     unknown = setdiff(string.(keys(kw)), header)
     @assert isempty(unknown) "unknown CSV column/s in test row: $unknown"

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -150,11 +150,9 @@ end
 
 @testset "an id filter that matches nothing is reported, not obeyed silently (#21)" begin
     # Filtering by id is a convenience for iterating on one run; an id that matches nothing is a
-    # typo, not a request for less. Unchecked, a total miss emptied the pipeline and only failed at
-    # the very end, when ffmpeg's concat demuxer was handed a zero-entry list — reported as
-    # "Error opening input: Invalid data found when processing input", which points at the footage
-    # rather than the filter. A PARTIAL miss was worse: it silently tracked fewer runs than asked,
-    # with no error at all.
+    # typo, not a request for less. Both the total miss (which would fail late and unhelpfully out
+    # of ffmpeg) and the partial one (which would silently track fewer runs than asked) must be
+    # reported here instead.
     dir = mktempdir()
     make_video(joinpath(dir, "cal.mp4"); size = (320, 240), duration = 2)
     target, _ = make_target_video(dir, "idf")
@@ -232,11 +230,11 @@ end
 @testset "AprilTag: registered stack survives a large pan, the rolling phase, and tag loss" begin
     # A harder synthetic flight than the e2e above, aimed at the registered background stack: a
     # large pan amplitude (the crop window sweeps nearly the whole canvas margin), more frames than
-    # the background window (so the rolling phase actually runs — the e2e above fits entirely in
-    # the prefill), and the first tag occluded both BEFORE the first full tag set (exercising the
+    # the background window (so the rolling phase runs at all — the e2e above fits entirely in the
+    # prefill), and the first tag occluded both BEFORE the first full tag set (exercising the
     # backfilled pre-seed registrations) and inside the rolling phase (the borrowed ones). Driven
-    # through `track` directly (no CSVs) with a start_location, which must cross the seed frame's
-    # registration to land on the (reference-space) stack.
+    # through `track` directly, with a start_location that must cross the seed frame's registration
+    # to land on the reference-space stack.
     dir = mktempdir()
     occluded = vcat(1:3, 260:264)
     vid, groundpath, sl, nframes = make_apriltag_video(dir, "bigpan"; nframes = 300, amp = 55, occlude = occluded)
@@ -364,9 +362,8 @@ end
 
 @testset "diagnostic video: multi-run, mixed calibrations" begin
     # All three rectification kinds in one pipeline run: two only_scale rectifications on
-    # different-sized source videos (which used to produce a broken mixed-resolution diagnostic —
-    # the fixed canvas makes every segment identical, and the concat-demuxer keeps timestamps
-    # strictly monotonic) plus a matlab rectification read from a .mat file.
+    # different-sized source videos — the case the fixed canvas exists for, since a mixed-resolution
+    # diagnostic cannot be stream-copied — plus a matlab rectification read from a .mat file.
     dir = mktempdir()
     make_video(joinpath(dir, "cal_big.mp4"); size = (640, 480))
     make_video(joinpath(dir, "cal_small.mp4"); size = (320, 240))

--- a/test/pawsometracker.jl
+++ b/test/pawsometracker.jl
@@ -1,9 +1,7 @@
-# Direct PawsomeTracker coverage. The former package's test files were dev scratch (they
-# referenced a local dataset folder and a hard-coded mounted video), so this compact suite
-# replaces them, using the shared synthetic-trajectory generator (test/common.jl): ffmpeg's geq
-# renders a disc following a known sine, encoded losslessly so the analytic ground truth is
-# exact. (VerifyRuns' test_tracking.jl additionally exercises track through the gateway,
-# including anamorphic and scaled variants.)
+# Direct PawsomeTracker coverage, over the shared synthetic-trajectory generator (test/common.jl):
+# ffmpeg's geq renders a disc following a known sine, encoded losslessly so the analytic ground
+# truth is exact. VerifyRuns' test_tracking.jl additionally exercises track through the gateway,
+# including anamorphic and scaled variants.
 module PawsomeTrackerTests
 
 using Test
@@ -29,17 +27,16 @@ const DATADIR = mktempdir()
     end
 
     @testset "start_location's declared type is what is actually supported (#18)" begin
-        # CartesianIndex{2} sat in this union with no get_guess method behind it, so it type-checked
-        # at the call and then died with a MethodError once the video was open and the background
-        # stack built. Rejecting it at the keyword boundary names the expected type and costs nothing.
-        # If it is ever reinstated it needs a get_guess method — and this test to change with it.
+        # The union names only what has a get_guess method behind it, so an unsupported type is
+        # rejected at the keyword boundary rather than dying with a MethodError once the video is
+        # open. Reinstating CartesianIndex{2} needs a get_guess method, and this test to change.
         @test_throws TypeError track(base_file; start_location = CartesianIndex(50, 55))
     end
 
     @testset "the background stack stores frames at their decoded width (#27)" begin
         # The stack is the largest allocation in the program — a 1080p frame at background_length
         # 250 is ~494 MB as N0f8 against ~1978 MB as Float32 — and its values come from an N0f8
-        # decode, so the wider type buys no precision. Nothing else in the suite would catch a
+        # decode, so the wider type buys no precision. Nothing else in the suite catches a
         # regression here: tracking accuracy is identical either way, which is the whole point.
         vid = PT.Video(base_file, 25, 0, 2, 1.0)
         try
@@ -47,10 +44,10 @@ const DATADIR = mktempdir()
             @test eltype(stack) == PT.Gray{PT.N0f8}
             @test eltype(parent(parent(stack))) == PT.Gray{PT.N0f8}
 
-            # ...while the buffer receiving the BACKGROUND-SUBTRACTED frame stays Float32, because
-            # that difference is negative for a darker target and N0f8 wraps silently rather than
-            # erroring (0.2 - 0.5 == 0.702). The tracking assertions elsewhere in this file are what
-            # fail if the widening in `detect` is dropped — the DoG then chases inverted noise.
+            # ...while the buffer receiving the BACKGROUND-SUBTRACTED frame stays Float32: that
+            # difference is negative for a darker target, and N0f8 wraps silently rather than
+            # erroring (0.2 - 0.5 == 0.702). Drop the widening in `detect` and the DoG chases
+            # inverted noise — which the tracking assertions elsewhere in this file catch.
             tr = PT.Tracker(vid, true, 10, (21, 21), (vid.height, vid.width), true)
             @test eltype(tr.img) == PT.Gray{Float32}
         finally
@@ -128,9 +125,9 @@ const DATADIR = mktempdir()
     end
 
     @testset "a long-stationary target is not absorbed into the background" begin
-        # the disc pauses for 17 s — far longer than the 250-frame rolling background window — which
-        # used to absorb it into the per-pixel background model (the model's max saw only the disc
-        # at those pixels), erase it from the subtracted image, and set the tracker wandering
+        # the disc pauses for 17 s, far longer than the 250-frame rolling background window: without
+        # protect_target the model absorbs it, erases it from the subtracted image, and the tracker
+        # wanders off
         paused, paused_exp = make_target_video(DATADIR, "pt_pause"; duration = 30, pause = (8, 25))
         _, ij = track(joinpath(DATADIR, only(paused)); start_location = (55, 50), target_width = 10)
         @test length(ij) == 750

--- a/test/probing.jl
+++ b/test/probing.jl
@@ -21,7 +21,7 @@ const P = Fromage.Probing
     write(corrupt, read(whole)[1:500])
 
     # Opens cleanly, but has no video stream at all: ffprobe exits 0 and reports only the container
-    # duration. This is the case that used to arrive by luck through a random fixture.
+    # duration — the case the deterministic corrupt fixture deliberately does not cover.
     audio_only = joinpath(dir, "audio.m4a")
     FFMPEG.ffmpeg_exe(`-y -loglevel error -f lavfi -i sine=frequency=440:duration=1 -c:a aac $audio_only`)
 

--- a/test/quality.jl
+++ b/test/quality.jl
@@ -1,5 +1,4 @@
-# Code-quality checks for the consolidated package, replacing the per-package Aqua /
-# ExplicitImports tests the former packages carried.
+# Package-wide Aqua / ExplicitImports checks.
 module QualityTests
 
 using Test
@@ -10,7 +9,7 @@ using Fromage
 @testset "quality" begin
     @testset "Aqua" begin
         # ambiguities are skipped: the heavy image/OpenCV dependency stack reports ambiguities in
-        # methods this package doesn't own (the former packages skipped them too).
+        # methods this package doesn't own.
         Aqua.test_all(Fromage; ambiguities = false)
     end
 


### PR DESCRIPTION
First slice of #68: candidates 01 and 09 from the simplification ledger — the comment/docstring cleanup.

Comments in `src/` and `test/` now describe what the code **does**, not how it got there. The reasoning that used to sit inline — the alternatives that were tried, the bugs that ruled them out, the measurements behind the constants — moves to a new `DESIGN-HISTORY.md`, organised by subsystem (Pipeline, Concurrency, Rectifications, Tracking, AprilTag, The gateways, Error handling, CSV cell parsing, Testing) and cross-referenced by issue number, so `git log --grep '#nn'` gets you to the commit.

Where the rationale is load-bearing on the *current* code — the exception-narrowing `catch` blocks, for instance, where deleting the justification would leave them looking careless — the reasoning moved to the history file and a one-line pointer stayed behind.

Also removes five blocks of commented-out dead code: an old `cornerSubPix` call, a `@show`, a stale `extract` function, a dead struct field, and two abandoned `detect` lines.

### Numbers

| | before | after | comment ratio |
|---|---|---|---|
| `src/` | 3518 | 3369 | 27% → 23% |
| `test/` | 3576 | 3561 | 19% → 19% |

`DESIGN-HISTORY.md` is 516 lines, linked from the README's Development section.

The test pass barely moved, and that is deliberate. Read closely, the test comments are not archaeology — they are arithmetic (`# 0, 1, 2, 3, 4 — only 0 and 1 land on the board: 2 detections < 3`), and they are the only thing making the fixtures legible. The ~15 that genuinely retold history were trimmed; the rest stayed. Cutting the test comment budget further should come from the triplicated harness (ledger candidate 10) and the filename ceremony (15), not from deleting explanation.

### Verification

- No executable code changed — every line in the diff is a comment, a docstring, or commented-out dead code.
- `Meta.parseall` over every file in `src/`: all parse.
- `JULIA_NUM_THREADS=auto julia --project -e 'using Pkg; Pkg.test()'` → **1042 passed / 1042 total**, 8m04s.

This PR is also the first one through CI on this branch layout, so it doubles as a check that the online run is green before the structural candidates start landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7