### PR TITLE
Rectification builders take keywords, chosen by type (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -117,6 +117,34 @@ negligible.
 
 ## Rectifications
 
+### Rectification builders take keywords, and are chosen by type (#68)
+
+`Rectification(c::Video)` used to unpack its struct into **fifteen positional arguments**, and the
+extrinsics-only variant into eleven — two methods of one function, told apart by nothing but how
+many arguments arrived. The receiving signatures were bare names in a fixed order:
+
+```julia
+Rectification(file, extrinsic, start, stop, temporal_step, yadif, blur, width, height,
+              n_corners, checker_size, aspect, radial_parameters, center, north)
+```
+
+`width`/`height` are both `Int`; `start`/`stop`, both `Float64`; `center`/`north`, both the same
+optional pair. Transposing any of those pairs compiles, runs, and returns a wrong map — the failure
+mode is a subtly rotated or mirrored arena, not an error. The test suite showed the cost directly:
+one call read `R.Rectification(vid, extrinsic_t, missing, missing, Wimg, Himg, …)` with nothing to
+say which `missing` was `yadif` and which was `blur`.
+
+The four builders are now keyword-only and named for what they build — `from_video`,
+`from_extrinsic`, `from_matlab`, `from_scale`, matching the files they already lived in — plus
+`PawsomeTracker.ApriltagRectification`. Arity no longer selects anything; the calibration's type
+does, in `VerifyRectifications/types.jl`, which is the only module that can see both
+`Rectifications` and `PawsomeTracker`. The seven facts every builder needs about the source video
+travel together as `_source(c.source)`.
+
+`Rectifications` declares `function Rectification end` and exports it, but every method lives in
+`VerifyRectifications`: this module owns the concept and the builders, the gateway owns the types
+the dispatch is on.
+
 ### The extrinsics-only rectification is selected by absence, and never flagged
 
 Which constructor a rectification gets is decided *solely* by whether the calibs row has an

--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -254,7 +254,7 @@ function apriltag_image2real(M, center, north, width, height)
 end
 
 # Build the AprilTag rectification from a verified `type = apriltag` calibs row.
-function ApriltagRectification(file, extrinsic, ntags, family, checker_size, center, north, width, height)
+function ApriltagRectification(; file, extrinsic, ntags, family, checker_size, center, north, width, height)
     ref = reference_frame(file, extrinsic, ntags, family, checker_size)
     # Building a rectification has nowhere to put an issue string, so the report becomes a throw
     # here. In the normal pipeline this is unreachable: VerifyRectifications ran

--- a/src/Rectifications/Rectifications.jl
+++ b/src/Rectifications/Rectifications.jl
@@ -45,6 +45,17 @@ include("from_video.jl")
 include("from_matlab.jl")
 include("plotting.jl")
 
+"""
+    Rectification(c; diagnostic = nothing)
+
+The image ↔ real map pair for one verified calibration `c`, chosen by `c`'s type. The methods live
+in `VerifyRectifications`, which owns those types; each reads `c`'s fields and calls one of the
+builders here — `from_video`, `from_extrinsic`, `from_matlab`, `from_scale` — or
+`PawsomeTracker.ApriltagRectification`, by keyword. Declared here because this module owns the
+concept and `Fromage` reaches for the name through it.
+"""
+function Rectification end
+
 export Rectification
 
 end

--- a/src/Rectifications/from_matlab.jl
+++ b/src/Rectifications/from_matlab.jl
@@ -4,7 +4,7 @@
 # angle conventions) is ported untouched from CameraCalibrations.jl's `loadMAT`. Real-world
 # coordinates come out in the `.mat`'s own world units (whatever square size the MATLAB
 # calibration was given), so the unit scale is 1.
-function Rectification(file, extrinsic, matlab_file, extrinsic_index, aspect, center, north, width, height; diagnostic = nothing)
+function from_matlab(; file, extrinsic, matlab_file, extrinsic_index, aspect, center, north, width, height, diagnostic = nothing)
     dict = matread(matlab_file)
     # the Camera Calibrator wraps everything in a single top-level struct (e.g. "cameraParams");
     # unwrap until the calibration fields are at hand (VerifyRectifications already verified they

--- a/src/Rectifications/from_scale.jl
+++ b/src/Rectifications/from_scale.jl
@@ -1,4 +1,8 @@
-function Rectification(file, extrinsic, scale, aspect, center, north, width, height; diagnostic = nothing)
+# The simplest rectification: a uniform `scale` (real-world units per pixel) and the pixel aspect
+# ratio, with no camera model at all. `file`/`extrinsic` are used only to render the diagnostic
+# frame. Keyword-only, like every builder here — see the note above the dispatchers in
+# VerifyRectifications/types.jl.
+function from_scale(; file, extrinsic, scale, aspect, center, north, width, height, diagnostic = nothing)
     image2real = LinearMap(scale * SDiagonal(SVector{2, Float64}(1, aspect)))
     real2image = inv(image2real)
     center = default_center(center, width, height)

--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -177,7 +177,8 @@ end
 # however, are read off a GUI (Gimp, Photoshop) by hand, so they are:
 # 1. pixel coordinates with width first and height second, (w, h)
 # 2. at an aspect ratio of 1, whatever `aspect` says
-function Rectification(file, extrinsic, start, stop, temporal_step, yadif, blur, width, height, n_corners, checker_size, aspect, radial_parameters, center, north; diagnostic = nothing)
+function from_video(; file, extrinsic, start, stop, temporal_step, yadif, blur, width, height,
+        n_corners, checker_size, aspect, radial_parameters, center, north, diagnostic = nothing)
     vf = _vf(yadif, blur)
     intrinsic_task = Threads.@spawn extract_intrinsics(file, start, stop, temporal_step, vf, width, height, n_corners)
     extrinsic_corners = get_corners(file, extrinsic, vf, width, height, n_corners)
@@ -188,7 +189,7 @@ function Rectification(file, extrinsic, start, stop, temporal_step, yadif, blur,
 end
 
 """
-    Rectification(file, extrinsic, yadif, blur, width, height, n_corners, checker_size, aspect, center, north)
+    from_extrinsic(; file, extrinsic, yadif, blur, width, height, n_corners, checker_size, aspect, center, north)
 Extrinsics-only rectification: no intrinsic-calibration window exists, so the camera pose (and
 focal length) are fit from the single extrinsic frame with every lens-distortion coefficient fixed
 at zero — the map is effectively the board-plane homography, disregarding lens aberrations.
@@ -199,7 +200,8 @@ than flagged; everything else (`yadif`, `blur`, `n_corners`, `checker_size`, `as
 `north`) is honoured as usual. Filling only one of the two bounds is rejected upstream. See
 DESIGN-HISTORY.md for why this asymmetry is deliberate.
 """
-function Rectification(file, extrinsic, yadif, blur, width, height, n_corners, checker_size, aspect, center, north; diagnostic = nothing)
+function from_extrinsic(; file, extrinsic, yadif, blur, width, height, n_corners, checker_size,
+        aspect, center, north, diagnostic = nothing)
     vf = _vf(yadif, blur)
     extrinsic_corners = get_corners(file, extrinsic, vf, width, height, n_corners)
     ismissing(extrinsic_corners) && error("no corners detected at extrinsic time stamp")

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -1,6 +1,7 @@
 module VerifyRectifications
 
-using ..Rectifications: get_corners, _vf, extrinsic_gray_frame
+using ..Rectifications: get_corners, _vf, extrinsic_gray_frame, from_extrinsic, from_matlab,
+    from_scale, from_video
 import ..Rectifications: Rectification
 using ..PawsomeTracker: PawsomeTracker, ApriltagRectification
 using FileIO: FileIO

--- a/src/VerifyRectifications/types.jl
+++ b/src/VerifyRectifications/types.jl
@@ -67,24 +67,44 @@ elseif row.type == "apriltag"
 else # can only be matlab
     MATLAB(source(row), row.calibration_id, row.matlab_file, row.extrinsic_index)
 end
-Rectification(c::Video; kwargs...) = Rectification(c.source.file, c.source.extrinsic, c.start, c.stop, c.temporal_step, c.yadif, c.blur, c.source.width, c.source.height, c.n_corners, c.checker_size, c.source.aspect, c.radial_parameters, c.source.center, c.source.north; kwargs...)
+
+# `Rectification(c)` turns one verified calibs row into its image ↔ real map pair. Which builder
+# runs is chosen by the row's type, which the parser already decided — not by how many arguments
+# get passed, and every argument travels by name. That matters here more than it usually does:
+# `width`/`height`, `start`/`stop` and `center`/`north` are same-typed neighbours, so a
+# transposition would produce a silently wrong map rather than an error.
+
+# The six facts every builder needs. `aspect` is not among them: the AprilTag path recovers metric
+# scale from the tags themselves and has no pixel-aspect correction to make, so the three builders
+# that do need it ask for it by name.
+_source(s::Source) = (; s.file, s.extrinsic, s.center, s.north, s.width, s.height)
+
+Rectification(c::Video; kwargs...) =
+    from_video(; _source(c.source)..., c.source.aspect, c.start, c.stop, c.temporal_step, c.yadif,
+        c.blur, c.n_corners, c.checker_size, c.radial_parameters, kwargs...)
 
 # A Video without a calibs window (both bounds blank ⇒ Video{Missing}) is an extrinsics-only
 # rectification: the pose and focal length come from the single extrinsic frame and lens aberrations
 # are disregarded. temporal_step/radial_parameters play no role and are deliberately NOT flagged
-# when filled anyway (see the extrinsics-only Rectification docstring); only one bound filled is
-# still an error (verify_pair).
-Rectification(c::Video{Missing}; kwargs...) = Rectification(c.source.file, c.source.extrinsic, c.yadif, c.blur, c.source.width, c.source.height, c.n_corners, c.checker_size, c.source.aspect, c.source.center, c.source.north; kwargs...)
+# when filled anyway (see the `from_extrinsic` docstring); only one bound filled is still an error
+# (verify_pair).
+Rectification(c::Video{Missing}; kwargs...) =
+    from_extrinsic(; _source(c.source)..., c.source.aspect, c.yadif, c.blur, c.n_corners,
+        c.checker_size, kwargs...)
 
 # A MATLAB rectification reads the camera model (intrinsics, distortion, and the pose picked by
 # extrinsic_index) from the .mat file; the source video supplies the frame size (already
 # cross-checked against the .mat's ImageSize) and the extrinsic timestamp for the diagnostics.
-Rectification(c::MATLAB; kwargs...) = Rectification(c.source.file, c.source.extrinsic, c.matlab_file, c.extrinsic_index, c.source.aspect, c.source.center, c.source.north, c.source.width, c.source.height; kwargs...)
+Rectification(c::MATLAB; kwargs...) =
+    from_matlab(; _source(c.source)..., c.source.aspect, c.matlab_file, c.extrinsic_index, kwargs...)
 
-Rectification(c::Scale; kwargs...) = Rectification(c.source.file, c.source.extrinsic, c.scale, c.source.aspect, c.source.center, c.source.north, c.source.width, c.source.height; kwargs...)
+Rectification(c::Scale; kwargs...) =
+    from_scale(; _source(c.source)..., c.source.aspect, c.scale, kwargs...)
 
 # An AprilTag rectification builds its shared reference from the extrinsic frame (detecting the tags
 # and fitting the metric map) and carries the centre/north gauge. There is no diagnostic image to
 # render at build time — the top-down diagnostic is produced per-run during tracking — so `kwargs`
 # (e.g. `diagnostic`) are ignored.
-Rectification(c::Apriltag; kwargs...) = ApriltagRectification(c.source.file, c.source.extrinsic, c.apriltags, c.family, c.checker_size, c.source.center, c.source.north, c.source.width, c.source.height)
+Rectification(c::Apriltag; kwargs...) =
+    ApriltagRectification(; _source(c.source)..., ntags = c.apriltags, c.family, c.checker_size)
+

--- a/test/Rectifications/test_from_matlab.jl
+++ b/test/Rectifications/test_from_matlab.jl
@@ -2,7 +2,7 @@
 # the fields the way MATLAB does (the loader ports CameraCalibrations.jl's loadMAT, conventions
 # included), using fronto-parallel pinholes (R = 0, t = (0, 0, Z)) whose geometry is known in
 # closed form: at the arena plane one world unit spans f/Z pixels, so ratio = Z/f.
-@testset "matlab-based Rectification" begin
+@testset "matlab-based rectification" begin
     W, H = 640, 480
     f, Z = 500.0, 100.0
     matdir = mktempdir()
@@ -16,9 +16,14 @@
         path
     end
     mat = writemat(joinpath(matdir, "consistent.mat"))
+    # Every case below is this call with one field varied. Naming them is what the keyword-only
+    # builder buys: the test now says which `missing` is the centre and which is the north.
+    rectify(; kw...) = R.from_matlab(; file = "unused.mp4", extrinsic = 0.0, matlab_file = mat,
+        extrinsic_index = 1, aspect = 1.0, center = missing, north = missing,
+        width = W, height = H, kw...)
 
     @testset "fronto-parallel geometry is recovered" begin
-        rect = R.Rectification("unused.mp4", 0.0, mat, 1, 1.0, missing, missing, W, H)
+        rect = rectify()
         @test rect.ratio ≈ Z / f                     # one world unit spans f/Z pixels
         # center defaults to the frame centre — here the principal point — so the origin sits there
         @test rect.image2real(SVector(H / 2, W / 2)) ≈ [0, 0] atol = 1e-8
@@ -32,20 +37,20 @@
     end
 
     @testset "extrinsic_index selects the pose" begin
-        rect2 = R.Rectification("unused.mp4", 0.0, mat, 2, 1.0, missing, missing, W, H)
+        rect2 = rectify(extrinsic_index = 2)
         @test rect2.ratio ≈ 2Z / f                   # the second pose sits twice as far away
     end
 
     @testset "radial distortion from the file round-trips" begin
         matk = writemat(joinpath(matdir, "distorted.mat"); k = [0.1, 0.0])
-        rect = R.Rectification("unused.mp4", 0.0, matk, 1, 1.0, missing, missing, W, H)
+        rect = rectify(matlab_file = matk)
         for q in (SVector(100.0, 120.0), SVector(300.0, 500.0))
             @test rect.real2image(rect.image2real(q)) ≈ q atol = 1e-6
         end
     end
 
     @testset "center/north define a rigid reference frame" begin
-        rect = R.Rectification("unused.mp4", 0.0, mat, 1, 1.0, SVector(320.0, 240.0), SVector(320.0, 100.0), W, H)
+        rect = rectify(center = SVector(320.0, 240.0), north = SVector(320.0, 100.0))
         p0 = SVector(100.0, 120.0)
         # centering + northing is rigid: a one-pixel step still spans Z/f world units
         @test norm(rect.image2real(p0 + SVector(1.0, 0.0)) - rect.image2real(p0)) ≈ Z / f atol = 1e-6

--- a/test/Rectifications/test_from_scale.jl
+++ b/test/Rectifications/test_from_scale.jl
@@ -1,4 +1,4 @@
-# The scale-based `Rectification` constructor (from_scale.jl): a pure affine rectification with no
+# `from_scale` (from_scale.jl): a pure affine rectification with no
 # camera calibration. Without `diagnostic` it never touches the video, so we test it as a transform.
 # (The `diagnostic` branch reuses `warp_extrinsic` + FileIO.save, already exercised by Tier 3.)
 
@@ -6,8 +6,8 @@
 
     @testset "scales pixel steps into real units" begin
         for (scale, aspect) in ((0.5, 1.0), (2.0, 1.0), (0.5, 1.4))
-            rect = R.Rectification("unused.mp4", 0.0, scale, aspect,
-                missing, missing, 640, 480)
+            rect = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, scale, aspect,
+                center = missing, north = missing, width = 640, height = 480)
             image2real = rect.image2real
             p0 = SVector(100.0, 120.0)
             dx = image2real(p0 + SVector(1.0, 0.0)) - image2real(p0)
@@ -23,8 +23,10 @@
 
     @testset "center defaults to frame centre" begin
         # center = missing must reproduce the explicit frame-centre pixel exactly
-        i2r_def = R.Rectification("unused.mp4", 0.0, 0.5, 1.0, missing, missing, 640, 480).image2real
-        i2r_exp = R.Rectification("unused.mp4", 0.0, 0.5, 1.0, SVector(320.0, 240.0), missing, 640, 480).image2real
+        scaled(; kw...) = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, scale = 0.5, aspect = 1.0,
+            center = missing, north = missing, width = 640, height = 480, kw...)
+        i2r_def = scaled().image2real
+        i2r_exp = scaled(center = SVector(320.0, 240.0)).image2real
         for p in (SVector(0.0, 0.0), SVector(50.0, -30.0), SVector(640.0, 480.0))
             @test i2r_def(p) ≈ i2r_exp(p)
         end
