### PR TITLE
One track body, not four (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -250,6 +250,39 @@ Zero turns background subtraction off, but the stack itself stays, because it is
 source of the current frame. It holds 2 slices rather than 1: a single-slice stack has no valid
 linear-interpolation stencil along the slice axis.
 
+### One `track` body, not four (#68)
+
+`track` had two methods — one video and several — and each carried an AprilTag branch and an
+ordinary branch. All four resolved `window_size` from `missing` the same way, computed `dia_fps`
+the same way (comment included, twice, verbatim), opened and `finally`-closed the diagnostic, and
+stitched the timestamps with the same two lines.
+
+The vector method is now the implementation and the single-video method is a wrapper around a
+one-element vector. That was checked to be equivalent before the change, not after: identical
+timestamps (same values *and* the same `StepRangeLen{Float64, TwicePrecision…}` type), identical
+coordinates and type, and a diagnostic video of the same dimensions, frame count and rate. Cost:
+within noise on wall clock, +16 allocations out of ~1000. The AprilTag path keeps its exact
+guarantee under test — `findall(ismissing, xy) == occluded` pins where a lost tag reports `missing`,
+through the wrapper.
+
+The keyword the wrapper still declares itself is `start_location`, because its type annotation is
+load-bearing (see below).
+
+### What was deliberately *not* merged
+
+The AprilTag and ordinary branches still stand apart, and the last line of each still differs:
+
+```julia
+isnothing(rectification) ? (ts, ij) : (ts, map(rectification.image2real, ij))   # ordinary
+_apply_image2real(rectification.image2real, reduce(vcat, segs))                # AprilTag
+```
+
+`_apply_image2real` is missing-tolerant and would cover both — but only by widening the ordinary
+path's return element type from `SVector{2, Float64}` to `Union{Missing, SVector{2, Float64}}`, for
+every run that can never produce a `missing`. The two branches also track with different functions
+(`track_apriltag` vs `track_one`), hold different element types, and differ on whether segments
+chain their start locations. One `if` is the honest shape.
+
 ### `start_location`'s declared type is exactly what is supported (#18)
 
 `CartesianIndex{2}` sat in the keyword's `Union` with no `get_guess` method behind it, so a call

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -369,62 +369,25 @@ selects the H.264 encoder) is given, an annotated diagnostic video is written th
 $(DIAGNOSTIC_SPEEDUP)× real time; a `rectification` also renders it top-down instead of as the
 raw frame.
 """
-function track(
-        file::AbstractString;
-        start::Real = 0,
-        stop::Real = get_duration(file),
-        target_width::Real = 25,
+# A single video is a one-segment run, so the vector method below is the implementation and this is
+# just the spelling most callers want. Passing a one-element vector was verified to give identical
+# timestamps and coordinates — same values and same types — as the separate body this replaces, at
+# no measurable cost. See DESIGN-HISTORY.md.
+function track(file::AbstractString; start::Real = 0, stop::Real = get_duration(file),
         # The union is exactly what is supported (#18). `RowCol` is absent on purpose despite having
         # a method: that is the internal form a *later* segment's start takes in the vector method,
         # carried over from the previous segment's last coordinate, not something a caller supplies.
-        start_location::Union{Missing, NTuple{2, Int}} = missing,
-        window_size::Union{Missing, Int, NTuple{2, Int}} = round(Int, 2target_width),
-        darker_target::Bool = true,
-        fps::Real = get_framerate(file),
-        diagnostic_file::Union{Nothing, AbstractString} = nothing,
-        initial_search_factor::Real=4,
-        scale::Real = 1,
-        background_length::Integer = DEFAULT_BACKGROUND_LENGTH,
-        rectification = nothing # rectification object
-    )
-
-    # `missing` means "use the default", like a blank csv cell: resolve it up front so the
-    # `Missing` never reaches fix_window_size (which has no method for it).
-    window_size = ismissing(window_size) ? round(Int, 2target_width) : window_size
-
-    # The diagnostic declares the rate its frames actually arrive at, which is knowable only from
-    # the video — hence the probe; `Video` derives the same stride from the same rule (#55).
-    dia_fps = effective_fps(get_framerate(file), fps)
-
-    # AprilTag mode (drone footage): the rectification carries the shared reference and detector
-    # family; register out camera motion, track, and return metric ground coordinates with the
-    # rectification's centre/north gauge applied. The AprilTag diagnostic (top-down rectified) is created
-    # here and shared with track_apriltag.
-    if rectification isa ApriltagRectification
-        dia = diagnose_apriltag(diagnostic_file, rectification.reference, darker_target, dia_fps)
-        ts, coords = try
-            track_apriltag(file, start, stop, scale * target_width, start_location,
-                round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia,
-                rectification.reference, rectification.family,
-                (rectification.height, rectification.width), scale * initial_search_factor,
-                scale, background_length)
-        finally
-            close(dia)
-        end
-        return (ts, _apply_image2real(rectification.image2real, coords))
-    end
-
-    ts, coords = diagnose(diagnostic_file, darker_target, rectification, dia_fps) do dia
-        track_one(file, start, stop, scale*target_width, start_location, round.(Int, scale .* fix_window_size(window_size)), darker_target, fps, dia, scale * initial_search_factor, scale, background_length)
-    end
-    # With a rectification, return the target in real-world coordinates (its `image2real` applied);
-    # without one, the raw pixel track.
-    return isnothing(rectification) ? (ts, coords) : (ts, map(rectification.image2real, coords))
+        start_location::Union{Missing, NTuple{2, Int}} = missing, kwargs...)
+    return track([file]; start = [start], stop = [stop], start_location = [start_location], kwargs...)
 end
 
 # Apply an image2real map over a track that may hold `missing` frames (AprilTag mode reports
 # `missing` where a frame lost a tag), leaving the missings in place.
 _apply_image2real(f, coords) = map(c -> ismissing(c) ? missing : f(c), coords)
+
+# The segments' timestamps are one clock: the first segment's start and step, running to the total
+# number of samples. Segments share a frame rate (see runs.md), so the step is the same throughout.
+_concat_timestamps(tss) = range(tss[1][1], step = step(tss[1]), length = sum(length, tss))
 
 """
     track(files::AbstractVector; start::AbstractVector, stop::AbstractVector, target_width,
@@ -485,9 +448,7 @@ function track(
         finally
             close(dia)
         end
-        n = sum(length, tss)
-        ts = range(tss[1][1], step = step(tss[1]), length = n)
-        return (ts, _apply_image2real(rectification.image2real, reduce(vcat, segs)))
+        return (_concat_timestamps(tss), _apply_image2real(rectification.image2real, reduce(vcat, segs)))
     end
 
     ijs = Vector{Vector{RowCol}}(undef, nfiles)
@@ -499,11 +460,13 @@ function track(
             end_location = ijs[i][end]
         end
     end
-    n = sum(length, tss)
-    ts = range(tss[1][1], step = step(tss[1]), length = n)
+    ts = _concat_timestamps(tss)
     ij = vcat(ijs...)
 
-    # real-world coordinates when a rectification is given (see the single-file method), else pixels
+    # Real-world coordinates when a rectification is given, else pixels. This stays `map`, not
+    # `_apply_image2real`: no coordinate here can be `missing`, and routing it through the
+    # missing-tolerant version would widen the returned element type to `Union{Missing, …}` for
+    # every ordinary rectified run.
     return isnothing(rectification) ? (ts, ij) : (ts, map(rectification.image2real, ij))
 end
 


### PR DESCRIPTION
Candidate **07**, made nearly free by #80.

## What changed

`track` had two methods — one video and several — and **each carried an AprilTag branch and an ordinary branch**. All four resolved `window_size` from `missing` the same way, computed `dia_fps` the same way (comment included, twice, verbatim), opened and `finally`-closed the diagnostic, and stitched timestamps with the same two lines.

The vector method is now the implementation. The single-video method is a wrapper:

```julia
function track(file::AbstractString; start::Real = 0, stop::Real = get_duration(file),
        start_location::Union{Missing, NTuple{2, Int}} = missing, kwargs...)
    return track([file]; start = [start], stop = [stop], start_location = [start_location], kwargs...)
end
```

`start_location` is the one keyword it still declares itself, because that type annotation is load-bearing (#18) and there is a test that depends on it raising `TypeError`.

The duplicated timestamp stitching became `_concat_timestamps(tss)`.

## Why this is safe

Equivalence was established during #80, before either change: routing a one-segment run through the vector method gives identical timestamps (same values **and** the same `StepRangeLen{Float64, TwicePrecision…}` type), identical coordinates and type, and a diagnostic video of the same dimensions, frame count and rate — at no measurable cost (+16 allocations out of ~1000).

The AprilTag path is the one that worries me most, because `missing` coordinates flow through it. It keeps an exact guarantee under test:

```julia
@test findall(ismissing, xy) == occluded    # a lost tag ⇒ missing, exactly there
```

That test drives the single-file method, so it now exercises the wrapper. The segmented AprilTag branch has its own test too.

## What I deliberately did *not* merge

The AprilTag and ordinary branches still stand apart. Their last lines differ:

```julia
isnothing(rectification) ? (ts, ij) : (ts, map(rectification.image2real, ij))   # ordinary
_apply_image2real(rectification.image2real, reduce(vcat, segs))                # AprilTag
```

`_apply_image2real` is missing-tolerant and *would* cover both — but only by widening the ordinary path's returned element type from `SVector{2, Float64}` to `Union{Missing, SVector{2, Float64}}`, for every run that can never produce a `missing`. The branches also track with different functions (`track_apriltag` vs `track_one`), hold different element types, and differ on whether segments chain their start locations. One `if` is the honest shape — and the reasoning is now in `DESIGN-HISTORY.md` so nobody re-derives it and "simplifies" it into a regression.

## Numbers

**src/ code lines −33** (2129 → 2096) against an estimated −80. `PawsomeTracker.jl` itself goes 513 → 476 lines. Second consecutive negative delta.

**No test changes were needed at all** — which is the clearest payoff yet from candidate 03: a structural refactor of the package's hottest path, and the suite absorbed it without a single edit.

**1032 / 1032 pass** (8m16s with coverage). Coverage 99.02%; `PawsomeTracker.jl` 97.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7