### PR TITLE
A benchmark harness, in two tiers (#68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ benchmark/*.json
 coverage
 env
 node_modules
+/benchmark/Manifest.toml

--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -621,3 +621,48 @@ They run during precompilation, which the coverage run does not instrument, so t
 hit by the test suite no matter how well the package is tested. Both workloads point at
 nonexistent files, so they exercise the full parse + verification path but bail before any
 ffprobe, `matread` or corner detection — no bundled media, fast and deterministic.
+
+## Benchmarks
+
+### Two tiers, because one sampling strategy cannot serve both (#68)
+
+`benchmark/benchmarks.jl` defines a single BenchmarkTools `SUITE`, which is the only thing the
+runner has to agree on — AirspeedVelocity (`benchpkg Fromage --rev=main,my-branch`) and
+PkgBenchmarks both read it, so the choice stays reversible. It is deliberately not wired into CI:
+the suite already runs a full ffmpeg workload on every PR, and benchmark numbers from a shared
+runner would be noise presented as data.
+
+The `"micro"` group is pure, in-memory and deterministic — lens distortion forward and inverse,
+the rectification's coordinate maps, the AprilTag ground geometry, and the detection filter.
+BenchmarkTools samples these properly and the numbers mean what they say, so this is the tier that
+can settle a design question.
+
+The `"macro"` group is whole pipelines: `track` over the shared disc fixture, the same with a
+diagnostic video, and `main` over a one-calibration, one-run data folder. These decode video,
+spawn ffprobe and encode an `.mp4`, so a sampled statistic would be measuring the filesystem and
+the scheduler rather than the code. Each runs once (`samples = 1, evals = 1`) and reports wall
+clock and allocations — a regression tripwire, not a measurement.
+
+Fixtures come from `test/fixtures.jl`, so a benchmark and a test measure the same synthetic media.
+
+### What the benchmarks cannot tell you
+
+Nothing in `benchmark/` touches a network filesystem. The threading shape in `track` and `main`
+exists to survive EAGAIN on a CIFS share under concurrent ffmpeg reads — a contention failure
+against a network filesystem, not a throughput number. No local benchmark reproduces it, so the
+threading work has to be measured by a hand-run against the real data.
+
+### `detect` is measured through `imfilter!`, not directly
+
+Benchmarking `detect` itself would mean reconstructing a `Tracker`, a background stack and an open
+`Video` from package internals — and would need rewriting by exactly the change it exists to
+judge. What the threading question actually turns on is one call: `imfilter!` over a search window
+a few tens of pixels wide. That is benchmarked directly, against the serial algorithm on the same
+window and kernel, with the tracker's own shapes (a 10 px target, a 21×21 window) and no internals
+in the way. End-to-end throughput is covered by the `"macro"` group.
+
+The first run answered the question it was built for. On 32 threads, `CPUThreads` and `CPU1` come
+out within 1% of each other (282 μs against 284 μs): the innermost layer of parallelism buys
+nothing at this window size. The same run priced the other open question — the bisection inverse
+costs 274 μs per 640 pixels against 3.3 μs for the forward map, about 428 ns a pixel, which is the
+budget a polynomial root has to beat.

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"
+FFMPEG = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+Fromage = "f7d2997e-1be8-4771-a487-05d70e6e0672"
+ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[sources]
+Fromage = {path = ".."}

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,129 @@
+# Benchmarks for Fromage. The runner is a choice; `SUITE` is the contract.
+#
+#     benchpkg Fromage --rev=main,my-branch          # AirspeedVelocity, from the repo root
+#     using PkgBenchmark; judge("Fromage", "my-branch", "main")
+#
+# Two tiers, because one sampling strategy cannot serve both:
+#
+#   "micro" — pure, in-memory, deterministic. BenchmarkTools samples these properly and the
+#             numbers mean what they say, so this is the tier that can settle a design question.
+#   "macro" — whole pipelines: decoding video, spawning ffprobe, encoding an .mp4. A sampled
+#             statistic here would measure the filesystem and the scheduler, not the code, so
+#             each runs once and reports wall clock and allocations. Read them as a regression
+#             tripwire, not as a measurement — and not at all on a busy machine.
+#
+# What this cannot tell you: nothing here touches a network filesystem. The threading shape in
+# `track` and `main` exists to survive EAGAIN on a CIFS share under concurrent ffmpeg reads, and
+# that is a contention failure no local benchmark reproduces. Measuring it needs a hand-run
+# against the real data (#68, candidate 06).
+
+using BenchmarkTools
+using ColorTypes: Gray
+using ComputationalResources: CPU1, CPUThreads
+using FixedPointNumbers: N0f8
+using Fromage: Fromage, main
+using Fromage.PawsomeTracker: track
+using ImageFiltering: Algorithm, Kernel, NoPad, imfilter!
+using OffsetArrays: OffsetMatrix
+using PaddedViews: PaddedView
+using StaticArrays: SVector
+
+const R = Fromage.Rectifications
+const PT = Fromage.PawsomeTracker
+
+# The test suite's synthetic media, so a benchmark and a test measure the same fixture.
+include(joinpath(@__DIR__, "..", "test", "fixtures.jl"))
+using .Fixtures
+
+const DATADIR = mktempdir()
+const SUITE = BenchmarkGroup()
+
+# ---------------------------------------------------------------------------
+# micro — pure and deterministic
+# ---------------------------------------------------------------------------
+
+# A realistic barrel distortion: two radial coefficients with k₁ < 0, so the map folds and
+# `inv_lens_distortion` takes its bracketed branch rather than the doubling one. The fold sits at
+# r ≈ 1.09, well outside the sampled radii, so no point is clamped.
+const K = (-0.28, 0.09)
+const RSTAR = R._first_critical(K)
+# one row of a 640-wide frame in normalised image coordinates — the granularity the warp works at
+const PIXELS = [SVector(0.0, x) for x in range(-0.6, 0.6; length = 640)]
+
+lens = SUITE["micro"]["lens distortion"] = BenchmarkGroup()
+lens["_first_critical"] = @benchmarkable R._first_critical($K)
+lens["forward, 640 px"] = @benchmarkable [R.lens_distortion(v, $K) for v in $PIXELS]
+lens["inverse, 640 px"] = @benchmarkable [R.inv_lens_distortion(v, $K, $RSTAR) for v in $PIXELS]
+
+# An only_scale rectification: no video is read when `diagnostic` is nothing, so this is a pure
+# pair of coordinate maps.
+const RECT = R.Rectification("unread.mp4", 0, 0.05, 1.0, missing, missing, 640, 480)
+const IMAGE_PTS = vec([SVector(float(r), float(c)) for r in 1:16:480, c in 1:16:640])
+const REAL_PTS = map(RECT.image2real, IMAGE_PTS)
+
+geom = SUITE["micro"]["geometry"] = BenchmarkGroup()
+geom["image2real, 1200 pts"] = @benchmarkable map($(RECT.image2real), $IMAGE_PTS)
+geom["real2image, 1200 pts"] = @benchmarkable map($(RECT.real2image), $REAL_PTS)
+
+# The AprilTag ground geometry, on the four-tag layout the tests use: all closed-form, no detector.
+const HOMOG = SVector{2, Float64}[SVector(1400, 880), SVector(1500, 890), SVector(1490, 970), SVector(1395, 965)]
+const HOMOG_DST = SVector{2, Float64}[SVector(0, 0), SVector(96, 0), SVector(96, 96), SVector(0, 96)]
+const TAG = [SVector(c[1] + 400, c[2] - 400) for c in PT.CANON]
+
+tags = SUITE["micro"]["apriltag geometry"] = BenchmarkGroup()
+tags["homography_dlt"] = @benchmarkable PT.homography_dlt($HOMOG, $HOMOG_DST)
+tags["place_square"] = @benchmarkable PT.place_square($TAG)
+
+# Candidate 06 asks whether `imfilter!(CPUThreads(...))` earns its keep on a search window a few
+# tens of pixels wide. Measured against the serial algorithm on the same window and the same
+# kernel, with no tracker internals in the way, so the comparison outlives whatever `detect`
+# becomes. The shapes come from the tracker's own defaults: a 10 px target, a 21×21 window.
+const SIGMA = PT.get_sigma(10)
+const DOG = -1 * Kernel.DoG((SIGMA, SIGMA))
+const RADII = (10, 10)
+const FRAME_SZ = (480, 640)
+const PAD = UnitRange.(1 .- (RADII .+ size(DOG)), FRAME_SZ .+ (RADII .+ size(DOG)))
+const FILT_IN = PaddedView(zero(Gray{Float32}),
+    Gray{Float32}.(reshape(range(0, 1; length = prod(FRAME_SZ)), FRAME_SZ)), PAD)
+const FILT_OUT = OffsetMatrix(Matrix{Float64}(undef, length.(PAD)), PAD)
+const WINDOW = UnitRange.((240, 320) .- RADII, (240, 320) .+ RADII)
+
+filt = SUITE["micro"]["detection filter"] = BenchmarkGroup()
+filt["DoG over a 21x21 window, CPUThreads"] =
+    @benchmarkable imfilter!(CPUThreads(Algorithm.FIR()), $FILT_OUT, $FILT_IN, $DOG, NoPad(), $WINDOW)
+filt["DoG over a 21x21 window, CPU1"] =
+    @benchmarkable imfilter!(CPU1(Algorithm.FIR()), $FILT_OUT, $FILT_IN, $DOG, NoPad(), $WINDOW)
+
+# ---------------------------------------------------------------------------
+# macro — whole pipelines, one shot each
+# ---------------------------------------------------------------------------
+
+# The shared disc fixture: 100×100, 2 s at 25 fps, lossless, analytic trajectory.
+const TARGET = joinpath(DATADIR, only(first(make_target_video(DATADIR, "bench_target"))))
+
+# A complete data folder for `main`: one checkerboard calibration and one run over the disc. The
+# CSVs deliberately omit n_corners and target_width, so both gateways' defaults are exercised.
+const MAIN_DIR = let dir = mktempdir()
+    png = joinpath(@__DIR__, "..", "test", "VerifyRectifications", "fixtures", "checkerboard.png")
+    make_checkerboard_video(joinpath(dir, "board.mp4"), png)
+    target, _ = make_target_video(dir, "run")
+    write(joinpath(dir, "calibs.csv"),
+        "calibration_id,file,type,extrinsic,start,stop,checker_size\nc1,board.mp4,video,1,0,4,4\n")
+    write(joinpath(dir, "runs.csv"),
+        "calibration_id,file,start_location\nc1,$(only(target)),\"(55, 50)\"\n")
+    dir
+end
+
+# `main` writes results_dir relative to the working directory, so each run gets a fresh one.
+run_main() = cd(() -> main(MAIN_DIR; rectification_defaults = (n_corners = (5, 8),),
+                                     tracking_defaults = (target_width = 10,)), mktempdir())
+
+pipe = SUITE["macro"] = BenchmarkGroup()
+pipe["track, 50 frames"] =
+    @benchmarkable(track($TARGET; start_location = (55, 50), target_width = 10),
+                   samples = 1, evals = 1)
+pipe["track + diagnostic video"] =
+    @benchmarkable(track($TARGET; start_location = (55, 50), target_width = 10,
+                         diagnostic_file = joinpath(mktempdir(), "d.mp4")),
+                   samples = 1, evals = 1)
+pipe["main, one calibration + one run"] = @benchmarkable(run_main(), samples = 1, evals = 1)


### PR DESCRIPTION
The instrument the remaining ledger candidates need. Two of them turn on questions the test suite cannot answer: whether a polynomial root beats 200 bisection steps *per pixel* (13), and whether threading the innermost filter earns its keep (06).

## Shape

`benchmark/benchmarks.jl` defines a single BenchmarkTools `SUITE` — all a runner has to agree on, so the choice stays reversible. AirspeedVelocity (`benchpkg Fromage --rev=main,my-branch`) and PkgBenchmarks both read it. **Not wired into CI**: the suite already runs a full ffmpeg workload on every PR, and benchmark numbers off a shared runner would be noise presented as data.

**`"micro"`** — pure, in-memory, deterministic. BenchmarkTools samples these properly and the numbers mean what they say.

| | |
|---|---|
| lens distortion | `_first_critical`, forward and inverse over 640 px |
| geometry | `image2real` / `real2image` over 1200 points |
| apriltag geometry | `homography_dlt`, `place_square` |
| detection filter | the DoG over a 21×21 window, `CPUThreads` vs `CPU1` |

**`"macro"`** — whole pipelines: `track` over the shared disc fixture, the same with a diagnostic video, and `main` over a one-calibration/one-run data folder. These decode video, spawn ffprobe and encode an `.mp4`, so a sampled statistic would be measuring the filesystem and the scheduler. Each runs once (`samples = 1, evals = 1`) and reports wall clock and allocations — a regression tripwire, not a measurement.

Fixtures come from `test/fixtures.jl`, which #75 made importable, so a benchmark and a test measure the same synthetic media.

## Two findings from the first run

Machine: 32 threads.

| benchmark | result |
|---|---|
| DoG, 21×21 window, `CPUThreads` | 281.6 μs |
| DoG, 21×21 window, `CPU1` | 284.2 μs |

**Within 1% of each other, on 32 threads.** That is direct evidence for candidate 06's claim that the innermost layer of parallelism buys nothing at this window size — the layer can go on its own merits, before touching the semaphore or the nesting above it.

| benchmark | result |
|---|---|
| `lens_distortion`, 640 px | 3.3 μs |
| `inv_lens_distortion`, 640 px | 273.8 μs |

**The inverse costs 82× the forward map**, about 428 ns a pixel. That is the budget a companion-matrix eigensolve has to beat for candidate 13, and it is now a number rather than an argument.

Macro baseline: `track` 251 ms, `track` + diagnostic 420 ms, `main` 1.095 s.

## What it deliberately does not do

**`detect` is measured through `imfilter!`, not directly.** Benchmarking `detect` itself would mean reconstructing a `Tracker`, a background stack and an open `Video` from package internals — and would need rewriting by exactly the change it exists to judge. The threading question turns on one call, so that call is benchmarked directly with the tracker's own shapes and no internals in the way. End-to-end is covered by the macro tier.

**Nothing here touches a network filesystem.** The threading shape exists to survive EAGAIN on a CIFS share under concurrent ffmpeg reads — a contention failure, not a throughput number. 06 still needs a hand-run against the real data; this harness does not change that.

## Verification

`julia --project=benchmark` runs both tiers; `[sources] Fromage = {path = ".."}` is set and verified to resolve to the working tree from a deleted `Manifest.toml`, so the harness is reproducible from what is committed. `benchmark/Manifest.toml` is gitignored (`benchmark/*.json` already was).

I have **not** run `benchpkg` or `benchmarkpkg` here — neither is installed, and I did not want a benchmark runner doing git operations on the working repo. The file follows the standard `SUITE` convention both consume; worth one confirming run before relying on the rev-to-rev comparison.

**1025 / 1025 pass**, unchanged — this PR touches no file the package or its tests load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7