### PR TITLE
Shared test code is two modules, not one include (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -533,7 +533,9 @@ It used to be `rand(UInt8, 500)`, which made every corrupt-video test a dice rol
 random blob in 300 is recognised by ffprobe as some container, whereupon it exits 0 and reports
 nothing usable rather than failing. That input is real and the code must handle it, but it has no
 business arriving at random — it is now covered deliberately by the audio-only case in
-`test/probing.jl`, while the fixture always exercises the outright-unreadable path.
+`test/probing.jl`, while the fixture always exercises the outright-unreadable path. Every corrupt
+fixture now comes from that one generator; `test/probing.jl` and the AprilTag tests in
+`test/fromage.jl` each used to build their own.
 
 ### Ground truth is analytic
 
@@ -575,9 +577,38 @@ it has to be something a caller could observe.
 
 ### Each suite runs in its own wrapper module
 
-Their helper constants — `DATADIR`, `ART`, `HEADER`, `make_video` — would otherwise collide.
+Their suite-specific names — `DATADIR`, `ART`, `HEADER`, `check` — would otherwise collide.
 Testsets nest fine across module boundaries, since they use the task's dynamic scope rather than
 lexical scope.
+
+### Shared test code is a module, not an `include` (#68)
+
+`test/common.jl` was textually included into all four suite modules, which meant four compiled
+copies and, worse, three of its definitions resolved a name belonging to whichever module included
+them: `_merge` called that module's `row`, `load_capturing` called its `check`, and `write_csv`
+took its `HEADER` as a default. Reading `common.jl` did not tell you what those calls did.
+
+It is now two modules, split by who needs them. `test/fixtures.jl` holds the synthetic media — the
+ffmpeg generators and the analytic ground truth that comes with them — plus the ffprobe readers,
+and all four suites use it. `test/harness.jl` holds the CSV plumbing: `csvcell`, `write_csv`,
+`buildrow`, `flagged`, and `capturing`, which now takes the thunk instead of reaching for `check`.
+Only the two gateway suites use it; the tracker and end-to-end suites no longer compile it at all.
+Each suite declares its `DATADIR` before including its `helpers.jl`, so artifacts and entry points
+read top to bottom with nothing resolved late.
+
+What did *not* move is the per-suite half. The plan had been to parameterise one harness by
+(loader, header, artifacts) so both gateways shared their entry points. Written out, the factory
+plus the unpacking each suite needs came to more lines than the five each suite spends now on
+`row`, `write_csv`, `check`, `load_capturing` and `clean` — and it hid which loader a given `check`
+reaches. Two short explicit definitions beat one shared indirect one here.
+
+### Fixture encoding is not what makes the suite slow
+
+Encoding each shared video once and copying it, rather than re-encoding the same content per suite,
+was on the table: roughly 19 of the ~45 ffmpeg invocations produce content another suite has
+already built. Timed, the entire generator set costs about 2.5 s — against `quality` (Aqua and
+ExplicitImports) at 71 s, `PawsomeTracker` at 56 s and `Rectifications` at 26 s. A fixture cache
+would have added machinery to save well under 1% of the run, so the duplicate encodes stay.
 
 ### JET runs only on the pinned Julia minor
 

--- a/test/VerifyRectifications/helpers.jl
+++ b/test/VerifyRectifications/helpers.jl
@@ -1,14 +1,16 @@
-# Suite-specific helpers; the generic infrastructure (video/CSV builders, flagged, …) lives in
-# test/common.jl, included by the wrapper module before this file.
+# Everything specific to this gateway: the artifacts, the column header, and the four entry points
+# its test files use. The generic infrastructure lives in test/fixtures.jl (synthetic videos,
+# ffprobe readers) and test/harness.jl (CSV building, `flagged`, `capturing`).
 using Test
 using Fromage: VerifyRectifications
 using CSV, DataFrames
 using FFMPEG, MAT
+import ..Harness: write_csv
 
 const VRect = VerifyRectifications
 
 # ---------------------------------------------------------------------------
-# Artifact generation (videos, matlab files) into a shared directory.
+# Artifact generation (videos, matlab files) into DATADIR.
 # ---------------------------------------------------------------------------
 
 # The first `board_t` seconds show the (padded, 500×376) checkerboard, the rest is cornerless
@@ -72,9 +74,8 @@ make_matlab_consistent(path; f = 500.0, Z = 100.0) = (MAT.matwrite(path, Dict("c
 # 0…4 s, so the video must be longer than 4 s. 5 s satisfies both with a 1 s margin.
 const VIDEO_DURATION = 5
 
-"Generate every shared artifact into `dir`; return a NamedTuple of their basenames."
-function setup_artifacts(dir)
-    checkerboard_png = joinpath(@__DIR__, "fixtures", "checkerboard.png")
+# Every shared artifact, generated into DATADIR; the NamedTuple gives their basenames.
+const ART = let dir = DATADIR, checkerboard_png = joinpath(@__DIR__, "fixtures", "checkerboard.png")
     make_video(joinpath(dir, "video.mp4"); duration = VIDEO_DURATION, size = (640, 480))      # dim (640,480)
     make_checkerboard_video(joinpath(dir, "board.mp4"), checkerboard_png; duration = VIDEO_DURATION) # dim (500,376)
     make_mixed_video(joinpath(dir, "mixed.mp4"), checkerboard_png)                  # board 0–2 s, testsrc 2–5 s
@@ -87,10 +88,10 @@ function setup_artifacts(dir)
     make_matlab_nested(joinpath(dir, "nested.mat"); imagesize = (480, 640))        # dim (640,480), matches video.mp4
     make_matlab_mismatch(joinpath(dir, "mismatch.mat"))                            # translation/rotation pose counts differ
     make_matlab_consistent(joinpath(dir, "consistent.mat"))                        # buildable: fronto-parallel pinhole, dim (640,480)
-    return (video = "video.mp4", board = "board.mp4", mixed = "mixed.mp4", corrupt = "corrupt.mp4", interlaced = "interlaced.mp4",
-            good_mat = "good.mat", noimsize_mat = "noimsize.mat", bad_mat = "bad.mat",
-            partial_mat = "partialcalib.mat", nested_mat = "nested.mat", mismatch_mat = "mismatch.mat",
-            consistent_mat = "consistent.mat")
+    (video = "video.mp4", board = "board.mp4", mixed = "mixed.mp4", corrupt = "corrupt.mp4", interlaced = "interlaced.mp4",
+     good_mat = "good.mat", noimsize_mat = "noimsize.mat", bad_mat = "bad.mat",
+     partial_mat = "partialcalib.mat", nested_mat = "nested.mat", mismatch_mat = "mismatch.mat",
+     consistent_mat = "consistent.mat")
 end
 
 # ---------------------------------------------------------------------------
@@ -105,6 +106,7 @@ const HEADER = ["calibration_id", "path", "file", "matlab_file", "type", "extrin
 
 row(; kw...) = buildrow(HEADER; kw...)
 write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)
+_merge(base; kw...) = row(; merge(base, values(kw))...)
 
 # Clean baseline rows per rectification type; override any field via keyword to isolate one issue.
 # (Each scenario is loaded as its own single-row CSV, so there is no cross-row coupling.)
@@ -125,7 +127,7 @@ mixedrow(; kw...) = _merge((calibration_id = "x", path = ".", file = ART.mixed, 
                             checker_size = 4, temporal_step = 0.9, radial_parameters = 1, blur = 0); kw...)
 
 # ---------------------------------------------------------------------------
-# Run + assert. DATADIR is defined in the wrapper module before any test file runs.
+# Run + assert.
 # ---------------------------------------------------------------------------
 
 "Write `rows` to a CSV in DATADIR and load it. Scenario rows keep indices 1:length(rows).
@@ -138,6 +140,9 @@ function check(name, rows; strict = false, header = HEADER, defaults = (;), issu
     csv = write_csv(joinpath(DATADIR, name), rows; header)
     VRect.load_rectifications(DATADIR, csv; strict, defaults, issues_dir)
 end
+
+"Like `check`, but also capture what the load prints to stdout. Returns (result, output)."
+load_capturing(name, rows; kw...) = capturing(() -> check(name, rows; kw...))
 
 # A clean load returns Vector{RectificationMethod}; a load with issues keeps the df's :issues.
 clean(df) = !hasproperty(df, :issues) || all(isempty, df.issues)

--- a/test/VerifyRuns/helpers.jl
+++ b/test/VerifyRuns/helpers.jl
@@ -1,26 +1,28 @@
-# Suite-specific helpers; the generic infrastructure (video/CSV builders, flagged, tracking
-# ground truth, …) lives in test/common.jl, included by the wrapper module before this file.
+# Everything specific to this gateway: the artifacts, the column header, and the four entry points
+# its test files use. The generic infrastructure lives in test/fixtures.jl (synthetic videos,
+# ffprobe readers) and test/harness.jl (CSV building, `flagged`, `capturing`).
 using Test
 using Fromage: VerifyRuns
 using CSV, DataFrames
+import ..Fixtures: make_target_video
+import ..Harness: write_csv
 
 const VR = VerifyRuns
 
 # ---------------------------------------------------------------------------
-# Artifact generation (videos) into a shared directory.
+# Artifact generation (videos) into DATADIR.
 # ---------------------------------------------------------------------------
+
+const VIDEO_DURATION = 5
 
 # a.mp4 is the baseline run video (5 s, 640×480, 30 fps); b.mp4 is a second segment video (8 s);
 # small.mp4 has different pixel dimensions (320×240) to exercise the dimension-consistency check.
-const VIDEO_DURATION = 5
-
-"Generate every shared artifact into `dir`; return a NamedTuple of their basenames."
-function setup_artifacts(dir)
+const ART = let dir = DATADIR
     make_video(joinpath(dir, "a.mp4"); duration = VIDEO_DURATION, size = (640, 480), rate = 30)
     make_video(joinpath(dir, "b.mp4"); duration = 8, size = (640, 480), rate = 30)
     make_video(joinpath(dir, "small.mp4"); duration = 5, size = (320, 240), rate = 30)
     make_corrupt_video(joinpath(dir, "corrupt.mp4"))
-    return (a = "a.mp4", b = "b.mp4", small = "small.mp4", corrupt = "corrupt.mp4")
+    (a = "a.mp4", b = "b.mp4", small = "small.mp4", corrupt = "corrupt.mp4")
 end
 
 # the known-trajectory disc videos (test_tracking.jl) land in DATADIR like every other artifact
@@ -37,6 +39,7 @@ const HEADER = ["run_id", "calibration_id", "path", "file", "start", "stop", "ta
 
 row(; kw...) = buildrow(HEADER; kw...)
 write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)
+_merge(base; kw...) = row(; merge(base, values(kw))...)
 
 # Clean baseline run row (run_id + calibration_id + a 5 s video; every other field defaults).
 # Override any field via keyword to isolate one issue. Each scenario is loaded as its own CSV, so
@@ -44,13 +47,16 @@ write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)
 runrow(; kw...) = _merge((run_id = "r", calibration_id = "c", file = ART.a); kw...)
 
 # ---------------------------------------------------------------------------
-# Run + assert. DATADIR is defined in the wrapper module before any test file runs.
+# Run + assert.
 # ---------------------------------------------------------------------------
 
 function check(name, rows; strict = false, header = HEADER, defaults = (;))
     csv = write_csv(joinpath(DATADIR, name), rows; header)
     VR.load_runs(DATADIR, csv; strict, defaults)
 end
+
+"Like `check`, but also capture what the load prints to stdout. Returns (result, output)."
+load_capturing(name, rows; kw...) = capturing(() -> check(name, rows; kw...))
 
 # A clean load returns Vector{Run}; a load with issues returns a DataFrame carrying :issues.
 clean(x) = x isa Vector{VR.Run}

--- a/test/fixtures.jl
+++ b/test/fixtures.jl
@@ -1,12 +1,15 @@
-# Test infrastructure shared by the suites, `include`d into each suite's wrapper module — the
-# things that genuinely differ per suite (DATADIR, HEADER, the baseline rows, `check`, `clean`)
-# stay module-local, while these definitions are written once. Functions that reference a
-# module-local name (`row` in `_merge`, `check` in `load_capturing`, `write_csv`'s per-suite
-# HEADER default) resolve it in the including module at call time.
+# The synthetic media every suite runs against — ffmpeg-encoded videos and the analytic ground
+# truth that comes with them — plus the ffprobe readers used to assert on produced videos.
+#
+# A module rather than an `include`d file: the four suites share one compiled copy, and generators
+# here can be shared without any of them reaching into another's scope.
+module Fixtures
 
-using DataFrames: AbstractDataFrame
 using FFMPEG: FFMPEG
 using Statistics: mean
+
+export make_video, make_checkerboard_video, make_corrupt_video, make_target_video,
+    tracking_rmse, probe_stream, probe_frames
 
 # ---------------------------------------------------------------------------
 # Video artifacts.
@@ -81,54 +84,6 @@ function tracking_rmse(ij, expected; skip = 1, offset = 0)
 end
 
 # ---------------------------------------------------------------------------
-# CSV building against the including module's HEADER.
-# ---------------------------------------------------------------------------
-
-csvcell(::Missing) = ""
-function csvcell(x)
-    s = x isa AbstractString ? String(x) : string(x)
-    (occursin(',', s) || occursin('"', s)) ? string('"', replace(s, '"' => "\"\""), '"') : s
-end
-
-function write_csv(path, rows, header)
-    open(path, "w") do io
-        println(io, join(header, ","))
-        for r in rows
-            println(io, join(csvcell.(r), ","))
-        end
-    end
-    path
-end
-
-# A kwarg not in `header` would be dropped silently, quietly testing nothing.
-function buildrow(header; kw...)
-    unknown = setdiff(string.(keys(kw)), header)
-    @assert isempty(unknown) "unknown CSV column/s in test row: $unknown"
-    return [get(kw, Symbol(c), missing) for c in header]
-end
-
-# Baseline-row merging: `row` is each suite's `buildrow(HEADER; ...)` wrapper.
-_merge(base; kw...) = row(; merge(base, values(kw))...)
-
-# ---------------------------------------------------------------------------
-# Run + assert.
-# ---------------------------------------------------------------------------
-
-"Like `check`, but also capture what the load prints to stdout. Returns (result, output). Routed
-through a temp file because redirect_stdout needs a real file descriptor, not an IOBuffer."
-function load_capturing(name, rows; strict = false)
-    mktemp() do path, io
-        result = redirect_stdout(() -> check(name, rows; strict), io)
-        flush(io)
-        result, read(path, String)
-    end
-end
-
-# A load with issues returns a DataFrame carrying :issues (non-strict); a clean one returns the
-# built objects, so anything that isn't a DataFrame is unflagged by definition.
-flagged(x, r, sub) = x isa AbstractDataFrame && any(m -> occursin(sub, m), x.issues[r])
-
-# ---------------------------------------------------------------------------
 # Video probing (ffprobe) — for asserting on produced (diagnostic) videos.
 # ---------------------------------------------------------------------------
 
@@ -167,4 +122,6 @@ function probe_frames(file)
         push!(dts, parse(Int, parts[2]))
     end
     return sizes, pts, dts
+end
+
 end

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -11,8 +11,7 @@ using StaticArrays: SVector
 using MAT: matwrite
 using AprilTags: getAprilTagImage, tag36h11
 using FFMPEG: ffmpeg_exe
-
-include("common.jl")
+using ..Fixtures
 
 # A synthetic "drone" video for the AprilTag pipeline: four tag36h11 tags fixed on a ground canvas, a
 # dark disc target moving along a known straight ground path, and a per-frame pan (a cropping window
@@ -343,7 +342,7 @@ end
     dir = mktempdir()
     vid, _, _, _ = make_apriltag_video(dir, "ref"; nframes = 20)
     file = joinpath(dir, vid)
-    corrupt = joinpath(dir, "corrupt.mp4"); write(corrupt, rand(UInt8, 500))
+    corrupt = make_corrupt_video(joinpath(dir, "corrupt.mp4"))
 
     @test PT.reference_frame(file, 0.2, 4, "tag36h11", 8)    isa PT.ReferenceFrame   # success
     @test PT.reference_frame(file, 0.2, 99, "tag36h11", 8)   isa String              # too few tags

--- a/test/harness.jl
+++ b/test/harness.jl
@@ -1,0 +1,50 @@
+# The CSV side of the two gateway suites: build a row against a suite's column header, write the
+# rows out, run the loader, and say what it flagged. Only the gateway suites need any of this.
+#
+# Everything here takes what it needs as an argument. The suite-specific half — the header, the
+# loader call, the baseline rows, what a clean result looks like — stays in each suite's
+# `helpers.jl`, where it is short enough to read at a glance.
+module Harness
+
+using DataFrames: AbstractDataFrame
+
+export csvcell, write_csv, buildrow, flagged, capturing
+
+csvcell(::Missing) = ""
+function csvcell(x)
+    s = x isa AbstractString ? String(x) : string(x)
+    (occursin(',', s) || occursin('"', s)) ? string('"', replace(s, '"' => "\"\""), '"') : s
+end
+
+function write_csv(path, rows, header)
+    open(path, "w") do io
+        println(io, join(header, ","))
+        for r in rows
+            println(io, join(csvcell.(r), ","))
+        end
+    end
+    path
+end
+
+# A kwarg not in `header` would be dropped silently, quietly testing nothing.
+function buildrow(header; kw...)
+    unknown = setdiff(string.(keys(kw)), header)
+    @assert isempty(unknown) "unknown CSV column/s in test row: $unknown"
+    return [get(kw, Symbol(c), missing) for c in header]
+end
+
+# A load with issues returns a DataFrame carrying :issues (non-strict); a clean one returns the
+# built objects, so anything that isn't a DataFrame is unflagged by definition.
+flagged(x, r, sub) = x isa AbstractDataFrame && any(m -> occursin(sub, m), x.issues[r])
+
+"Run `f`, returning (its result, what it printed to stdout). Routed through a temp file because
+redirect_stdout needs a real file descriptor, not an IOBuffer."
+function capturing(f)
+    mktemp() do path, io
+        result = redirect_stdout(f, io)
+        flush(io)
+        result, read(path, String)
+    end
+end
+
+end

--- a/test/pawsometracker.jl
+++ b/test/pawsometracker.jl
@@ -1,4 +1,4 @@
-# Direct PawsomeTracker coverage, over the shared synthetic-trajectory generator (test/common.jl):
+# Direct PawsomeTracker coverage, over the shared synthetic-trajectory generator (test/fixtures.jl):
 # ffmpeg's geq renders a disc following a known sine, encoded losslessly so the analytic ground
 # truth is exact. VerifyRuns' test_tracking.jl additionally exercises track through the gateway,
 # including anamorphic and scaled variants.
@@ -9,7 +9,7 @@ using Fromage.PawsomeTracker: track
 using Fromage: PawsomeTracker
 const PT = PawsomeTracker
 
-include("common.jl")
+using ..Fixtures
 
 # The background stack is a lazily-indexed view over the array that actually holds the frames, and
 # how many layers of view sit in between is nobody's business but `build_stack`'s. Unwrap to the

--- a/test/probing.jl
+++ b/test/probing.jl
@@ -6,19 +6,14 @@ module ProbingTests
 using Test
 using Fromage: Fromage
 using FFMPEG: FFMPEG
+using ..Fixtures
 
 const P = Fromage.Probing
 
 @testset "Probing (shared ffprobe plumbing)" begin
     dir = mktempdir()
-    vid = joinpath(dir, "v.mp4")
-    FFMPEG.ffmpeg_exe(`-y -loglevel error -f lavfi -i testsrc=duration=1:size=320x240:rate=25 -pix_fmt yuv420p $vid`)
-    # Deterministically unreadable: a real mp4 with everything after the first 500 bytes cut off.
-    # (Random bytes were used here before — see make_corrupt_video in common.jl for why they are not.)
-    corrupt = joinpath(dir, "c.mp4")
-    whole = joinpath(dir, "whole.mp4")
-    FFMPEG.ffmpeg_exe(`-y -loglevel error -f lavfi -i testsrc=duration=1:size=64x64:rate=5 -pix_fmt yuv420p $whole`)
-    write(corrupt, read(whole)[1:500])
+    vid = make_video(joinpath(dir, "v.mp4"); duration = 1, size = (320, 240), rate = 25)
+    corrupt = make_corrupt_video(joinpath(dir, "c.mp4"))
 
     # Opens cleanly, but has no video stream at all: ffprobe exits 0 and reports only the container
     # duration — the case the deterministic corrupt fixture deliberately does not cover.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,12 @@
-# The consolidated suite: each former package's tests run inside their own wrapper module (so
-# their helper constants — DATADIR, ART, HEADER, make_video, … — cannot collide), followed by the
-# Fromage-level end-to-end test. Testsets nest fine across module boundaries (they use the task's
+# The consolidated suite. Two support modules are defined first — `Fixtures` (the synthetic videos
+# and the ffprobe readers) and `Harness` (the gateway suites' CSV plumbing) — and then each former
+# package's tests run inside their own wrapper module, so their suite-specific names (DATADIR, ART,
+# HEADER, …) cannot collide. Testsets nest fine across module boundaries (they use the task's
 # dynamic scope, not lexical scope).
 using Test
+
+include("fixtures.jl")
+include("harness.jl")
 
 @testset "Fromage (consolidated)" begin
     include("quality.jl")

--- a/test/verifyrectifications.jl
+++ b/test/verifyrectifications.jl
@@ -2,13 +2,13 @@ module VerifyRectificationsTests
 
 using Test
 using Fromage: Fromage
+using ..Fixtures, ..Harness
 
-include("common.jl")
-include("VerifyRectifications/helpers.jl")
-
-# Shared artifacts and CSV scratch space, built once (ffmpeg is the slow part).
+# Shared artifacts and CSV scratch space, built once for the whole suite. DATADIR comes
+# first: helpers.jl generates into it and closes over it.
 const DATADIR = mktempdir()
-const ART = setup_artifacts(DATADIR)
+
+include("VerifyRectifications/helpers.jl")
 
 @testset "VerifyRectifications" begin
     include("VerifyRectifications/test_input.jl")

--- a/test/verifyruns.jl
+++ b/test/verifyruns.jl
@@ -2,13 +2,13 @@ module VerifyRunsTests
 
 using Test
 using Fromage: Fromage
+using ..Fixtures, ..Harness
 
-include("common.jl")
-include("VerifyRuns/helpers.jl")
-
-# Shared artifacts and CSV scratch space, built once (ffmpeg is the slow part).
+# Shared artifacts and CSV scratch space, built once for the whole suite. DATADIR comes
+# first: helpers.jl generates into it and closes over it.
 const DATADIR = mktempdir()
-const ART = setup_artifacts(DATADIR)
+
+include("VerifyRuns/helpers.jl")
 
 @testset "VerifyRuns" begin
     include("VerifyRuns/test_input.jl")


### PR DESCRIPTION
Candidate **10** from the [simplification ledger](https://claude.ai/code/artifact/5a74f007-2af9-4c11-ba19-7b585fc40366), plus the measurement that kills candidate **17**.

## What changed

`test/common.jl` was `include`d textually into all four suite modules. That meant four compiled copies, and — the part worth fixing — three of its definitions resolved a name belonging to whichever module included them: `_merge` called that module's `row`, `load_capturing` called its `check`, `write_csv` took its `HEADER` as a default. Reading `common.jl` did not tell you what those calls did.

It is now two modules, split by who needs them:

- **`test/fixtures.jl`** — the synthetic media (ffmpeg generators + the analytic ground truth) and the ffprobe readers. All four suites use it.
- **`test/harness.jl`** — the CSV plumbing: `csvcell`, `write_csv`, `buildrow`, `flagged`, and `capturing`, which now takes the thunk instead of reaching for `check`. Only the two gateway suites use it, so `PawsomeTrackerTests` and `FromageTests` stop compiling ~80 lines they never call.

Each suite declares `DATADIR` before including its `helpers.jl`, so its artifacts and entry points read top to bottom with nothing resolved late. `setup_artifacts(dir)` — a function called once, with `DATADIR` — became the `const ART = let dir = DATADIR … end` it always was.

Two fixtures were hand-rolled copies of a shared generator: `test/probing.jl` built its own truncated-mp4 corrupt fixture, and the AprilTag tests in `test/fromage.jl` still used `rand(UInt8, 500)`. Both now call `make_corrupt_video`, which removes the last `rand` from the suite.

## What did not change, and why

The plan was one harness parameterised by (loader, header, artifact set), giving both gateways the same entry points. Written out, the factory plus the unpacking each suite needs came to **more** lines than the five each suite currently spends on `row`, `write_csv`, `check`, `load_capturing` and `clean` — and it hid which loader a given `check` call reaches. Two short explicit definitions beat one shared indirect one here. Recorded in `DESIGN-HISTORY.md`.

## Candidate 17 is not worth doing

17 proposed caching the encoded fixtures on the premise that "encoding dominates setup". Roughly 19 of the ~45 ffmpeg invocations really are duplicates. But timed, the **entire** generator set costs **2.5 s**, against:

| testset | time |
|---|---|
| quality (Aqua + ExplicitImports) | 1m11s |
| PawsomeTracker | 56s |
| Rectifications | 26s |
| AprilTag | 6s |

A fixture cache would have added ~20 lines of machinery to save well under 1% of a 7½-minute run. Not done; the reasoning is in `DESIGN-HISTORY.md` so nobody re-derives it.

## Numbers

**+16 test lines** (3547 → 3563; +9 excluding blanks and comments) against an estimated **−120**. That is the wrong sign, and it should be read plainly: the two module headers, exports and doc comments cost more than the duplication removed. The value here is structural — one compiled copy instead of four, no late binding, and two suites no longer compiling the CSV half — not lines. Seventh estimate in a row to overshoot.

**1025 / 1025 pass** (7m30s with coverage), identical to `main`. **Coverage 96.29%** (1322/1373 coverable `src/` lines); the change is test-only and the assertion set is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7