### PR TITLE
only_track names its diagnostics by run_id, like main (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -46,6 +46,18 @@ Before that, the writer's framerate was left at VideoIO's default 24 while every
 written, so a 50 fps track played back at 0.48× speed. Hence `DIAGNOSTIC_SPEEDUP`/`DIAGNOSTIC_FPS`
 and the frame decimation.
 
+### `only_track` names its diagnostics by `run_id` (#68)
+
+It used to name them by loop index — `1.mp4`, `2.mp4` — while `main` named the same files by
+`run_id`. The two agree only when the csv names no runs, because `resolve_run_ids!` then imputes
+the row number as the id. As soon as a csv names its runs, or `run_ids` filters one out, the index
+no longer matches any row the user is looking at: asking for run `r5` alone wrote `1.mp4`.
+
+The duplication is what let the two drift. `main`, `only_track` and `only_rectify` now open through
+the same two functions — `gather_rectifications` and `gather_runs`, each making the results
+directory, loading the csv the caller named, and applying the id filter — so there is one place for
+that opening to be right.
+
 ### Diagnostics are `.mp4`, not `.ts`
 
 The old `.ts` segments defaulted to MPEG-2 at libavcodec's default *average* bitrate — constant

--- a/src/main.jl
+++ b/src/main.jl
@@ -45,6 +45,25 @@ function filter_ids!(xs, requested, id, what)
     return filter!(x -> getfield(x, id) ∈ requested, xs)
 end
 
+# The three entry points open the same way: make the results directory, load the csv the caller
+# named, and drop everything the caller did not ask for. The loaders return the annotated DataFrame
+# only under `strict = false`; on the default strict path they return the run/rectification vectors
+# — asserted so the union doesn't leak downstream (JET flags e.g. `length(::DataFrame)` otherwise).
+function gather_rectifications(data_path, calibs_file, defaults, calibration_ids = nothing)
+    mkpath(results_dir)
+    cs = load_rectifications(joinpath(data_path, calibs_file); defaults,
+        issues_dir = joinpath(results_dir, "issues"))::Vector{RectificationMethod}
+    return filter_ids!(cs, calibration_ids, :calibration_id, "calibration_ids")
+end
+
+function gather_runs(data_path, runs_file, defaults, run_ids = nothing)
+    mkpath(results_dir)
+    rs = load_runs(joinpath(data_path, runs_file); defaults)::Vector{Run}
+    return filter_ids!(rs, run_ids, :run_id, "run_ids")
+end
+
+build_rectifications(cs) = @showprogress desc = "Building rectifications" tmap(Rectification, cs)
+
 # `rectification_defaults`/`tracking_defaults` globally replace the hardcoded defaults of the
 # tuning parameters (e.g. `rectification_defaults = (n_corners = (5, 8), blur = 0)`,
 # `tracking_defaults = (target_width = 60,)`). The hierarchy is: csv cell → these kwargs → the
@@ -53,16 +72,8 @@ end
 # the named runs (only the rectifications those runs reference are built).
 function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.csv",
         rectification_defaults = (;), tracking_defaults = (;), run_ids = nothing)
-
-    mkpath(results_dir)
-
-    # The loaders return the annotated DataFrame only under `strict = false`; on the default strict
-    # path they return the run/rectification vectors — asserted so the union doesn't leak
-    # downstream (JET flags e.g. `length(::DataFrame)` otherwise).
-    cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults, issues_dir = joinpath(results_dir, "issues"))::Vector{RectificationMethod}
-    rs = load_runs(joinpath(data_path, runs_file); defaults = tracking_defaults)::Vector{Run}
-
-    filter_ids!(rs, run_ids, :run_id, "run_ids")
+    cs = gather_rectifications(data_path, calibs_file, rectification_defaults)
+    rs = gather_runs(data_path, runs_file, tracking_defaults, run_ids)
 
     run_calib_ids = [r.calibration_id for r in rs]
     filter!(c -> c.calibration_id ∈ run_calib_ids, cs)
@@ -74,7 +85,7 @@ function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.c
 
     calibs = DataFrame(calibration_id = calib_ids, c = cs)
 
-    calibs.rectification .= @showprogress desc = "Building rectifications" tmap(Rectification, calibs.c)
+    calibs.rectification .= build_rectifications(calibs.c)
 
     runs = DataFrame(calibration_id = [r.calibration_id for r in rs], run_id = [r.run_id for r in rs], r = rs)
     leftjoin!(runs, calibs, on = :calibration_id)
@@ -89,29 +100,18 @@ function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.c
     tforeach(save2csv, runs.run_id, runs.run)
 
     return runs
-
 end
 
+# Each diagnostic is named by its run's `run_id`, as in `main` — which is the row number when the
+# csv names no runs, and the run's own name when it does. Numbering by position instead would
+# rename every file as soon as `run_ids` filtered one out.
 function only_track(data_path::String; runs_file = "runs.csv", tracking_defaults = (;), run_ids = nothing)
