### PR TITLE
A run's arity is data, not a type (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -258,12 +258,40 @@ stack built. The union now names only what works. `RowCol` is absent on purpose 
 method: that is the internal form a *later* segment's start takes in the vector method, carried
 over from the previous segment's last coordinate, not something a caller supplies.
 
-### A `MultiRun`'s imputed start location must not mutate the run (#23)
+### A run's arity is data, not a type (#68)
+
+`Run` used to be abstract over `SingleRun` (scalar `file`/`start`/`stop`/`start_location`) and
+`MultiRun` (the same as aligned vectors). The split cost two `track` methods, two `get_duration`s,
+a separate `impute_start_location`, and a constructor branching on `nrow(g) == 1`.
+
+The comment above it said the arity was "materialized in the *type*, so `track` dispatches on it
+with no runtime branch". **That was wrong.** `load_runs` returns `Run[Run(g) for g in …]` — a
+`Vector{Run}` whose element type was *abstract*, so every `track(r)` from `main` was a dynamic
+dispatch anyway. Collapsing to one concrete struct is what actually delivers the static call:
+`isconcretetype(Run)` is now true, and so is the vector's element type.
+
+Routing a one-segment run through the vector `PawsomeTracker.track` was checked to be equivalent
+before the change, not after: identical timestamps (same values *and* same
+`StepRangeLen{Float64, TwicePrecision…}` type), identical coordinates and type, and a diagnostic
+video of the same dimensions, frame count and rate. The encoded bytes differ, but a control of two
+identical *scalar* runs differs too — H.264 here is not byte-reproducible, so that comparison
+proves nothing either way. Cost: within noise on wall clock, +16 allocations out of ~1000,
+identical peak memory.
+
+What it gives up: a single run's video is `only(r.files)` rather than `r.file`, and the type no
+longer states "exactly one segment". Two call sites in `src/`, so the price is small — but it is a
+price, and `verify_run_consistency!` is now the only thing asserting the shape.
+
+### A run's imputed start location must not mutate the run (#23)
 
 Assigning the resolved first-segment location back into `r.start_locations` meant the first
 `track` call wrote its `center` into the run, so a later call with a *different* `center` silently
 kept the first one — and the frame-centre fallback became unreachable too. A `Run` describes what
 the CSV said; tracking it leaves it alone.
+
+This used to be structurally impossible for a one-segment run, whose `start_location` was an
+immutable scalar field. Since the arity collapse it is a one-element vector taking the same
+imputation path, so the guarantee is asserted at both arities.
 
 ### Anamorphic video
 

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -53,8 +53,8 @@ function load_runs(data_path, file; strict = true, defaults = (;))
         return df
     end
 
-    # Clean: group the rows by :run_id, each group materialized into its concrete run type
-    # (SingleRun / MultiRun). The comprehension pins the element type to the abstract `Vector{Run}`.
+    # Clean: group the rows by :run_id, each group materialized into one `Run`. `Run` is concrete,
+    # so this vector's element type is too, and `track(r)` is statically dispatched.
     return Run[Run(g) for g in groupby(df, :run_id)]
 end
 

--- a/src/VerifyRuns/types.jl
+++ b/src/VerifyRuns/types.jl
@@ -1,20 +1,19 @@
-# A verified run: everything `PawsomeTracker.track` needs, guaranteed not to error. A run's arity —
-# a single video, or several segment videos sharing a `run_id` — is materialized in the *type*, so
-# `track` dispatches on it with no runtime branch and grouping yields a `Vector{Run}` of concrete
-# types directly.
+# A verified run: everything `PawsomeTracker.track` needs, guaranteed not to error. A run is one or
+# more segment videos sharing a `run_id`, held as aligned per-segment vectors in CSV order — a
+# single-video run being the one-element case. A non-first segment's `start_location` may be
+# `missing` (the target continues from where the previous one ended).
 #
 # `run_id` names the run and `calibration_id` names the rectification it uses (Fromage joins the two
 # on it, so a run without one has nothing to rectify against); neither is forwarded to `track`. The
