### PR TITLE
One diagnostic writer, three scenes (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -233,6 +233,28 @@ otherwise an anamorphic (sar < 1) target fills its own search window. `start_loc
 rectification's `center`/`north` are likewise display-pixel conventions and are bounds-checked
 against the display width, `width × sar`.
 
+### One diagnostic writer, three scenes (#68)
+
+`Diagnose`, `DiagnoseRectified` and `DiagnoseApriltag` were three structs carrying the same fields
+and repeating the same body: bump the counter, skip unless this is the `skip`-th frame, place the
+marker, push the trace, draw the circle and the path, stamp the label, write.
+
+Only two things ever differed — how the raw frame becomes a canvas, and where the tracked point
+lands on that canvas — so those two are now a *scene*: a callable
+`(frame, point, extra...) -> (canvas, ij)` plus a `canvas_prototype` that gives the writer its frame
+size. Everything else lives once, in `Diagnostic`. A fourth diagnostic mode is a scene, not a struct.
+
+The marker radius and label size stay per-mode (they scale with the canvas), and the circle's
+thickness is `max(1, radius ÷ 2)`, which reproduces all three of the old hardcoded values exactly.
+`ij` may come back `missing` — the AprilTag scene cannot locate the target on a frame without a full
+tag set — in which case the frame is still written, just unmarked, as before.
+
+One rendering detail changed. The unrectified writer used to stamp the label *before* drawing the
+marker, so a target that happened to sit under the text was drawn on top of it; the other two
+stamped the label last. All three now stamp last, which is the order that keeps the label legible —
+and the label exists precisely to be read (#22). The two orders only differ where marker and text
+overlap, in the top-left corner of the frame.
+
 ### Diagnostic label fonts are per-writer
 
 FreeType faces are stateful (one glyph slot per face) and FreeTypeAbstraction's per-face lock is

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -398,7 +398,7 @@ function track(
 
     # AprilTag mode (drone footage): the rectification carries the shared reference and detector
     # family; register out camera motion, track, and return metric ground coordinates with the
-    # rectification's centre/north gauge applied. The DiagnoseApriltag (top-down rectified) is created
+    # rectification's centre/north gauge applied. The AprilTag diagnostic (top-down rectified) is created
     # here and shared with track_apriltag.
     if rectification isa ApriltagRectification
         dia = diagnose_apriltag(diagnostic_file, rectification.reference, darker_target, dia_fps)

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -407,81 +407,55 @@ function detect_tags_roi!(dets, img, ids, boxes, sz)
     return corners
 end
 
-# Diagnostic for AprilTag mode: a top-down rectified video. Each frame is warped into a fixed cm
-# canvas through that frame's own image→cm homography, so a correct rectification renders the ground
-# plane stationary (the tags stop moving) while the beetle dot follows the target — letting the user
-# judge both rectification quality and tracking at a glance. The canvas covers the reference tags'
-# cm bounding box (plus a margin) at a fixed pixel size, with square pixels.
-struct DiagnoseApriltag <: Diagnosis
-    label::String
-    writer::VideoWriter
+# Diagnostic scene for AprilTag mode: a top-down rectified video. Each frame is warped into a fixed
+# cm canvas through that frame's own image→cm homography, so a correct rectification renders the
+# ground plane stationary (the tags stop moving) while the beetle dot follows the target — letting
+# the user judge both rectification quality and tracking at a glance. The canvas covers the
+# reference tags' cm bounding box (plus a margin) at a fixed pixel size, with square pixels.
+struct ApriltagScene
     m::Int
     xc::Float64                                   # canvas ↔ cm: centre (cm) …
     yc::Float64
     ppc::Float64                                  # … and pixels-per-cm
-    color::Gray{N0f8}
-    trace::CircularBuffer{CartesianIndex{2}}
-    state::Ref{Int}
-    skip::Int
-    radius::Int
-    font::Int
-    face::FTFont                                  # private per writer; see the FONT note in diagnose.jl
-
-    function DiagnoseApriltag(file::AbstractString, ref, darker_target, fps)
-        label = first(splitext(basename(file)))
-        m = DIAGNOSTIC_SIZE
-        cm = [apply_h(ref.M, p) for p in ref.corners]           # tag corners in ground cm
-        xs = getindex.(cm, 1)
-        ys = getindex.(cm, 2)
-        margin = 0.15 * max(maximum(xs) - minimum(xs), maximum(ys) - minimum(ys))
-        xc = (minimum(xs) + maximum(xs)) / 2
-        yc = (minimum(ys) + maximum(ys)) / 2
-        span = max(maximum(xs) - minimum(xs), maximum(ys) - minimum(ys)) + 2margin
-        ppc = m / span
-        skip = diagnostic_stride(fps)
-        buffer = Matrix{Gray{N0f8}}(undef, m, m)
-        writer = open_video_out(file, buffer; framerate = diagnostic_framerate(fps, skip),
-            encoder_private_options = DIAGNOSTIC_ENCODER)
-        new(label, writer, m, xc, yc, ppc, darker_target ? Gray{N0f8}(1) : Gray{N0f8}(0),
-            CircularBuffer{CartesianIndex{2}}(TRACE_BUFFER_SIZE), Ref(0), skip, max(2, m ÷ 60),
-            m ÷ 16, FTFont(String(FONT)))
-    end
 end
 
-# canvas pixel (row i, col j) ↔ ground cm (x, y), square pixels centred on (xc, yc)
-_canvas_to_cm(d::DiagnoseApriltag, i, j) = SVector(d.xc + (j - d.m/2)/d.ppc, d.yc + (i - d.m/2)/d.ppc)
-_cm_to_canvas(d::DiagnoseApriltag, cm) = CartesianIndex(round(Int, (cm[2]-d.yc)*d.ppc + d.m/2),
-                                                        round(Int, (cm[1]-d.xc)*d.ppc + d.m/2))
+function ApriltagScene(ref)
+    m = DIAGNOSTIC_SIZE
+    cm = [apply_h(ref.M, p) for p in ref.corners]           # tag corners in ground cm
+    xs = getindex.(cm, 1)
+    ys = getindex.(cm, 2)
+    extent = max(maximum(xs) - minimum(xs), maximum(ys) - minimum(ys))
+    span = extent + 2 * 0.15 * extent                       # the tags' bounding box, plus a margin
+    return ApriltagScene(m, (minimum(xs) + maximum(xs)) / 2, (minimum(ys) + maximum(ys)) / 2, m / span)
+end
 
-# per-frame: warp `frame` into the cm canvas via this frame's image→cm homography `H`, draw the
-# beetle (in cm) and its trace. `beetle` is `missing` on frames without a full tag set.
-function (d::DiagnoseApriltag)(frame, beetle, H)
-    d.state[] += 1
-    rem(d.state[], d.skip) == 0 || return nothing
+canvas_prototype(s::ApriltagScene) = Matrix{Gray{N0f8}}(undef, s.m, s.m)
+update_ratio!(::ApriltagScene, _) = nothing
+
+# canvas pixel (row i, col j) ↔ ground cm (x, y), square pixels centred on (xc, yc)
+_canvas_to_cm(s::ApriltagScene, i, j) = SVector(s.xc + (j - s.m/2)/s.ppc, s.yc + (i - s.m/2)/s.ppc)
+_cm_to_canvas(s::ApriltagScene, cm) = CartesianIndex(round(Int, (cm[2]-s.yc)*s.ppc + s.m/2),
+                                                     round(Int, (cm[1]-s.xc)*s.ppc + s.m/2))
+
+# Warp `frame` into the cm canvas via this frame's image→cm homography `H`. `beetle` is `missing` on
+# frames without a full tag set, and `H` is `nothing` when there is no map at all — then every canvas
+# pixel reads out of bounds and the frame comes out filled.
+function (s::ApriltagScene)(frame, beetle, H)
     Hinv = isnothing(H) ? nothing : inv(H)
     # output canvas (i,j) → source image (row,col): canvas→cm→image (cm→image is inv(H))
     tf = idx -> begin
         isnothing(Hinv) && return SVector(-1.0, -1.0)           # no map → fill (out of bounds)
-        c = _canvas_to_cm(d, idx[1], idx[2]); v = Hinv * SVector(c[1], c[2], 1.0)
+        c = _canvas_to_cm(s, idx[1], idx[2]); v = Hinv * SVector(c[1], c[2], 1.0)
         SVector(v[2]/v[3], v[1]/v[3])                           # (row, col) = (img_y, img_x)
     end
-    wimg = warp(Gray{N0f8}.(frame), tf, (1:d.m, 1:d.m); fillvalue = zero(Gray{N0f8}))
-    if !ismissing(beetle)
-        ij = _cm_to_canvas(d, beetle)
-        push!(d.trace, ij)
-        draw!(wimg, CirclePointRadius(ij, d.radius; thickness = max(1, d.radius ÷ 2), fill = false), d.color)
-        draw!(wimg, Path(d.trace), d.color)
-    end
-    out = parent(wimg)
-    # Stamp the run's name, as the other two writers do: `main` concatenates every run's diagnostic
-    # into one video, so without it no segment can be told from the next (#22).
-    renderstring!(out, d.label, d.face, d.font, d.font, d.font, halign = :hleft, valign = :vtop)
-    write(d.writer, out)
-    return nothing
+    wimg = warp(Gray{N0f8}.(frame), tf, (1:s.m, 1:s.m); fillvalue = zero(Gray{N0f8}))
+    return wimg, ismissing(beetle) ? missing : _cm_to_canvas(s, beetle)
 end
+
 diagnose_apriltag(::Nothing, _, _, _) = Dont()
-diagnose_apriltag(file::AbstractString, ref, darker_target, fps) = DiagnoseApriltag(file, ref, darker_target, fps)
-(::Dont)(_, _, _) = nothing                                     # 3-arg no-op for the apriltag callback
+diagnose_apriltag(file::AbstractString, ref, darker_target, fps) =
+    Diagnostic(file, darker_target, fps, ApriltagScene(ref);
+               radius = max(2, DIAGNOSTIC_SIZE ÷ 60), font = DIAGNOSTIC_SIZE ÷ 16)
 
 # Track the beetle across drone footage in a single pass, in the REFERENCE frame's coordinates: the
 # background stack lazily warps every slice through that slice's own registration (a RegisteredWarp
@@ -495,7 +469,7 @@ diagnose_apriltag(file::AbstractString, ref, darker_target, fps) = DiagnoseApril
 #
 # The reference is established once, from the calibration's extrinsic frame, and shared here;
 # `family` is the detector family it was built with; `ref_sz` is the reference frame's (rows, cols),
-# which the run's own resolution may differ from. `dia` is a `DiagnoseApriltag`/`Dont` created and
+# which the run's own resolution may differ from. `dia` is an AprilTag `Diagnostic`/`Dont` created and
 # closed by the caller, shared across a run's segments.
 function track_apriltag(file, start, stop, target_width, start_location, window_size, darker_target,
                         fps, dia, ref::ReferenceFrame, family, ref_sz, initial_search_factor, scale, background_length)

--- a/src/PawsomeTracker/diagnose.jl
+++ b/src/PawsomeTracker/diagnose.jl
@@ -26,56 +26,61 @@ const DIAGNOSTIC_ENCODER = (crf = 23, preset = "veryfast")
 
 abstract type Diagnosis end
 
-struct Diagnose <: Diagnosis
+# All three diagnostics do the same thing with a tracked frame: on every `skip`-th one, render it to
+# a canvas, ring the target, trail the last TRACE_BUFFER_SIZE marks behind it, stamp the run's label
+# (#22) and write. What differs is only how the frame becomes a canvas and where the target lands on
+# it — that is the `scene`, and it is the only thing a fourth diagnostic would have to supply.
+#
+# A scene is a callable `(frame, point, extra...) -> (canvas, ij)`, where `ij` may be `missing` on a
+# frame the mode cannot locate the target in (the marker and trace are then skipped, the frame is
+# still written). `canvas_prototype(scene)` gives the writer its frame size and element type.
+struct Diagnostic{S} <: Diagnosis
     label::String
-    buffer::Matrix{Gray{N0f8}}
-    color::Gray{N0f8}
     writer::VideoWriter
     trace::CircularBuffer{CartesianIndex{2}}
-    ratio::Ref{NTuple{2, Float64}}
     state::Ref{Int}
     skip::Int
-    face::FTFont
-
-    function Diagnose(file::AbstractString, darker_target, fps)
-        label = first(splitext(basename(file)))
-        buff_sz = DIAGNOSTIC_VIDEO_SIZE
-        buffer = Matrix{Gray{N0f8}}(undef, buff_sz...)
-        color = darker_target ? Gray{N0f8}(1) : Gray{N0f8}(0)
-        skip = diagnostic_stride(fps)
-        writer = open_video_out(file, buffer; framerate = diagnostic_framerate(fps, skip),
-            encoder_private_options = DIAGNOSTIC_ENCODER)
-        trace = CircularBuffer{CartesianIndex{2}}(TRACE_BUFFER_SIZE)
-        ratio = Ref{NTuple{2, Float64}}()
-        return new(label, buffer, color, writer, trace, ratio, Ref(0), skip, FTFont(String(FONT)))
-    end
-end
-diagnose(file::AbstractString, darker_target::Bool, ::Nothing, fps) = Diagnose(file, darker_target, fps)
-
-function update_ratio!(dia::Diagnose, sz)
-    return dia.ratio[] = size(dia.buffer) ./ sz
+    color::Gray{N0f8}
+    radius::Int
+    font::Int
+    face::FTFont          # private per writer; see the FONT note above
+    scene::S
 end
 
-function (dia::Diagnose)(img, point)
+function Diagnostic(file::AbstractString, darker_target, fps, scene; radius, font)
+    skip = diagnostic_stride(fps)
+    writer = open_video_out(file, canvas_prototype(scene); framerate = diagnostic_framerate(fps, skip),
+        encoder_private_options = DIAGNOSTIC_ENCODER)
+    return Diagnostic(first(splitext(basename(file))), writer,
+        CircularBuffer{CartesianIndex{2}}(TRACE_BUFFER_SIZE), Ref(0), skip,
+        darker_target ? Gray{N0f8}(1) : Gray{N0f8}(0), radius, font, FTFont(String(FONT)), scene)
+end
+
+function (dia::Diagnostic)(frame, point, extra...)
     dia.state[] += 1
-    if rem(dia.state[], dia.skip) == 0
-        ij = CartesianIndex(round.(Int, point .* dia.ratio[]))
+    rem(dia.state[], dia.skip) == 0 || return nothing
+    canvas, ij = dia.scene(frame, point, extra...)
+    if !ismissing(ij)
         push!(dia.trace, ij)
-        imresize!(dia.buffer, img)
-        renderstring!(dia.buffer, dia.label, dia.face, 20, 20, 20, halign = :hleft, valign = :vtop)
-        draw!(dia.buffer, CirclePointRadius(ij, 7; thickness = 3, fill = false), dia.color)
-        draw!(dia.buffer, Path(dia.trace), dia.color)
-        write(dia.writer, dia.buffer)
+        draw!(canvas, CirclePointRadius(ij, dia.radius; thickness = max(1, dia.radius ÷ 2), fill = false), dia.color)
+        draw!(canvas, Path(dia.trace), dia.color)
     end
+    # A warped canvas is offset-indexed; the writer wants the plain storage behind it (a no-op for
+    # the raw scene, whose canvas already is that storage). The label goes on last, so it stays
+    # legible wherever the target happens to be.
+    out = parent(canvas)
+    renderstring!(out, dia.label, dia.face, dia.font, dia.font, dia.font, halign = :hleft, valign = :vtop)
+    write(dia.writer, out)
     return nothing
 end
 
-Base.close(dia :: Diagnosis) = close_video_out!(dia.writer)
+Base.close(dia::Diagnosis) = close_video_out!(dia.writer)
 
 struct Dont end
 # `file` (the diagnostic_file) is nothing: no diagnostic video requested, whatever the rectification.
 diagnose(::Nothing, _, _, _) = Dont()
 (::Dont)(_, _) = nothing
+(::Dont)(_, _, _) = nothing                    # 3-arg no-op for the apriltag callback
 Base.close(::Dont) = nothing
 update_ratio!(::Dont, _) = nothing
 
@@ -88,53 +93,53 @@ function diagnose(f, file, darker_target, rectification, fps)
     end
 end
 
-struct DiagnoseRectified <: Diagnosis
-    label::String
-    indices
-    color::Gray{N0f8}
-    writer::VideoWriter
-    trace::CircularBuffer{CartesianIndex{2}}
-    state::Ref{Int}
-    skip::Int
-    image2real
-    real2image
-    radius::Int
-    font::Int
-    face::FTFont
+# Only the raw scene has anything to update; the warping ones map through a rectification that is
+# fixed at construction, so they answer with a no-op.
+update_ratio!(dia::Diagnostic, sz) = update_ratio!(dia.scene, sz)
 
-    function DiagnoseRectified(file::AbstractString, darker_target, rect, fps)
-        label = first(splitext(basename(file)))
-        # Fixed canvas, with the zoom adapting so the frame's smaller dimension always spans it:
-        # detail stays discernible while every segment comes out the same size.
-        m = DIAGNOSTIC_SIZE
-        D = LinearMap(SDiagonal{2}((min(rect.width, rect.height) / m) * rect.ratio * I))
-        real2image = rect.real2image ∘ D
-        image2real = inv(D) ∘ rect.image2real
-        indices = (-m÷2:m÷2 - 1, -m÷2:m÷2 - 1)
-        buffer = OffsetMatrix(Matrix{Gray{N0f8}}(undef, m, m), indices...)
-        color = darker_target ? Gray{N0f8}(1) : Gray{N0f8}(0)
-        skip = diagnostic_stride(fps)
-        writer = open_video_out(file, parent(buffer); framerate = diagnostic_framerate(fps, skip),
-            encoder_private_options = DIAGNOSTIC_ENCODER)
-        trace = CircularBuffer{CartesianIndex{2}}(TRACE_BUFFER_SIZE)
-        return new(label, indices, color, writer, trace, Ref(0), skip, image2real, real2image, m ÷ 30, m ÷ 16, FTFont(String(FONT)))
-    end
+# --- the scenes ---------------------------------------------------------------------------------
+
+# Unrectified: the raw frame resized into a fixed canvas, reusing one buffer across frames. The
+# frame size is not known until tracking opens the video, so the point→canvas ratio is filled in by
+# `update_ratio!` before the first write.
+struct RawScene
+    buffer::Matrix{Gray{N0f8}}
+    ratio::Ref{NTuple{2, Float64}}
 end
-diagnose(file::AbstractString, darker_target::Bool, rectification, fps) = DiagnoseRectified(file, darker_target, rectification, fps)
-
-function (dia::DiagnoseRectified)(img, point)
-    dia.state[] += 1
-    if rem(dia.state[], dia.skip) == 0
-        ij = CartesianIndex(Tuple(round.(Int, dia.image2real(point))))
-        push!(dia.trace, ij)
-        wimg = warp(Gray{N0f8}.(img), dia.real2image, dia.indices; fillvalue = zero(Gray{N0f8}))
-        draw!(wimg, CirclePointRadius(ij, dia.radius; thickness = dia.radius ÷ 2, fill = false), dia.color)
-        draw!(wimg, Path(dia.trace), dia.color)
-        wimg = parent(wimg)
-        renderstring!(wimg, dia.label, dia.face, dia.font, dia.font, dia.font, halign = :hleft, valign = :vtop)
-        write(dia.writer, wimg)
-    end
-    return nothing
+RawScene() = RawScene(Matrix{Gray{N0f8}}(undef, DIAGNOSTIC_VIDEO_SIZE...), Ref{NTuple{2, Float64}}())
+canvas_prototype(s::RawScene) = s.buffer
+update_ratio!(s::RawScene, sz) = s.ratio[] = size(s.buffer) ./ sz
+function (s::RawScene)(img, point)
+    imresize!(s.buffer, img)
+    return s.buffer, CartesianIndex(round.(Int, point .* s.ratio[]))
 end
 
-update_ratio!(::DiagnoseRectified, _) = nothing
+diagnose(file::AbstractString, darker_target::Bool, ::Nothing, fps) =
+    Diagnostic(file, darker_target, fps, RawScene(); radius = 7, font = 20)
+
+# Rectified: the frame warped onto the ground plane, into a fixed square canvas with the zoom
+# adapting so the frame's smaller dimension always spans it — detail stays discernible while every
+# segment comes out the same size (mandatory for the stream-copy concatenation; see DIAGNOSTIC_SIZE).
+struct RectifiedScene{I, R}
+    indices::NTuple{2, UnitRange{Int}}
+    image2real::I
+    real2image::R
+end
+
+function RectifiedScene(rect)
+    m = DIAGNOSTIC_SIZE
+    D = LinearMap(SDiagonal{2}((min(rect.width, rect.height) / m) * rect.ratio * I))
+    return RectifiedScene((-m÷2:m÷2 - 1, -m÷2:m÷2 - 1), inv(D) ∘ rect.image2real, rect.real2image ∘ D)
+end
+
+canvas_prototype(s::RectifiedScene) = Matrix{Gray{N0f8}}(undef, length.(s.indices)...)
+update_ratio!(::RectifiedScene, _) = nothing
+
+function (s::RectifiedScene)(img, point)
+    wimg = warp(Gray{N0f8}.(img), s.real2image, s.indices; fillvalue = zero(Gray{N0f8}))
+    return wimg, CartesianIndex(Tuple(round.(Int, s.image2real(point))))
+end
+
+diagnose(file::AbstractString, darker_target::Bool, rectification, fps) =
+    Diagnostic(file, darker_target, fps, RectifiedScene(rectification);
+               radius = DIAGNOSTIC_SIZE ÷ 30, font = DIAGNOSTIC_SIZE ÷ 16)

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -305,7 +305,7 @@ end
     rect = PT.ApriltagRectification(file, 0.2, 4, "tag36h11", 8, missing, missing, 480, 480)
 
     # the label is the diagnostic file's name — which `main` sets to the run_id
-    dia = PT.DiagnoseApriltag(joinpath(dir, "run7.mp4"), rect.reference, true, 25)
+    dia = PT.diagnose_apriltag(joinpath(dir, "run7.mp4"), rect.reference, true, 25)
     @test dia.label == "run7"
     close(dia)
 


### PR DESCRIPTION
Candidate 05 of the #68 simplification audit. Note this branches from `main`, not from #73 — they touch disjoint parts of `PawsomeTracker`, so either can merge first.

`Diagnose`, `DiagnoseRectified` and `DiagnoseApriltag` were three structs carrying the same fields (label, writer, trace, state, skip, color, radius, font, face) and repeating the same body: bump the counter, skip unless this is the `skip`-th frame, place the marker, push the trace, draw the circle and the path, stamp the label, write.

Only two things ever differed — how the raw frame becomes a canvas, and where the tracked point lands on that canvas. Those two are now a **scene**: a callable `(frame, point, extra...) -> (canvas, ij)` plus a `canvas_prototype` that tells the writer its frame size. Everything else lives once, in `Diagnostic{S}`.

- `RawScene` — resize into a fixed 360×640 buffer, reused across frames; owns the point→canvas ratio that `update_ratio!` fills in once tracking opens the video.
- `RectifiedScene` — warp onto the ground plane into the fixed square canvas.
- `ApriltagScene` — warp through each frame's own image→cm homography.

Adding a fourth mode is now a function, not a struct.

### Behaviour

The circle's thickness becomes `max(1, radius ÷ 2)`, which reproduces all three old hardcoded values exactly (7→3, 18→9, 9→4). A `missing` `ij` — the AprilTag scene on a frame without a full tag set — still writes the frame, just unmarked, as before.

**One rendering detail changed.** The unrectified writer stamped its label *before* drawing the marker, so a target sitting under the text was drawn on top of it; the other two stamped last. All three now stamp last, which is the order that keeps the label legible — and the label exists to be read (#22). The two orders differ only where marker and text overlap, in the top-left corner. Recorded in `DESIGN-HISTORY.md`.

One test changed: `test/fromage.jl` built a `PT.DiagnoseApriltag` directly and now goes through `PT.diagnose_apriltag`, the factory the tracker itself calls.

### Numbers

Full suite: **1025 passed, 0 failed** (8m05s), Aqua and ExplicitImports included.

The diagnostic machinery goes **170 → 126 lines of code** excluding blanks and comments, a 26% cut, and the diff deletes 139 lines for 118 added. But `src/` overall only goes 3353 → 3332: **−21 against a −100 estimate**, because much of what the collapse freed up went back in as comment explaining what a scene is and what changed. The structural win is real; the line count barely moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7