@@ -32,8 +34,8 @@
 
     @testset "northing preserves scale (rigid rotation)" begin
         # supplying a north point rotates the world frame; distances must be preserved
-        i2r = R.Rectification("unused.mp4", 0.0, 0.5, 1.0,
-            SVector(320.0, 240.0), SVector(320.0, 100.0), 640, 480).image2real
+        i2r = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, scale = 0.5, aspect = 1.0,
+            center = SVector(320.0, 240.0), north = SVector(320.0, 100.0), width = 640, height = 480).image2real
         p0 = SVector(100.0, 120.0)
         @test hypot((i2r(p0 + SVector(1.0, 0.0)) - i2r(p0))...) ≈ 0.5
         @test hypot((i2r(p0 + SVector(0.0, 1.0)) - i2r(p0))...) ≈ 0.5

--- a/test/Rectifications/test_rectification.jl
+++ b/test/Rectifications/test_rectification.jl
@@ -63,12 +63,15 @@
 
         # frames 0..10 (t = 0.05..1.05) drive the intrinsics; frame 11 (t = 1.15) is the extrinsic
         extrinsic_t, start, stop, step = 1.15, 0.05, 1.05, 0.1
-        common = (extrinsic_t, start, stop, step, missing, missing, Wimg, Himg,
-                  n_corners, checker_size, 1.0, 1)
+        # The two `missing`s used to be positional here, and nothing said which was `yadif` and
+        # which was `blur`.
+        common = (; file = vid, extrinsic = extrinsic_t, start, stop, temporal_step = step,
+                  yadif = missing, blur = missing, width = Wimg, height = Himg, n_corners,
+                  checker_size, aspect = 1.0, radial_parameters = 1)
 
         diag = mktempdir()
         # center = missing ⇒ defaults to the frame centre (the intended behaviour)