-# run-level values shared by both arities live in `Source`: the `track` parameters
-# (`target_width`…`scale`) plus the video's stored-pixel `width`/`height` and sample aspect ratio
-# `sar` as probed by ffprobe, which segments of a multi-segment run are verified to agree on
-# (display width = `width × sar`). The per-segment fields stay in the concrete types: `SingleRun`
-# carries scalars, `MultiRun` aligned per-segment vectors in CSV order, where a non-first segment's
-# `start_location` may be `missing` (the target continues from where the previous one ended).
+# run-level values live in `Source`: the `track` parameters (`target_width`…`scale`) plus the
+# video's stored-pixel `width`/`height` and sample aspect ratio `sar` as probed by ffprobe, which
+# the segments of a multi-segment run are verified to agree on (display width = `width × sar`).
 #
 # `stop`/`fps` are concrete, imputed from the probed video. `window_size` stays `missing` when the
 # CSV omitted it, and `track(::Run)` imputes it from `target_width`/`fps`/duration.
-abstract type Run end
+#
+# One concrete type, not an abstract `Run` over `SingleRun`/`MultiRun`: a run's arity is data, not a
+# kind of thing. See DESIGN-HISTORY.md for what the split cost and what it turned out not to buy.
 
 struct Source
     target_width::Float64
@@ -29,17 +28,7 @@ struct Source
     sar::Rational{Int}
 end
 
-struct SingleRun <: Run
-    run_id::String
-    calibration_id::String
-    source::Source
-    file::String
-    start::Float64
-    stop::Float64
-    start_location::Union{Missing, NTuple{2, Int}}
-end
-
-struct MultiRun <: Run
+struct Run
     run_id::String
     calibration_id::String
     source::Source
@@ -59,35 +48,29 @@ function Source(g::AbstractDataFrame)
         g.background_length[1], width, height, g.sar[1])
 end
 
-# Build the typed run for one `run_id` group (rows in CSV order): one row → `SingleRun`, several →
-# `MultiRun`. The identity columns are read off the first row, which verify_run_consistency!
-# guaranteed the segments agree on. The `collect(T, …)` narrows the per-segment columns from the
-# `allowmissing!`-widened `Union{Missing, T}` back to `T` — safe because only issue-free rows reach
-# here — and materializes the group's column views into owned vectors.
+# Build the run for one `run_id` group (rows in CSV order, one row per segment). The identity
+# columns are read off the first row, which verify_run_consistency! guaranteed the segments agree
+# on. The `collect(T, …)` narrows the per-segment columns from the `allowmissing!`-widened
+# `Union{Missing, T}` back to `T` — safe because only issue-free rows reach here — and materializes
+# the group's column views into owned vectors.
 function Run(g::AbstractDataFrame)
-    source = Source(g)
-    if nrow(g) == 1
-        SingleRun(g.run_id[1], g.calibration_id[1], source, g.file[1], g.start[1], g.stop[1], g.start_location[1])
-    else
-        MultiRun(g.run_id[1], g.calibration_id[1], source,
-                 collect(String, g.file),
-                 collect(Float64, g.start),
-                 collect(Float64, g.stop),
-                 Vector{Union{Missing, NTuple{2, Int}}}(g.start_location))
-    end
+    Run(g.run_id[1], g.calibration_id[1], Source(g),
+        collect(String, g.file),
+        collect(Float64, g.start),
+        collect(Float64, g.stop),
+        Vector{Union{Missing, NTuple{2, Int}}}(g.start_location))
 end
 
-# The run-level keywords shared by both `track` methods (`window_size` is imputed separately, by
+# The run-level keywords forwarded to `track` (`window_size` is imputed separately, by
 # impute_window_size).
 function shared_kw(r::Run)
     s = r.source
     (; s.target_width, s.darker_target, s.fps, s.initial_search_factor, s.scale, s.background_length)
 end
 
-# Drive `PawsomeTracker.track` from a verified run — the scalar method for a one-segment
-# `SingleRun`, the vector method for a multi-segment `MultiRun`. The returned coordinates are
-# (row, col) in *stored*-frame pixels of the original (unscaled) video; for an anamorphic video the
-# display-space x is col × sar.
+# Drive `PawsomeTracker.track` from a verified run. The returned coordinates are (row, col) in
+# *stored*-frame pixels of the original (unscaled) video; for an anamorphic video the display-space
+# x is col × sar.
 #
 # The run's (or first segment's) start_location falls back to `center` (e.g. the rectification's
 # scene centre) and then to the frame's centre, so `track` always gets a concrete starting point.
@@ -107,40 +90,30 @@ function get_window(target_width, fps, m, duration)
     max(ws1, ws2)
 end
 
