### PR TITLE
The small stuff: dead lines, a duplicate alias, arithmetic dressed as logic (#68)

### DIFF
--- a/src/Fromage.jl
+++ b/src/Fromage.jl
@@ -2,9 +2,9 @@ module Fromage
 
 # The four packages of the tracking ecosystem, consolidated as submodules (one repo, one version,
 # one test suite; see the README). Include order matters: Rectifications is used by
-# VerifyRectifications, PawsomeTracker by VerifyRuns, and the three shared modules by both
-# gateways -- Parsing (CSV-cell machinery), Probing (ffprobe plumbing) and Gateway (the csv ->
-# verified DataFrame pipeline the two gateways run in common).
+# VerifyRectifications and (for the `RowCol` alias) by PawsomeTracker, PawsomeTracker by VerifyRuns,
+# and the three shared modules by both gateways -- Parsing (CSV-cell machinery), Probing (ffprobe
+# plumbing) and Gateway (the csv -> verified DataFrame pipeline the two gateways run in common).
 include("Rectifications/Rectifications.jl")
 include("PawsomeTracker/PawsomeTracker.jl")
 include("parsing.jl")

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -17,8 +17,7 @@ using StaticArrays: SVector, SDiagonal
 using OpenCV: OpenCV
 using CoordinateTransformations: LinearMap, Transformation
 using LinearAlgebra: I
-
-const RowCol = SVector{2, Float32}
+using ..Rectifications: RowCol   # the one image-coordinate alias, defined where it is documented
 
 # Confidence gate for `detect`: when the window's peak DoG response falls below GATE_FRACTION of
 # the running response level, the frame is treated as "target not seen" (occlusion, glare,
@@ -71,23 +70,11 @@ effective_fps(vid_fps, requested) = vid_fps / frame_skip(vid_fps, requested)
 
 get_sigma(target_width) = target_width / 2sqrt(2log(2))
 
-function fix_window_size(wh::NTuple{2, Int}) 
-    w, h = wh
-    if !isodd(w)
-        w += 1
-    end
-    if !isodd(h)
-        h += 1
-    end
-    return (h, w)
-end
-
-function fix_window_size(l::Int) 
-    if !isodd(l)
-        l += 1
-    end
-    return (l, l)
-end
+# A window side must be odd (the detection kernels are centred on a pixel), so an even one is
+# rounded up. Note the transpose: the caller gives (width, height), the tracker wants (rows, cols).
+oddify(l::Int) = l + iseven(l)
+fix_window_size((w, h)::NTuple{2, Int}) = (oddify(h), oddify(w))
+fix_window_size(l::Int) = (oddify(l), oddify(l))
 
 function get_guess(start_index::RowCol, _, vid, _, _, _, _)
     guess = round.(Int, Tuple(vid.scale * start_index))
@@ -133,9 +120,10 @@ struct Video
         fps = vid_fps / skip                 # the rate actually delivered; `fps` means this from here on
         img = read(vid)
         t₀ = gettime(vid)
-        height, width = size(img)
-        tform = LinearMap(1/scale)
-        height, width = size(WarpedView(Array{Gray{Float32}}(undef, size(img)...), tform; fillvalue = zero(Gray{Float32})))
+        # The tracked frame is the scaled one, so :width/:height are the WARPED extent, not the
+        # video's. `WarpedView`'s axes depend only on `axes(img)` and the transform, so wrapping the
+        # frame we already hold measures it without decoding or allocating a second one.
+        height, width = size(WarpedView(img, LinearMap(1/scale); fillvalue = zero(eltype(img))))
         seek(vid, start + t₀)
         # Frames the window holds at the video's own rate, then how many of them the stride visits.
         # Sample i reads raw frame (i-1)*skip, and `cld` is exactly the count keeping that index

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -60,40 +60,28 @@ function homography_dlt(src, dst)
     H / H[3, 3]
 end
 
-# Rigid Procrustes: place the canonical square `canon` (no scaling — its size is known exactly) onto
-# four measured cm points, giving the best-fit true square at that pose. This is how each tag's
-# known metric geometry is imposed during the consensus fit.
-function place_square(D, canon = CANON)
-    mc = sum(canon) / 4
-    md = sum(D) / 4
-    H = sum((D[i] - md) * (canon[i] - mc)' for i in 1:4)      # 2×2 cross-covariance
-    F = svd(H)
-    R = F.U * F.Vt
-    if det(R) < 0                                             # reflection guard
-        R = F.U * SMatrix{2, 2, Float64}(1, 0, 0, -1) * F.Vt
-    end
-    [R * (c - mc) + md for c in canon]
-end
-
 # worst deviation (real units) of any tag edge from the true side length `side`, under an
 # image→cm homography `M`
 _worst_side(M, tag_corners, side = TAG_SIZE_CM) =
     maximum(abs(norm(apply_h(M, tc[i]) - apply_h(M, tc[mod1(i+1, 4)])) - side)
             for tc in tag_corners for i in 1:4)
 
-# best-fit rigid transform (rotation + translation, no scale) mapping point set `A` onto `B`,
-# returned as a function — used to pin the metric fit's global gauge each iteration.
+# Rigid Procrustes (Kabsch): the best-fit rotation + translation, no scale, mapping point set `A`
+# onto `B`, returned as a function. Used to pin the metric fit's global gauge each iteration.
 function rigid_align(A, B)
     ma = sum(A) / length(A)
     mb = sum(B) / length(B)
-    H = sum((B[i] - mb) * (A[i] - ma)' for i in eachindex(A))
+    H = sum((B[i] - mb) * (A[i] - ma)' for i in eachindex(A))  # 2×2 cross-covariance
     F = svd(H)
     R = F.U * F.Vt
-    if det(R) < 0                                             # reflection guard
-        R = F.U * SMatrix{2, 2, Float64}(1, 0, 0, -1) * F.Vt
-    end
-    p -> R * (p - ma) + mb
+    det(R) < 0 && (R = F.U * SMatrix{2, 2, Float64}(1, 0, 0, -1) * F.Vt)   # reflection guard
+    return p -> R * (p - ma) + mb
 end
+
+# Place the canonical square `canon` (no scaling — its size is known exactly) onto four measured cm
+# points, giving the best-fit true square at that pose. This is how each tag's known metric geometry
+# is imposed during the consensus fit: the same Kabsch solve as above, evaluated at `canon` itself.
+place_square(D, canon = CANON) = map(rigid_align(canon, D), canon)
 
 # Fit the metric map `M : image → ground cm` from all tags jointly. Bootstrap from one tag's
 # corners, then alternate: place a true square on each tag's current cm estimate (Procrustes), pin


### PR DESCRIPTION
Candidate 04 of the #68 simplification audit. Four independent cleanups, no behaviour change.

**A dead assignment, and a frame allocated to measure a size.** `Video`'s constructor computed `height, width = size(img)` and overwrote it on the next line but one. The line that replaced it allocated a whole `Array{Gray{Float32}}` frame purely to ask a `WarpedView` how big it would be — but a `WarpedView`'s axes depend only on `axes(img)` and the transform, so wrapping the frame we already hold measures the same thing without decoding or allocating a second one. Verified equal across several frame sizes and scales before the change.

**One `RowCol`, not two.** `const RowCol = SVector{2, Float32}` was defined identically in `Rectifications` (with a docstring) and in `PawsomeTracker` (without). They were always the same type; now they are also the same name. This adds a `PawsomeTracker` → `Rectifications` include edge, noted in `Fromage.jl`'s include-order comment.

**One Kabsch solve, not two.** `place_square` and `rigid_align` were the same four steps written twice: cross-covariance, SVD, reflection guard, apply. Both took the same means and the same cross-covariance orientation, so `place_square(D, canon)` is exactly `rigid_align(canon, D)` evaluated at `canon` — bit-identical, not merely equivalent.

**`fix_window_size`.** Sixteen lines of `if !isodd(x); x += 1; end` across four sites became `oddify(l) = l + iseven(l)`. The (width, height) → (rows, cols) transpose that the tuple method performs is now stated in a comment rather than hidden in the order of two `if` blocks.

### Numbers

Full suite: **1025 passed, 0 failed** (8m09s), Aqua and ExplicitImports included.

`src/` 3353 → 3330, **−23 against a −60 estimate**. Closer than the last four, and for once the shrink is nearly all real: the diff deletes 46 lines and adds 23, and most of what was added is comment explaining a transpose and a warped extent that the old code left the reader to work out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7