-        rect = R.Rectification(vid, common..., missing, missing; diagnostic = diag)
+        rect = R.from_video(; common..., center = missing, north = missing, diagnostic = diag)
         image2real = rect.image2real
         ext_corners = R.get_corners(vid, extrinsic_t, missing, Wimg, Himg, n_corners)
 
@@ -90,8 +93,9 @@
             # no calibs window: pose + focal fit from the extrinsic frame alone, distortion pinned
             # at zero. The rendered clip is a pure pinhole with the principal point at the frame
             # centre, so the single-view fit (which fixes the principal point there) is well-posed.
-            rect0 = R.Rectification(vid, extrinsic_t, missing, missing, Wimg, Himg,
-                                    n_corners, checker_size, 1.0, missing, missing)
+            rect0 = R.from_extrinsic(; file = vid, extrinsic = extrinsic_t, yadif = missing,
+                                     blur = missing, width = Wimg, height = Himg, n_corners,
+                                     checker_size, aspect = 1.0, center = missing, north = missing)
             real_pts = map(rect0.image2real, ext_corners)
             spacing = R.checker_size_pixel(real_pts, n_corners)
             @test spacing ≈ checker_size rtol = 0.05
@@ -100,7 +104,8 @@
 
         @testset "center defaults to frame centre" begin
             # explicit frame-centre pixel must reproduce the center = missing result exactly