-get_duration(r::SingleRun) = r.stop - r.start
-get_duration(r::MultiRun) = mapreduce(-, +, r.stops, r.starts)
+get_duration(r::Run) = mapreduce(-, +, r.stops, r.starts)
 
 function impute_window_size(r)
     s = r.source
     return @coalesce s.window_size get_window(s.target_width, s.fps, min(s.height, s.width), get_duration(r))
 end
 
-# For an AprilTag run the calibration's `center` is a pixel in the (moved) extrinsic frame, not the
-# run frame, so it can't seed the tracker's start: fall straight back to the run's own
-# start_location, a missing one becoming the frame-centre search inside `track`. Every other
-# rectification shares the run frame, so its centre is a valid fallback.
-function track(r::SingleRun; center = missing, rectification = nothing, kwargs...)
-    start_location = if rectification isa ApriltagRectification
-        r.start_location
-    else
-        @coalesce r.start_location center frame_center(r)
-    end
-    track(r.file; start = r.start, stop = r.stop, start_location, window_size = impute_window_size(r), shared_kw(r)..., rectification, kwargs...)
-end
-
 # The per-segment start locations with the first segment's fallbacks applied, as a vector `track`
 # can take. The `copy` is what makes this a query rather than an edit: a `Run` describes what the
 # csv said, and tracking it must leave it alone (#23).
-function impute_start_location(r::MultiRun, center)
+function impute_start_location(r::Run, center)
     sls = copy(r.start_locations)
     sls[1] = @coalesce sls[1] center frame_center(r)
     return sls
 end
 
-function track(r::MultiRun; center = missing, rectification = nothing, kwargs...)
-    # AprilTag: use the per-segment start_locations as-is (see the SingleRun note); each segment
-    # relocates on its own. Other rectifications keep the centre fallback for the first segment.
+# For an AprilTag run the calibration's `center` is a pixel in the (moved) extrinsic frame, not the
+# run frame, so it can't seed the tracker's start: the per-segment start_locations are used as-is,
+# a missing one becoming the frame-centre search inside `track`, and each segment relocates on its
+# own. Every other rectification shares the run frame, so its centre is a valid fallback for the
+# first segment.
+function track(r::Run; center = missing, rectification = nothing, kwargs...)
     sls = rectification isa ApriltagRectification ? r.start_locations : impute_start_location(r, center)
-    track(r.files; start = r.starts, stop = r.stops, start_location = sls, window_size = impute_window_size(r), shared_kw(r)..., rectification, kwargs...)
+    track(r.files; start = r.starts, stop = r.stops, start_location = sls,
+        window_size = impute_window_size(r), shared_kw(r)..., rectification, kwargs...)
 end
 

--- a/test/VerifyRuns/test_happy.jl
+++ b/test/VerifyRuns/test_happy.jl
@@ -4,7 +4,7 @@
         @test clean(runs)
         @test runs isa Vector{VR.Run}
         @test length(runs) == 1
-        @test only(runs) isa VR.SingleRun
+        @test length(only(runs).files) == 1
     end
 
     @testset "several valid runs, strict returns them without throwing" begin
@@ -15,6 +15,6 @@
                      strict = true)
         @test runs isa Vector{VR.Run}
         @test length(runs) == 3
-        @test all(r -> r isa VR.SingleRun, runs)   # each is a distinct one-file run
+        @test all(r -> length(r.files) == 1, runs)   # each is a distinct one-file run
     end
 end

--- a/test/VerifyRuns/test_parsing.jl
+++ b/test/VerifyRuns/test_parsing.jl
@@ -19,7 +19,7 @@
         runs = check("p_id_none.csv",
                      [runrow(run_id = missing), runrow(run_id = "   "), runrow(run_id = missing)])
         @test clean(runs)
-        @test all(r -> r isa VR.SingleRun, runs)
+        @test all(r -> length(r.files) == 1, runs)
         @test [r.run_id for r in runs] == ["1", "2", "3"]
 
         # all rows named ⇒ clean, ids used as-is
@@ -67,12 +67,12 @@
         runs = check("p_defaults.csv", [runrow()])   # only run_id + calibration_id + file set
         @test clean(runs)
         r = only(runs)
-        @test r isa VR.SingleRun                      # one file ⇒ scalar-field run type
+        @test length(r.files) == 1                    # one csv row ⇒ one segment
         @test r.calibration_id        == "c"   # the baseline's id (required, never defaulted)
-        @test r.start                        == 0.0
+        @test only(r.starts)                 == 0.0
         @test r.source.target_width          == 25.0
         @test r.source.window_size           === missing