-
-    mkpath(results_dir)
-
-    rs = load_runs(joinpath(data_path, runs_file); defaults = tracking_defaults)::Vector{Run}
-
-    filter_ids!(rs, run_ids, :run_id, "run_ids")
-
-    runs = @showprogress desc = "Building runs" tmap((i, r) -> track(r; diagnostic_file = joinpath(results_dir, "$i.mp4")), 1:length(rs), rs)
-
-    return runs
+    rs = gather_runs(data_path, runs_file, tracking_defaults, run_ids)
+    return @showprogress desc = "Building runs" tmap(
+        r -> track(r; diagnostic_file = joinpath(results_dir, string(r.run_id, ".mp4"))), rs)
 end
 
 function only_rectify(data_path::String; calibs_file = "calibs.csv", rectification_defaults = (;), calibration_ids = nothing)
-    mkpath(results_dir)
-
-    cs = load_rectifications(joinpath(data_path, calibs_file); defaults = rectification_defaults, issues_dir = joinpath(results_dir, "issues"))::Vector{RectificationMethod}
-
-    filter_ids!(cs, calibration_ids, :calibration_id, "calibration_ids")
-
-    calibs = @showprogress desc = "Building rectifications" tmap(Rectification, cs)
-
+    cs = gather_rectifications(data_path, calibs_file, rectification_defaults, calibration_ids)
+    return build_rectifications(cs)
 end

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -136,7 +136,8 @@ end
     p = SVector(7.0, 11.0)
     @test rect.real2image(rect.image2real(p)) ≈ p   # the two maps are inverses
 
-    # no rectification involved: raw pixel coordinates, one raw-view diagnostic per run (numbered)
+    # no rectification involved: raw pixel coordinates, one raw-view diagnostic per run, named by
+    # run_id — which this csv does not set, so it is the imputed row number
     runs = cd(() -> Fromage.only_track(dir; tracking_defaults = (target_width = 10,)), outdir)
     @test length(runs) == 1
     _, ij = only(runs)
@@ -145,6 +146,20 @@ end
     diag = joinpath(outdir, "results_dir", "1.mp4")
     @test isfile(diag)
     @test filesize(diag) > 0
+
+    # When the csv does name its runs, the diagnostic carries that name — and keeps it when a
+    # filter drops an earlier run. Numbering by position instead would name this file "1.mp4",
+    # which matches no row in the csv the user is looking at.
+    open(joinpath(dir, "named.csv"), "w") do io
+        println(io, "run_id,calibration_id,file,start_location,background_length")
+        println(io, "solo_a,c1,$(only(target)),\"(55, 50)\",0")
+        println(io, "solo_b,c1,$(only(target)),\"(55, 50)\",0")
+    end
+    named_out = mktempdir()
+    cd(() -> Fromage.only_track(dir; runs_file = "named.csv", run_ids = ["solo_b"],
+                                tracking_defaults = (target_width = 10,)), named_out)
+    @test isfile(joinpath(named_out, "results_dir", "solo_b.mp4"))
+    @test !isfile(joinpath(named_out, "results_dir", "1.mp4"))
 end
 
 @testset "an id filter that matches nothing is reported, not obeyed silently (#21)" begin


### PR DESCRIPTION
Candidate **16** from the [ledger](https://claude.ai/code/artifact/5a74f007-2af9-4c11-ba19-7b585fc40366). It was filed as deduplication. The duplication turned out to be hiding a bug, and that is the actual reason to land this.

## The bug

`only_track` named each diagnostic by **loop index** — `1.mp4`, `2.mp4` — while `main` named the same files by `run_id`.

The two agree only when the csv names no runs, because `resolve_run_ids!` then imputes the row number as the id. That is why every existing test passed. As soon as a csv *does* name its runs, or `run_ids` filters one out, the index matches no row the user is looking at:

```julia
only_track(dir; run_ids = ["r5"])   # wrote results_dir/1.mp4
```

Now named by `run_id`, the same as `main`. The new test writes a two-run csv, asks for the second run only, and requires `solo_b.mp4` to exist and `1.mp4` not to.

## The deduplication that let it drift

`main`, `only_track` and `only_rectify` each repeated `mkpath`, the loader call with its `::Vector{...}` assertion, and `filter_ids!` — with the explanatory comment on only one of the three copies. They now open through two functions, `gather_rectifications` and `gather_runs`: make the results directory, load the csv the caller named, apply the id filter. One place for that opening to be right.

Also: `only_rectify` ended on a bare `calibs = @showprogress …` and a trailing blank line, which read as unfinished. It returns explicitly now. The twice-repeated `@showprogress desc = "Building rectifications" tmap(Rectification, …)` became `build_rectifications`.

## Numbers, and they are bad

**`src/main.jl` is 117 lines before and after. Exactly zero.** `src/` code lines (excluding blanks and comments) go **up by 6**: 2117 → 2123. Two extracted functions cost more `function`/`end`/`return` boilerplate than the duplicated one-liners saved, and `only_track` gained a three-line comment stating the naming invariant.

The estimate was −15. That is the eighth in a row to overshoot and the second to land on the wrong side of zero. **If a line reduction is what you want from candidate 16, this PR does not deliver it** — what it delivers is a user-visible bug fixed, the drift that caused it closed off, and a test that keeps it closed. Your call whether that trade is worth merging.

## Verification

**1027 / 1027 pass** (8m22s with coverage) — up from 1025, the two new naming assertions. `src/main.jl` coverage 96.4% (54/56). Total for the run was 99.03% (1325/1338 coverable lines); I am not presenting that as a change against #75's 96.29%, because the set of instrumented files differed between the two runs and I have not isolated why.

Rebased onto `main` with #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7