-            i2r_explicit = R.Rectification(vid, common..., SVector(Wimg / 2, Himg / 2), missing).image2real
+            i2r_explicit = R.from_video(; common..., center = SVector(Wimg / 2, Himg / 2),
+                                        north = missing).image2real
             @test all(a ≈ b for (a, b) in zip(map(image2real, ext_corners),
                                               map(i2r_explicit, ext_corners)))
         end

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -254,7 +254,8 @@ end
     vid, groundpath, sl, nframes = make_apriltag_video(dir, "bigpan"; nframes = 300, amp = 55, occlude = occluded)
     file = joinpath(dir, vid)
     # extrinsic at t = 0.2 s (frame 6): the frames around t = 0 have the occluded tag
-    rect = Fromage.PawsomeTracker.ApriltagRectification(file, 0.2, 4, "tag36h11", 8, missing, missing, 480, 480)
+    rect = Fromage.PawsomeTracker.ApriltagRectification(; file = file, extrinsic = 0.2, ntags = 4, family = "tag36h11",
+        checker_size = 8, center = missing, north = missing, width = 480, height = 480)
     ts, xy = Fromage.PawsomeTracker.track(file; rectification = rect, start_location = sl, target_width = 12)
     @test length(xy) == nframes
     @test findall(ismissing, xy) == occluded            # a lost tag ⇒ missing, exactly there