-        @test r.start_location               === missing
+        @test only(r.start_locations)        === missing
         @test r.source.darker_target         == true
         @test r.source.initial_search_factor == 4.0
         @test r.source.scale                 == 1.0
@@ -81,7 +81,7 @@
     @testset "start/stop accept seconds and HH:MM:SS" begin
         @test clean(check("p_secs.csv",  [runrow(start = "1.0", stop = "3.5")]))
         @test clean(check("p_clock.csv", [runrow(start = "00:00:01", stop = "00:00:03")]))
-        @test only(check("p_clock2.csv", [runrow(start = "00:00:02")])).start == 2.0
+        @test only(only(check("p_clock2.csv", [runrow(start = "00:00:02")])).starts) == 2.0
     end
 
     @testset "whitespace is trimmed from string fields" begin

--- a/test/VerifyRuns/test_segments.jl
+++ b/test/VerifyRuns/test_segments.jl
@@ -6,8 +6,7 @@
         @test clean(runs)
         @test length(runs) == 1
         r = only(runs)
-        @test r isa VR.MultiRun                # two segments ⇒ vector-field run type
-        @test length(r.files) == 2
+        @test length(r.files) == 2             # two csv rows ⇒ two segments
         @test basename.(r.files) == ["a.mp4", "b.mp4"]
         @test r.starts == [0.0, 1.0]
         @test r.stops  == [4.0, 7.0]
@@ -20,7 +19,7 @@
                                           runrow(run_id = "y", file = ART.b)])
         @test clean(runs)
         @test length(runs) == 2
-        @test all(r -> r isa VR.SingleRun, runs)
+        @test all(r -> length(r.files) == 1, runs)
         @test [r.run_id for r in runs] == ["x", "y"]
     end
 
@@ -46,12 +45,12 @@
         @test flagged(df, 2, "run segments disagree on dimension")
     end
 
-    @testset "a MultiRun's segments must agree on calibration_id (required on every row)" begin
-        # all segments share the same calibration_id ⇒ clean, carried onto the MultiRun
+    @testset "a run's segments must agree on calibration_id (required on every row)" begin
+        # all segments share the same calibration_id ⇒ clean, carried onto the run
         runs = check("seg_cal_same.csv", [runrow(run_id = "s", file = ART.a, calibration_id = "cal_1"),
                                           runrow(run_id = "s", file = ART.b, calibration_id = "cal_1")])
         @test clean(runs)
-        @test only(runs) isa VR.MultiRun
+        @test length(only(runs).files) == 2
         @test only(runs).calibration_id == "cal_1"
 
         # omitting it is not allowed: every such segment row is flagged at parse time
@@ -91,7 +90,7 @@
         runs = check("seg_nomutate.csv", [runrow(run_id = "m", file = ART.a, start_location = missing),
                                           runrow(run_id = "m", file = ART.b)])
         r = only(runs)
-        @test r isa VR.MultiRun
+        @test length(r.files) == 2
         before = copy(r.start_locations)
         @test all(ismissing, before)                  # nothing to impute from the csv
 
@@ -110,5 +109,19 @@
         sls3 = VR.impute_start_location(r, missing)
         @test sls3[1] == VR.frame_center(r)
         @test isequal(r.start_locations, before)
+    end
+
+    @testset "...including a one-segment run (#23, #68)" begin
+        # A single-video run used to carry its start_location as an immutable scalar field, so this
+        # could not go wrong at arity 1. It is a one-element vector now, and every run takes the
+        # same imputation path, so the guarantee has to be asserted here too.
+        r = only(check("seg_nomutate_one.csv", [runrow(run_id = "o", start_location = missing)]))
+        @test length(r.files) == 1
+        @test all(ismissing, r.start_locations)
+        sls = VR.impute_start_location(r, (7, 9))
+        @test sls == [(7, 9)]
+        @test sls !== r.start_locations
+        @test all(ismissing, r.start_locations)          # the run itself is untouched
+        @test VR.impute_start_location(r, (11, 13)) == [(11, 13)]   # so a second call is free
     end
 end

--- a/test/VerifyRuns/test_tracking.jl
+++ b/test/VerifyRuns/test_tracking.jl
@@ -125,7 +125,7 @@
         runs = check("t_seg.csv", rows)
         @test clean(runs)
         r = only(runs)
-        @test r isa VR.MultiRun
+        @test length(r.files) == 3
         _, ij = VR.track(r)
         @test length(ij) == 50
         @test tracking_rmse(ij, seg_exp) < 1

