### PR TITLE
The two gateways share their plumbing, not their rules (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -315,6 +315,32 @@ a pixel in the (moved) extrinsic frame, not in the run frame.
 
 ## The gateways
 
+### The two gateways share their plumbing, not their rules (#68)
+
+`VerifyRectifications` and `VerifyRuns` are the same pipeline over different columns: read and
+screen the CSV, back-fill the columns a row type does not use, resolve paths against the data
+folder, read each physical file once, null a field when a check trips, print what was wrong. That
+sequence had been written out twice, close enough that a fix to one copy was routinely not applied
+to the other.
+
+It now lives once, in `src/gateway.jl` (`read_rows`, `backfill!`, `verify!`, `resolve_paths!`,
+`read_per_file!`, `report_issues`), and the parsing of ffprobe's output moved alongside it into
+`src/probing.jl` (`frame_geometry`, `parse_framerate`, `parse_sar`, `parse_sample_aspect`,
+`is_interlaced`). `Gateway` knows nothing about either domain: every message it emits is either
+passed in by the caller or built from a column name, which is what keeps `"file does not exist"`
+and `"matlab_file does not exist"` — or `"(run_id: …)"` and `"(calibration_id: …)"` — one line of
+code instead of two.
+
+What deliberately stayed duplicated is what actually differs: each gateway's `COLUMNS`, its
+`DEFAULTS`, its row parsers, its `probe_video` (they ask ffprobe for different entries and derive
+different things from them), and its list of `verify!` calls — that list is the domain, and its
+ordering is load-bearing (see below).
+
+One behaviour was unified rather than preserved: `VerifyRectifications.parse_sample_aspect` used to
+return a negative `Float64` for a negative numerator, where `VerifyRuns.parse_sar` returned the
+square-pixel fallback. Both now take the fallback. No caller could use a negative aspect ratio, and
+every case either suite pins was already agreed on by both.
+
 ### Failures are reported, not thrown
 
 A calibration whose extrinsic frame yields no corners, a `.mat` missing a required field, an

--- a/src/Fromage.jl
+++ b/src/Fromage.jl
@@ -2,12 +2,14 @@ module Fromage
 
 # The four packages of the tracking ecosystem, consolidated as submodules (one repo, one version,
 # one test suite; see the README). Include order matters: Rectifications is used by
-# VerifyRectifications, PawsomeTracker by VerifyRuns, and Parsing (the shared CSV-cell machinery)
-# and Probing (the shared ffprobe plumbing) by both gateways.
+# VerifyRectifications, PawsomeTracker by VerifyRuns, and the three shared modules by both
+# gateways -- Parsing (CSV-cell machinery), Probing (ffprobe plumbing) and Gateway (the csv ->
+# verified DataFrame pipeline the two gateways run in common).
 include("Rectifications/Rectifications.jl")
 include("PawsomeTracker/PawsomeTracker.jl")
 include("parsing.jl")
 include("probing.jl")
+include("gateway.jl")
 include("VerifyRectifications/VerifyRectifications.jl")
 include("VerifyRuns/VerifyRuns.jl")
 

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -1,16 +1,16 @@
 module VerifyRectifications
 
-using CSV: CSV
 using ..Rectifications: get_corners, _vf, extrinsic_gray_frame
 import ..Rectifications: Rectification
 using ..PawsomeTracker: PawsomeTracker, ApriltagRectification
 using FileIO: FileIO
 using Chain: Chain, @chain
 using DataFramesMeta: DataFramesMeta, @groupby, @rtransform!, @transform!, AbstractDataFrame,
-    ByRow, Cols, DataFrame, Not, allowmissing!, completecases, dropmissing, groupby,
-    nonunique, nrow, passmissing, select, select!, subset
+    ByRow, DataFrame, Not, allowmissing!, completecases, dropmissing, groupby, nonunique, nrow,
+    passmissing, select, subset
+using ..Gateway: backfill!, read_per_file!, read_rows, report_issues, resolve_paths!, verify!
 using ..Parsing: Parsing, MyTemporal, parseto!
-using ..Probing: probe_fields
+using ..Probing: frame_geometry, is_interlaced, no_video_stream, parse_sample_aspect, probe_fields
 using MAT: MAT, matread
 using OhMyThreads: OhMyThreads, tmap
 using PrecompileTools: @setup_workload, @compile_workload
@@ -36,23 +36,7 @@ end
 # (see DEFAULTS in parsers.jl); the hierarchy is csv cell → `defaults` → hardcoded/probed value.
 function load_rectifications(data_path, file; strict = true, defaults = (;), issues_dir = joinpath("results_dir", "issues"))
     defaults = resolve_defaults(defaults)   # fail fast on unknown keys / unconvertible values
-    # verify csv file exists
-    if !isfile(file)
-        error("calibration `.csv` file missing")
-    end
-    csvrows = CSV.Rows(file)
-
-    # verify csv file has rows in it
-    if isempty(Tables.rows(csvrows))
-        error("csv file is empty")
-    end
-
-    # verify csv all the columns are expected
-    sch = Tables.schema(csvrows)
-    unrecognized = setdiff(sch.names, COLUMNS)
-    if !isempty(unrecognized)
-        error("unrecognized column/s in calibration file: $unrecognized")
-    end
+    csvrows = read_rows(file, COLUMNS, "calibration")
 
     # parse rows to RectificationMethods or error messages
     cs = @showprogress desc = "Parsing calibs.csv" tmap(r -> parse_row(r, defaults), collect(csvrows))
@@ -62,16 +46,10 @@ function load_rectifications(data_path, file; strict = true, defaults = (;), iss
 
     verifications!(df, data_path, issues_dir)
 
-    if any(!isempty, df.issues)
-        # a blank calibration_id cell is itself flagged as an issue, so it can be missing here
-        msg = join([string(ismissing(cid) ? "row $i" : "row $i (calibration_id: $cid)", ": ", join(issues, ", "))
-                    for (i, (cid, issues)) in enumerate(zip(df.calibration_id, df.issues)) if !isempty(issues)], '\n')
-        println('\n' * "The following are issues with the calibs.csv file:\n" * msg)
-        if strict
-            error("there were issues with the calibration (see above)")
-        else
-            return df
-        end
+    # a blank calibration_id cell is itself flagged as an issue, so it can be missing here
+    if report_issues(df, :calibration_id, "calibs.csv", "calibration", strict;
+                     mention = (i, cid) -> !ismissing(cid))
+        return df
     end
 
     # The comprehension pins the element type to the abstract `Vector{RectificationMethod}` (as in

--- a/src/VerifyRectifications/parsers.jl
+++ b/src/VerifyRectifications/parsers.jl
@@ -147,11 +147,7 @@ function parse_row(row, defaults = DEFAULTS)
         push!(dict[:issues], "wrong type")
     end
     verify_irrelevant(dict, row)
-    for col in COLUMNS
-        if !haskey(dict, col)
-            dict[col] = missing
-        end
-    end
+    backfill!(dict, COLUMNS)
     verify_center2north(dict)
     return dict
 end

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -13,17 +13,9 @@ function read_video_metadata!(df::AbstractDataFrame)
     # :width/:height have no CSV column (they are not user-supplied); create them here so the probe
     # can fill them, alongside the intermediate :duration/:dimension columns.
     @transform! df :duration = missing :dimension = missing :width = missing :height = missing
-    gs = @chain df begin
-        dropmissing([:file, :type], view = true)
-        groupby([:file, :type])
-    end
     # Every type carries a source video (:file), so every group is probed once: the read fills
     # :duration/:dimension/:width/:height for all, plus imputes :aspect (and :yadif for video).
-    groups = collect(gs)
-    metas = @showprogress desc = "Reading calibration videos..." tmap(g -> probe_video(g.file[1]), groups)
-    for (g, meta) in zip(groups, metas)
-        apply_video_metadata!(g, meta)
-    end
+    read_per_file!(df, :file, [:file, :type], "Reading calibration videos...", probe_video, apply_video_metadata!)
 end
 
 apply_video_metadata!(g, issue::String) = @transform! g :duration = missing :dimension = missing :issues = push!.(:issues, issue)
@@ -128,15 +120,9 @@ end
 # by read_video_metadata!, so the cross-check runs here against it.
 function read_matlab_metadata!(df::AbstractDataFrame)
     @transform! df :n_extrinsics = missing
-    gs = @chain df begin
-        dropmissing([:matlab_file], view = true)   # matlab_file is set for matlab rows only
-        groupby(:matlab_file)
-    end
-    mats = collect(gs)
-    metas = @showprogress desc = "Reading matlab calibration files..." tmap(g -> matlab_metadata(g.matlab_file[1]), mats)
-    for (g, meta) in zip(mats, metas)
-        apply_matlab_metadata!(g, meta)
-    end
+    # matlab_file is set for matlab rows only, so non-matlab rows form no group and are untouched.
+    read_per_file!(df, :matlab_file, [:matlab_file], "Reading matlab calibration files...",
+                   matlab_metadata, apply_matlab_metadata!)
 end
 
 # Pure read+derive: one matread, then structure/extrinsic-count/dimension off the same dict. A bad
@@ -185,47 +171,20 @@ function matlab_extrinsic_count(dict)
     return first(counts)
 end
 
-const INTERLACED_FIELD_ORDERS = ("tt", "bb", "tb", "bt")
-
-# Reduce ffprobe's "num:den" sample aspect ratio to a Float64, mirroring VideoIO.aspect_ratio's
-# fallback: an undefined / zero / nonsensical ratio defaults to 1.0.
-function parse_sample_aspect(s)
-    occursin(':', s) || return 1.0
-    num, den = tryparse.(Int, split(s, ':'))
-    (num === nothing || den === nothing || den == 0 || num == 0) ? 1.0 : num / den
-end
-
 # Probe one video file with a single ffprobe call: frame width/height, container duration, sample
 # (pixel) aspect ratio and field order (interlacing). Returns a NamedTuple, or an "issue reading..."
-# string for a corrupt/unreadable file. The spawn and its `key=value` output are handled by
-# ..Probing (shared with VerifyRuns); what stays here is which entries this gateway asks for and
-# what it derives from them.
+# string for a corrupt/unreadable file. The spawn, its `key=value` output and the parsing of each
+# field are handled by ..Probing (shared with VerifyRuns); what stays here is which entries this
+# gateway asks for and what it derives from them.
 function probe_video(file)
     fields = probe_fields(file, "stream=width,height,sample_aspect_ratio,field_order:format=duration")
     fields isa String && return fields                 # unreadable file: pass the issue straight on
-    # The three fields nothing downstream can proceed without; `tryparse` reports an absent or
-    # unparseable one as `nothing`. A miss here means ffprobe *succeeded* and still could not
-    # describe a video (an audio-only file, or junk it recognised a container in), which is not a
-    # usable video either — hence the same "issue reading from video file" wording.
-    width    = tryparse(Int, get(fields, "width", ""))
-    height   = tryparse(Int, get(fields, "height", ""))
-    duration = tryparse(Float64, get(fields, "duration", ""))
-    if isnothing(width) || isnothing(height) || isnothing(duration)
-        return "issue reading from video file: ffprobe reported no usable video stream (missing or unparseable width/height/duration)"
-    end
+    geometry = frame_geometry(fields)
+    isnothing(geometry) && return no_video_stream("width/height/duration")
     # aspect and field order have documented fallbacks, so a missing one is not an error.
-    return (; width, height, duration,
+    return (; geometry...,
               aspect = parse_sample_aspect(get(fields, "sample_aspect_ratio", "1:1")),
-              yadif  = get(fields, "field_order", "progressive") in INTERLACED_FIELD_ORDERS)
-end
-
-function verify!(df::AbstractDataFrame, predicate, msg, args...)
-    field = first(args)
-    cols = Cols(args...)
-    @chain df begin
-        subset(cols => ByRow(passmissing(predicate)), view = true, skipmissing = true)
-        @transform! $field = missing :issues = push!.(:issues, msg)
-    end
+              yadif  = is_interlaced(fields))
 end
 
 # Errors raised inside a `tmap` come back wrapped in a TaskFailedException — but only when the
@@ -420,30 +379,10 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
     rm(issues_dir; recursive = true, force = true)
 
     verify_unique_ids!(df)
-    @transform! df :path = passmissing(joinpath).(data_path, :path)
 
-    # A path naming the video itself is the common slip, and it must be reported as such rather
-    # than as "does not exist" (#33). Runs first, and verify! nulls :path on failure, so the
-    # existence check below skips the row rather than piling on.
-    verify!(df, isfile, "path is a file, not a folder — it should be the folder holding the video, with the file name in the `file` column", :path)
-    verify!(df, !isdir, "path does not exist", :path)
-
-    verify!(df, (f, p) -> !isfile(joinpath(p, f)), "file does not exist", :file, :path)
-
-    # matlab_file (the .mat, matlab rows only) is resolved against path just like :file. verify!
-    # skips missing, so non-matlab rows (matlab_file === missing) are untouched.
-    verify!(df, (f, p) -> !isfile(joinpath(p, f)), "matlab_file does not exist", :matlab_file, :path)
-
-    # Collapse data_path/path/file into one canonical absolute path stored in :file (and the same
-    # for :matlab_file), then drop :path, whose job the isdir/isfile checks above have finished. The
-    # resolved :file is the identity used by every later step (the read passes, duplicate detection)
-    # and :matlab_file groups the .mat reads. realpath is safe because non-existent paths were nulled
-    # just above, and is what collapses "./x", "a/../x" and symlinks onto one key.
-    @transform! df :file = passmissing(joinpath).(:path, :file)
-    @transform! df :file = passmissing(realpath).(:file)
-    @transform! df :matlab_file = passmissing(joinpath).(:path, :matlab_file)
-    @transform! df :matlab_file = passmissing(realpath).(:matlab_file)
-    select!(df, Not(:path))
+    # The resolved :file is the identity every later step uses (the read passes, duplicate
+    # detection); :matlab_file (the .mat, matlab rows only) groups the .mat reads.
+    resolve_paths!(df, data_path, :file, :matlab_file)
 
     # One read per physical file: ffprobe on the source video (every type) and matread on the .mat
     # (matlab). read_video_metadata! must run first: it sets the frame size that bounds-checks

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -1,12 +1,11 @@
 module VerifyRuns
 
-using CSV: CSV
-using Chain: Chain, @chain
-using DataFramesMeta: DataFramesMeta, @transform!, AbstractDataFrame, ByRow, Cols,
-    DataFrame, Not, allowmissing!, dropmissing, groupby, nrow, passmissing, select!, subset
+using DataFramesMeta: DataFramesMeta, @transform!, AbstractDataFrame, DataFrame,
+    allowmissing!, groupby, nrow
+using ..Gateway: backfill!, read_per_file!, read_rows, report_issues, resolve_paths!, verify!
 using ..Parsing: Parsing, MyTemporal, parseto!
 import ..Parsing: mytryparse                # extended on MyWindow (a type this module owns)
-using ..Probing: probe_fields
+using ..Probing: frame_geometry, no_video_stream, parse_framerate, parse_sar, probe_fields
 using OhMyThreads: OhMyThreads, tmap
 using ..PawsomeTracker: PawsomeTracker, ApriltagRectification, get_sigma
 import ..PawsomeTracker: track
@@ -33,23 +32,7 @@ end
 # (see DEFAULTS in parsers.jl); the hierarchy is csv cell → `defaults` → hardcoded/probed value.
 function load_runs(data_path, file; strict = true, defaults = (;))
     defaults = resolve_defaults(defaults)   # fail fast on unknown keys / unconvertible values
-    # verify csv file exists
-    if !isfile(file)
-        error("runs `.csv` file missing")
-    end
-    csvrows = CSV.Rows(file)
-
-    # verify csv file has rows in it
-    if isempty(Tables.rows(csvrows))
-        error("csv file is empty")
-    end
-
-    # verify all the columns are expected
-    sch = Tables.schema(csvrows)
-    unrecognized = setdiff(sch.names, COLUMNS)
-    if !isempty(unrecognized)
-        error("unrecognized column/s in runs file: $unrecognized")
-    end
+    csvrows = read_rows(file, COLUMNS, "runs")
 
     # parse each row to a Dict of parsed values + an :issues accumulator
     cs = @showprogress desc = "Parsing runs.csv..." tmap(r -> parse_row(r, defaults), collect(csvrows))
@@ -63,17 +46,11 @@ function load_runs(data_path, file; strict = true, defaults = (;))
 
     verifications!(df, data_path)
 
-    if any(!isempty, df.issues)
-        # a run_id that is missing (mixed numbering) or equal to the row number (auto-assigned)
-        # adds nothing over "row $i", so it is only mentioned when the csv named the run itself
-        msg = join([string(ismissing(rid) || rid == string(i) ? "row $i" : "row $i (run_id: $rid)", ": ", join(issues, ", "))
-                    for (i, (rid, issues)) in enumerate(zip(df.run_id, df.issues)) if !isempty(issues)], '\n')
-        println('\n' * "The following are issues with the runs.csv file:\n" * msg)
-        if strict
-            error("there were issues with the runs (see above)")
-        else
-            return df
-        end
+    # a run_id that is missing (mixed numbering) or equal to the row number (auto-assigned) adds
+    # nothing over "row $i", so it is only mentioned when the csv named the run itself
+    if report_issues(df, :run_id, "runs.csv", "runs", strict;
+                     mention = (i, rid) -> !ismissing(rid) && rid != string(i))
+        return df
     end
 
     # Clean: group the rows by :run_id, each group materialized into its concrete run type

--- a/src/VerifyRuns/parsers.jl
+++ b/src/VerifyRuns/parsers.jl
@@ -63,10 +63,7 @@ end
 function parse_row(row, defaults = DEFAULTS)
     dict = Dict{Symbol, Any}(:issues => String[])
     parse_run!(dict, row, defaults)
-    for col in COLUMNS
-        haskey(dict, col) || (dict[col] = missing)
-    end
-    return dict
+    return backfill!(dict, COLUMNS)
 end
 
 # run_id is all-or-nothing: either every row names its run (enabling multi-segment runs), or no row

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -1,66 +1,26 @@
-# Reduce ffprobe's "num/den" r_frame_rate to a Float64, or `nothing` when the field is absent or
-# unparseable (tryparse semantics, so the caller reports it as malformed output rather than a
-# `parse` throwing out of the probe). A zero denominator (undefined rate) falls back to the
-# numerator, keeping the value finite for the fps checks below.
-function parse_framerate(s)
-    occursin('/', s) || return tryparse(Float64, s)
-    parts = split(s, '/')
-    length(parts) == 2 || return nothing
-    num = tryparse(Float64, parts[1])
-    den = tryparse(Float64, parts[2])
-    (isnothing(num) || isnothing(den)) && return nothing
-    return iszero(den) ? num : num / den
-end
-
-# ffprobe reports the sample (pixel) aspect ratio as "num:den"; "N/A" or "0:1" mean undefined and
-# fall back to square pixels. The display-space width of a frame is width × sar.
-function parse_sar(s)
-    parts = split(s, ':')
-    length(parts) == 2 || return 1//1
-    num = tryparse(Int, parts[1])
-    den = tryparse(Int, parts[2])
-    (isnothing(num) || isnothing(den) || num ≤ 0 || den ≤ 0) && return 1//1
-    return num // den
-end
-
 # Probe one video file with a single ffprobe call: frame width/height (stored pixels), sample aspect
 # ratio, container duration and the (real) frame rate. Returns a NamedTuple, or an "issue reading..."
-# string for a corrupt/unreadable file. The spawn and its `key=value` output are handled by
-# ..Probing (shared with VerifyRectifications); what stays here is which entries this gateway asks
-# for and what it derives from them.
+# string for a corrupt/unreadable file. The spawn, its `key=value` output and the per-field parsers
+# are shared with VerifyRectifications in ..Probing; what stays here is which entries this gateway
+# asks for and which of them it cannot proceed without. `fps` is one of those — it imputes the run's
+# tracking rate when the csv leaves it blank. `sar` has a documented square-pixel fallback, so a
+# missing one is not an error.
 function probe_video(file)
     fields = probe_fields(file, "stream=width,height,r_frame_rate,sample_aspect_ratio:format=duration")
     fields isa String && return fields                 # unreadable file: pass the issue straight on
-    # The four fields nothing downstream can proceed without (`fps` imputes the run's tracking rate
-    # when the csv leaves it blank); `tryparse` reports an absent or unparseable one as `nothing`. A
-    # miss here means ffprobe *succeeded* and still could not describe a video (an audio-only file,
-    # or junk it recognised a container in), which is not a usable video either — hence the same
-    # "issue reading from video file" wording.
-    width    = tryparse(Int, get(fields, "width", ""))
-    height   = tryparse(Int, get(fields, "height", ""))
-    duration = tryparse(Float64, get(fields, "duration", ""))
-    fps      = parse_framerate(get(fields, "r_frame_rate", ""))
-    if isnothing(width) || isnothing(height) || isnothing(duration) || isnothing(fps)
-        return "issue reading from video file: ffprobe reported no usable video stream (missing or unparseable width/height/duration/frame rate)"
+    geometry = frame_geometry(fields)
+    fps = parse_framerate(get(fields, "r_frame_rate", ""))
+    if isnothing(geometry) || isnothing(fps)
+        return no_video_stream("width/height/duration/frame rate")
     end
-    # sar has a documented square-pixel fallback, so a missing one is not an error.
-    return (; width, height, duration, fps, sar = parse_sar(get(fields, "sample_aspect_ratio", "1:1")))
+    return (; geometry..., fps, sar = parse_sar(get(fields, "sample_aspect_ratio", "1:1")))
 end
 
 # One ffprobe per physical video file fills the intermediate :dimension/:duration/:video_fps columns
 # and imputes the two blank-able run parameters: :stop (← duration) and :fps (← video frame rate).
-# Grouping on the canonical resolved :file reads one physical file once, not once per spelling.
 function read_video_metadata!(df::AbstractDataFrame)
     @transform! df :dimension = missing :duration = missing :video_fps = missing :sar = missing
-    gs = @chain df begin
-        dropmissing([:file], view = true)
-        groupby(:file)
-    end
-    groups = collect(gs)
-    metas = @showprogress desc = "Reading runs videos..." tmap(g -> probe_video(g.file[1]), groups)
-    for (g, meta) in zip(groups, metas)
-        apply_video_metadata!(g, meta)
-    end
+    read_per_file!(df, :file, [:file], "Reading runs videos...", probe_video, apply_video_metadata!)
 end
 
 apply_video_metadata!(g, issue::String) = @transform! g :issues = push!.(:issues, issue)
@@ -75,17 +35,6 @@ end
 
 # window_size is either an Int side length or an (w, h) tuple; "non-positive" covers both shapes.
 window_nonpositive(x) = x isa Tuple ? any(≤(0), x) : x ≤ 0
-
-# Subset the rows whose `args` trip `predicate`, null the offending field (first of `args`) so later
-# checks skip them, and record `msg`. `passmissing`/`skipmissing` leave already-missing fields alone.
-function verify!(df::AbstractDataFrame, predicate, msg, args...)
-    field = first(args)
-    cols = Cols(args...)
-    @chain df begin
-        subset(cols => ByRow(passmissing(predicate)), view = true, skipmissing = true)
-        @transform! $field = missing :issues = push!.(:issues, msg)
-    end
-end
 
 # Run-level fields, as opposed to the per-segment file/start/stop/start_location: the whole run
 # shares one value (they end up in the run's `Source`), so segments of one run must agree on them —
@@ -108,19 +57,9 @@ function verify_run_consistency!(df::AbstractDataFrame)
 end
 
 function verifications!(df::AbstractDataFrame, data_path)
-    # Resolve path against data_path, check existence, then collapse path/file into one canonical
-    # absolute :file (the identity used for per-file reads and segment grouping) and drop path.
-    # realpath is safe because non-existent paths were nulled to missing just above.
-    @transform! df :path = passmissing(joinpath).(data_path, :path)
-    # A path naming the video itself is the common slip, and must be reported as such rather than as
-    # "does not exist" (#33). Runs first, and verify! nulls :path on failure, so the existence check
-    # below skips the row rather than piling on.
-    verify!(df, isfile, "path is a file, not a folder — it should be the folder holding the video, with the file name in the `file` column", :path)
-    verify!(df, !isdir, "path does not exist", :path)
-    verify!(df, (f, p) -> !isfile(joinpath(p, f)), "file does not exist", :file, :path)
-    @transform! df :file = passmissing(joinpath).(:path, :file)
-    @transform! df :file = passmissing(realpath).(:file)
-    select!(df, Not(:path))
+    # :file becomes the canonical absolute path — the identity used for per-file reads and segment
+    # grouping.
+    resolve_paths!(df, data_path, :file)
 
     # One ffprobe per file: fills :dimension/:duration/:video_fps and imputes :stop/:fps.
     read_video_metadata!(df)

--- a/src/gateway.jl
+++ b/src/gateway.jl
@@ -1,0 +1,105 @@
+# The plumbing both gateway submodules (VerifyRectifications and VerifyRuns) run their CSV through,
+# in the order they run it: read and screen the file, resolve every path against the data folder,
+# read each physical file once, flag rows that fail a check, and print what was wrong.
+#
+# What stays in each gateway is what actually differs — its column list, its defaults, its row
+# parsers, and its checks. This module knows nothing about either domain; every message it emits is
+# either passed in or built from a column name.
+module Gateway
+
+using CSV: CSV
+using Chain: Chain, @chain
+using DataFramesMeta: DataFramesMeta, @transform!, AbstractDataFrame, ByRow, Cols, Not,
+    dropmissing, groupby, passmissing, select!, subset
+using OhMyThreads: OhMyThreads, tmap
+using ProgressMeter: ProgressMeter, @showprogress
+using Tables: Tables
+
+# Read the CSV and screen it before a single cell is parsed: the file must exist, hold at least one
+# row, and name only columns the gateway recognizes. `what` names the file in the two messages that
+# mention it ("runs"/"calibration"), which are the gateway's own words for its input.
+function read_rows(file, columns, what)
+    isfile(file) || error("$what `.csv` file missing")
+    rows = CSV.Rows(file)
+    isempty(Tables.rows(rows)) && error("csv file is empty")
+    unrecognized = setdiff(Tables.schema(rows).names, columns)
+    isempty(unrecognized) || error("unrecognized column/s in $what file: $unrecognized")
+    return rows
+end
+
+# A row parser fills only the columns its type consumes; every other recognized column must still
+# exist (as missing) so the rows form one rectangular DataFrame.
+function backfill!(dict, columns)
+    for col in columns
+        haskey(dict, col) || (dict[col] = missing)
+    end
+    return dict
+end
+
+# Subset the rows whose `args` trip `predicate`, null the offending field (first of `args`) so later
+# checks skip them, and record `msg`. `passmissing`/`skipmissing` leave already-missing fields alone.
+function verify!(df::AbstractDataFrame, predicate, msg, args...)
+    field = first(args)
+    cols = Cols(args...)
+    @chain df begin
+        subset(cols => ByRow(passmissing(predicate)), view = true, skipmissing = true)
+        @transform! $field = missing :issues = push!.(:issues, msg)
+    end
+end
+
+# Resolve `:path` against the data folder, check it is a folder holding each of `filecols`, then
+# collapse each of those into one canonical absolute path and drop `:path`, whose job is then done.
+#
+# A path naming the video itself is the common slip, and must be reported as such rather than as
+# "does not exist" (#33). It runs first, and `verify!` nulls `:path` on failure, so the existence
+# check below skips the row rather than piling on. `realpath` is safe for the same reason —
+# non-existent paths were nulled just above — and is what collapses "./x", "a/../x" and symlinks
+# onto the one key that later steps group physical files by.
+function resolve_paths!(df::AbstractDataFrame, data_path, filecols...)
+    @transform! df :path = passmissing(joinpath).(data_path, :path)
+    verify!(df, isfile, "path is a file, not a folder — it should be the folder holding the video, with the file name in the `file` column", :path)
+    verify!(df, !isdir, "path does not exist", :path)
+    for col in filecols
+        # `verify!` skips missing, so a column only some row types carry (VerifyRectifications'
+        # :matlab_file) leaves the rest untouched.
+        verify!(df, (f, p) -> !isfile(joinpath(p, f)), "$col does not exist", col, :path)
+        @transform! df $col = passmissing(joinpath).(:path, $col)
+        @transform! df $col = passmissing(realpath).($col)
+    end
+    select!(df, Not(:path))
+    return df
+end
+
+# One read per physical file, in parallel: group the rows that name one, read each group's file
+# once, then fold the result back into its rows with `apply!`. Grouping on the canonical resolved
+# path (see `resolve_paths!`) reads a file reached through several spellings once, not once per
+# spelling. `read` returns either the metadata or an issue string, and `apply!` dispatches on which.
+function read_per_file!(df::AbstractDataFrame, filecol, groupcols, desc, read, apply!)
+    groups = @chain df begin
+        dropmissing(groupcols, view = true)
+        groupby(groupcols)
+        collect
+    end
+    metas = @showprogress desc = desc tmap(g -> read(g[1, filecol]), groups)
+    for (g, meta) in zip(groups, metas)
+        apply!(g, meta)
+    end
+    return df
+end
+
+# Print every row's issues, one line per row, and throw under `strict`. Returns whether anything was
+# wrong, so a caller can hand the raw DataFrame back instead of building its objects.
+#
+# `mention(i, id)` decides whether row `i`'s identity adds anything over "row $i" — an id that is
+# missing, or that was auto-generated from the row number, does not.
+function report_issues(df::AbstractDataFrame, idcol, csv_name, what, strict; mention)
+    any(!isempty, df.issues) || return false
+    ids = df[!, idcol]
+    msg = join([string(mention(i, id) ? "row $i ($idcol: $id)" : "row $i", ": ", join(issues, ", "))
+                for (i, (id, issues)) in enumerate(zip(ids, df.issues)) if !isempty(issues)], '\n')
+    println('\n' * "The following are issues with the $csv_name file:\n" * msg)
+    strict && error("there were issues with the $what (see above)")
+    return true
+end
+
+end # module Gateway

--- a/src/probing.jl
+++ b/src/probing.jl
@@ -1,6 +1,7 @@
 # The ffprobe plumbing shared by the two gateways (VerifyRectifications and VerifyRuns): spawn one
-# ffprobe, read its `key=value` output, report an unreadable file as an issue string. Which entries
-# to ask for, and what to derive from them, stays in the gateways.
+# ffprobe, read its `key=value` output, parse the individual fields it reports, and report an
+# unreadable file as an issue string. Which entries to ask for, and which of them a given gateway
+# cannot proceed without, stays in the gateways.
 #
 # Its own module rather than part of `Parsing`, which is CSV-cell machinery depending on nothing
 # but Dates — spawning ffprobe has no business widening that.
@@ -40,5 +41,55 @@ end
 # Other failures are rare and worth printing in full.
 probe_failure(::ProcessFailedException) = "ffprobe could not read it (the file is corrupt, truncated, or not a video)"
 probe_failure(e) = sprint(showerror, e)
+
+# The frame size and duration, which no gateway can proceed without, or `nothing` if ffprobe
+# described none of them. A miss means ffprobe *succeeded* and still could not describe a video (an
+# audio-only file, or junk it recognised a container in) — not a usable video either, hence
+# `no_video_stream` shares the "issue reading from video file" prefix of an outright failed read.
+# Each gateway names its own required fields in the message, since it asks for its own entries.
+function frame_geometry(fields)
+    width    = tryparse(Int, get(fields, "width", ""))
+    height   = tryparse(Int, get(fields, "height", ""))
+    duration = tryparse(Float64, get(fields, "duration", ""))
+    (isnothing(width) || isnothing(height) || isnothing(duration)) && return nothing
+    return (; width, height, duration)
+end
+
+no_video_stream(required) = "issue reading from video file: ffprobe reported no usable video stream (missing or unparseable $required)"
+
+# Reduce ffprobe's "num/den" r_frame_rate to a Float64, or `nothing` when the field is absent or
+# unparseable (tryparse semantics, so the caller reports it as malformed output rather than a
+# `parse` throwing out of the probe). A zero denominator (undefined rate) falls back to the
+# numerator, keeping the value finite for the fps checks downstream.
+function parse_framerate(s)
+    occursin('/', s) || return tryparse(Float64, s)
+    parts = split(s, '/')
+    length(parts) == 2 || return nothing
+    num = tryparse(Float64, parts[1])
+    den = tryparse(Float64, parts[2])
+    (isnothing(num) || isnothing(den)) && return nothing
+    return iszero(den) ? num : num / den
+end
+
+# ffprobe reports the sample (pixel) aspect ratio as "num:den"; "N/A", "0:1" and anything else
+# nonsensical mean undefined and fall back to square pixels. The display-space width of a frame is
+# width × sar. VerifyRuns wants the exact ratio (it bounds-checks a pixel coordinate against
+# width × sar); VerifyRectifications wants the Float64 that mirrors VideoIO.aspect_ratio.
+function parse_sar(s)
+    parts = split(s, ':')
+    length(parts) == 2 || return 1//1
+    num = tryparse(Int, parts[1])
+    den = tryparse(Int, parts[2])
+    (isnothing(num) || isnothing(den) || num ≤ 0 || den ≤ 0) && return 1//1
+    return num // den
+end
+
+parse_sample_aspect(s) = Float64(parse_sar(s))
+
+# ffprobe's field_order for interlaced footage; anything else (including an absent field) is
+# progressive, and only interlaced footage needs deinterlacing.
+const INTERLACED_FIELD_ORDERS = ("tt", "bb", "tb", "bt")
+
+is_interlaced(fields) = get(fields, "field_order", "progressive") in INTERLACED_FIELD_ORDERS
 
 end # module Probing


### PR DESCRIPTION
Candidate 02 of the #68 simplification audit.

`VerifyRectifications` and `VerifyRuns` are the same pipeline over different columns — read and screen the CSV, back-fill the columns a row type does not use, resolve paths against the data folder, read each physical file once, null a field when a check trips, print what was wrong — and that sequence had been written out twice, close enough that a fix to one copy was routinely not applied to the other.

**New `src/gateway.jl`** holds it once: `read_rows`, `backfill!`, `verify!`, `resolve_paths!`, `read_per_file!`, `report_issues`. The module knows nothing about either domain; every message it emits is either passed in by the caller or built from a column name, which is what makes `"file does not exist"` / `"matlab_file does not exist"` and `"(run_id: …)"` / `"(calibration_id: …)"` one line of code instead of two.

**`src/probing.jl`** gains the parsing of ffprobe's output, next to the plumbing that produces it: `frame_geometry`, `no_video_stream`, `parse_framerate`, `parse_sar`, `parse_sample_aspect`, `is_interlaced`.

What deliberately stays per-gateway is what actually differs: each `COLUMNS`, each `DEFAULTS`, the row parsers, each `probe_video` (they ask ffprobe for different entries and derive different things), and the ordered list of `verify!` calls — that list *is* the domain, and its ordering is load-bearing.

### Behaviour

Every user-facing message is preserved byte for byte. One behaviour is unified rather than preserved: `VerifyRectifications.parse_sample_aspect` returned a negative `Float64` for a negative numerator, where `VerifyRuns.parse_sar` returned the square-pixel fallback; both now take the fallback. No caller could use a negative aspect ratio, and every case either suite pins was already agreed on by both. Recorded in `DESIGN-HISTORY.md` along with what is now shared and why.

### Numbers

Full suite: **1042 passed, 0 failed** (8m05s), Aqua and ExplicitImports included.

`src/` goes 3369 → 3353 lines (2220 → 2188 excluding blanks and comments). The ledger estimated −130; the honest figure is −16. The duplication is genuinely gone — the diff deletes 228 lines and adds 212 — but a shared module has to document itself, and the six extracted functions now carry one set of comments where previously each copy carried its own terse ones. The win here is that there is one place to fix, not a smaller file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7