@@ -279,7 +280,8 @@ end
     vidB, _, slB, nB = make_apriltag_video(dir, "segB"; nframes = 40)
     fileA, fileB = joinpath(dir, vidA), joinpath(dir, vidB)
     # the reference comes from segment A's extrinsic frame and serves both segments
-    rect = Fromage.PawsomeTracker.ApriltagRectification(fileA, 0.2, 4, "tag36h11", 8, missing, missing, 480, 480)
+    rect = Fromage.PawsomeTracker.ApriltagRectification(; file = fileA, extrinsic = 0.2, ntags = 4, family = "tag36h11",
+        checker_size = 8, center = missing, north = missing, width = 480, height = 480)
 
     diag = joinpath(dir, "segmented.mp4")
     sls = Vector{Union{Missing, NTuple{2, Int}}}([slA, slB])
@@ -316,7 +318,8 @@ end
     vid, _, sl, _ = make_apriltag_video(dir, "lbl"; nframes = 40)
     file = joinpath(dir, vid)
     PT = Fromage.PawsomeTracker
-    rect = PT.ApriltagRectification(file, 0.2, 4, "tag36h11", 8, missing, missing, 480, 480)
+    rect = PT.ApriltagRectification(; file = file, extrinsic = 0.2, ntags = 4, family = "tag36h11",
+        checker_size = 8, center = missing, north = missing, width = 480, height = 480)
 
     # the label is the diagnostic file's name — which `main` sets to the run_id
     dia = PT.diagnose_apriltag(joinpath(dir, "run7.mp4"), rect.reference, true, 25)