--- a/test/VerifyRuns/test_video_metadata.jl
+++ b/test/VerifyRuns/test_video_metadata.jl
@@ -1,7 +1,7 @@
 @testset "video metadata (probe + imputation)" begin
     @testset "stop and fps are imputed from the video" begin
         r = only(check("vm_impute.csv", [runrow()]))   # stop & fps omitted
-        @test r.stop ≈ VIDEO_DURATION atol = 0.1        # ← container duration (5 s)
+        @test only(r.stops) ≈ VIDEO_DURATION atol = 0.1 # ← container duration (5 s)
         @test r.source.fps == 30.0                      # ← video frame rate
     end
 
@@ -14,7 +14,7 @@
 
     @testset "CSV values win over imputation" begin
         r = only(check("vm_explicit.csv", [runrow(stop = "3", fps = "15")]))
-        @test r.stop == 3.0
+        @test only(r.stops) == 3.0
         @test r.source.fps == 15.0
     end
 


### PR DESCRIPTION
Candidate **11**. You asked me to check whether it even works before doing it — it does, but **the ledger's argument for it was backwards**, so the justification here is different.

## The split bought nothing

`types.jl` claimed the arity was "materialized in the *type*, so `track` dispatches on it with no runtime branch and grouping yields a `Vector{Run}` of concrete types directly."

`load_runs` returns `Run[Run(g) for g in …]`. `Run` was **abstract**, so that vector's element type was abstract, and every `track(r)` call from `main` was a **dynamic** dispatch. The split cost two `track` methods, two `get_duration`s, a separate `impute_start_location` and a constructor branch — to buy a dispatch that never happened.

Collapsing to one concrete struct is what actually delivers it: `isconcretetype(Run)` is now `true`, and so is the element type of what `load_runs` returns.

## Equivalence, checked before the change rather than after

Routing a one-segment run through the vector `PawsomeTracker.track`:

| | scalar `track(f)` | vector `track([f])` |
|---|---|---|
| timestamps | identical values **and** type (`StepRangeLen{Float64, TwicePrecision…}`) | ✓ |
| coordinates | identical values **and** type (`Vector{SVector{2,Float32}}`) | ✓ |
| diagnostic video | 640×360, 25 frames, 25 fps | identical |

The encoded diagnostic **bytes** differ — but a control of two identical *scalar* runs differs too (4647 vs 4677 bytes). H.264 is not byte-reproducible here, so that comparison proves nothing either way; without the control it would have looked like a real regression.

Cost: within noise on wall clock (123.1 ms vs 115.0 ms), **+16 allocations out of ~1000**, identical peak memory.

## The test pass you asked for

Eight `isa VR.SingleRun` / `isa VR.MultiRun` assertions were change-detectors of exactly the kind candidate 03 was meant to clear before structural work — and missed. They now assert what a caller can observe, `length(r.files)`, which is **strictly stronger** in one case: `@test r isa VR.MultiRun` in `test_tracking.jl` never checked the segment count at all, and now asserts 3.

Five singular field accesses became `only(r.starts)` / `only(r.stops)` / `only(r.start_locations)`. One of those I initially missed because my grep assumed the variable was named `r`; the suite caught it, and I then searched by field name instead.

**One genuine gap closed.** #23 — imputing a start location must not mutate the run — was *structurally impossible* for a one-segment run, whose `start_location` was an immutable scalar field. It is a one-element vector now taking the same imputation path, so that failure mode is newly reachable at arity 1. Added a one-segment case to the #23 testset with a comment saying why it exists.

I deliberately did **not** add `@test isconcretetype(eltype(runs))`. It is the point of the change, but it is a type property rather than observable behaviour, and asserting it would pin the design the way the `isa SingleRun` tests just did. It belongs in `DESIGN-HISTORY.md`, where it now is.

## What it gives up

A single run's video is `only(r.files)` rather than `r.file`, and the type no longer states "exactly one segment" — `verify_run_consistency!` is now the only thing asserting the shape. Two call sites in `src/`, so the price is small, but it is a price.

## Numbers

**src/ code lines −23** (2152 → 2129) against an estimated −50. First negative delta in eleven candidates. Test code +9 (the new #23 case).

**1032 / 1032 pass** (7m10s with coverage), up five. Coverage 99.03%; `VerifyRuns/types.jl` 100%.

Candidate 07 is now nearly free: `track(r::Run)` only ever calls the vector method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7