@@ -370,8 +373,10 @@ end
     @test PT.apriltag_extrinsic_issue(corrupt, 0.2, 4, "tag36h11", 8) isa String
 
     # ...while the rectification builder, which has nowhere to put a message, still throws
-    @test_throws ErrorException PT.ApriltagRectification(corrupt, 0.2, 4, "tag36h11", 8, missing, missing, 480, 480)
-    @test_throws ErrorException PT.ApriltagRectification(file, 0.2, 99, "tag36h11", 8, missing, missing, 480, 480)
+    @test_throws ErrorException PT.ApriltagRectification(; file = corrupt, extrinsic = 0.2, ntags = 4, family = "tag36h11",
+        checker_size = 8, center = missing, north = missing, width = 480, height = 480)
+    @test_throws ErrorException PT.ApriltagRectification(; file = file, extrinsic = 0.2, ntags = 99, family = "tag36h11",
+        checker_size = 8, center = missing, north = missing, width = 480, height = 480)
 end
 
 @testset "diagnostic video: multi-run, mixed calibrations" begin


### PR DESCRIPTION
Candidate **08** from the [ledger](https://claude.ai/code/artifact/5a74f007-2af9-4c11-ba19-7b585fc40366).

## The problem

`Rectification(c::Video)` unpacked its struct into **fifteen positional arguments**; the extrinsics-only variant into eleven. Two methods of one function, told apart by nothing but how many arguments arrived — into signatures that were bare names in a fixed order:

```julia
Rectification(file, extrinsic, start, stop, temporal_step, yadif, blur, width, height,
              n_corners, checker_size, aspect, radial_parameters, center, north)
```

`width`/`height` are both `Int`. `start`/`stop`, both `Float64`. `center`/`north`, the same optional pair. Transposing any of them compiles, runs, and returns a subtly rotated or mirrored arena — a silent wrong answer, not an error.

The test suite showed the cost better than any argument could:

```julia
rect0 = R.Rectification(vid, extrinsic_t, missing, missing, Wimg, Himg, n_corners, ...)
```

Nothing there says which `missing` is `yadif` and which is `blur`.

## The change

Four keyword-only builders, named for what they build — `from_video`, `from_extrinsic`, `from_matlab`, `from_scale`, matching the files they already lived in — plus `PawsomeTracker.ApriltagRectification`. Arity now selects nothing; the calibration's type does, in `VerifyRectifications/types.jl`, the only module that can see both `Rectifications` and `PawsomeTracker`:

```julia
Rectification(c::Video; kwargs...) =
    from_video(; _source(c.source)..., c.source.aspect, c.start, c.stop, c.temporal_step,
        c.yadif, c.blur, c.n_corners, c.checker_size, c.radial_parameters, kwargs...)
```

`Rectifications` declares `function Rectification end` and exports it while every method lives in `VerifyRectifications`: this module owns the concept and the builders, the gateway owns the types the dispatch is on.

The tests改 read as tables of overrides now:

```julia
rectify(; kw...) = R.from_matlab(; file = "unused.mp4", extrinsic = 0.0, matlab_file = mat,
    extrinsic_index = 1, aspect = 1.0, center = missing, north = missing, width = W, height = H, kw...)

rect2 = rectify(extrinsic_index = 2)
rect  = rectify(center = SVector(320.0, 240.0), north = SVector(320.0, 100.0))
```

## One bug I introduced, and what caught it

My first `_source` carried all seven `Source` fields including `aspect` — but the AprilTag builder takes no `aspect` (it recovers metric scale from the tags themselves). The AprilTag end-to-end test failed with:

```
MethodError: no method matching ApriltagRectification(; …, aspect::Float64, …)
  got unsupported keyword argument "aspect"
```

Named, at the call, pointing at the exact argument. Under the positional scheme the equivalent slip — one extra value shifting everything after it — would have been a `MethodError` on arity if lucky, or a wrong map if not. `_source` now carries the six facts every builder shares, and the three that need `aspect` ask for it by name.

Worth recording that my pre-flight smoke ran `quality`, `Rectifications` and `VerifyRectifications` but not the end-to-end suite, which is where this surfaced. The full run caught it.

## Numbers

**src/ code lines +20** (2123 → 2143) against an estimated **−30**. Most of the addition is call sites that now name their arguments, and tests that read as tables. Per your note, I'm not treating that as a problem — but the ledger's estimate was wrong again, and in the same direction as 10 and 16.

**1027 / 1027 pass** (8m18s with coverage). Coverage 98.96% (1326/1340); `VerifyRectifications/types.jl` 100%.

Rebased onto `main` with #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7