### PR TITLE
Duplicates are found by grouping, not by a shadow index column (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -559,6 +559,30 @@ video can legitimately carry several rectifications differing in, say, `blur` �
 the same identity that disagree on the remaining parameters also get a conflicting-parameters
 issue.
 
+Within a duplicate set the **first row in csv order stands** and every later one is rejected: its
+`:calibration_id` is nulled, so nothing downstream can join a run onto a rectification that was
+thrown out.
+
+### Duplicates are found by grouping, not by a shadow index column (#68)
+
+The check used to copy the frame, append a throwaway `:_row` column carrying each row's index,
+build three boolean masks, split video from non-video, and write the flags back through that index.
+The bookkeeping was the part most likely to be wrong in a way no test would catch.
+
+`parentindices` does the same job for free: the per-type frames are views of `df` all the way down,
+so a group's rows already know where they came from. Both halves are now one `groupby` — the
+non-video half over every column that is not `:calibration_id` or `:issues` (`:type` among them, so
+the two kinds never group together), the video half over its identity key — sharing one
+`reject_duplicates!`.
+
+Equivalence was not taken on faith. Three semantics the old code encoded implicitly and nothing
+asserted — that the duplicate's `:calibration_id` is nulled, that with three identical rows the
+first is kept and *both* others flagged, and that the video and non-video halves are judged
+separately — were written as tests against the old implementation first. Then both implementations
+were run over 4,000 randomly generated frames drawn from a deliberately tiny value space (so
+collisions and `missing`s are common, and a third of rows arrive pre-flagged): identical
+`:calibration_id` and identical `:issues` every time.
+
 ### `comment` is exempt from the irrelevant-column check (#16)
 
 A filled cell in a column the row's `type` never reads is flagged, because it usually means the

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -6,7 +6,7 @@ import ..Rectifications: Rectification
 using ..PawsomeTracker: PawsomeTracker, ApriltagRectification
 using FileIO: FileIO
 using DataFrames: AbstractDataFrame, ByRow, DataFrame, Not, allowmissing!, completecases,
-    dropmissing, groupby, nonunique, nrow, passmissing, select, subset
+    dropmissing, groupby, nonunique, nrow, passmissing, subset
 using ..Gateway: backfill!, blank!, read_per_file!, read_rows, report_issues, resolve_paths!,
     verify!
 using ..Parsing: Parsing, MyTemporal, parseto!

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -342,6 +342,19 @@ function verify_apriltag_extrinsics!(df::AbstractDataFrame, issues_dir)
     end
 end
 
+# Within one group of rectifications that count as the same, the first row in csv order stands and
+# every later one is rejected: its :calibration_id is nulled so nothing downstream can join a run
+# onto a rejected rectification. `parentindices` recovers each row's position in `df` — the group is
+# a view all the way down to it — so the flags land on the right rows with no bookkeeping column.
+# Returns the rejected rows, empty when the group holds only one.
+function reject_duplicates!(df::AbstractDataFrame, g::AbstractDataFrame)
+    nrow(g) > 1 || return Int[]
+    dups = parentindices(g)[1][2:end]
+    df[dups, :calibration_id] .= missing
+    push!.(df[dups, :issues], "duplicate rectification")
+    return dups
+end
+
 function verify_unique_calibrations!(df::AbstractDataFrame)
     # What makes two rectifications "the same" is type-dependent, so partition by :type:
     #   * matlab / only_scale: identical on *every* field (calibration_id and issues aside).
@@ -350,32 +363,26 @@ function verify_unique_calibrations!(df::AbstractDataFrame)
     #     two same-identity rows still *should* agree on them — when they don't, the duplicate also
     #     gets a conflicting-parameters issue.
     # :file is already the canonical resolved path, so equivalent spellings compare equal with no
-    # per-call realpath. The throwaway :_row column carries each row's index in `df`, so flags
-    # written through the type-partitioned views land on the right rows.
-    cmp = select(df, Not(:calibration_id, :issues))
-    cmp._row = collect(axes(cmp, 1))
-    # Compare only rows that are otherwise valid: a row that failed an earlier check has had its
+    # per-call realpath.
+    #
+    # Only rows that are otherwise valid take part: a row that failed an earlier check has had its
     # offending field nulled to `missing`, which can collapse two genuinely distinct rows into a
     # spurious "duplicate". Such rows are already reported anyway.
-    ok = isempty.(df.issues)
-    isvideo = ok .& coalesce.(cmp.type .== "video", false)
+    candidates = @view df[isempty.(df.issues), :]
+    isvideo = coalesce.(candidates.type .== "video", false)
 
-    # matlab / only_scale: nonunique keeps the first occurrence, flags the rest.
-    nonvideo = @view cmp[ok .& .!coalesce.(cmp.type .== "video", false), :]
-    nv_dups = nonvideo._row[nonunique(nonvideo, Not(:_row))]
-    df[nv_dups, :calibration_id] .= missing
-    push!.(df[nv_dups, :issues], "duplicate rectification")
+    # matlab / only_scale: same iff every compared field matches, so the grouping key is every
+    # column that is not :calibration_id or :issues. :type is among them, so the two kinds never
+    # group together.
+    for g in groupby(@view(candidates[.!isvideo, :]), Not(:calibration_id, :issues))
+        reject_duplicates!(df, g)
+    end
 
-    # video: group by identity; within each group keep the first occurrence and reject the rest.
-    identity = [:file, :start, :stop, :extrinsic, :center, :north]
     other = [:checker_size, :n_corners, :temporal_step, :radial_parameters, :blur, :yadif, :aspect]
-    for g in groupby(@view(cmp[isvideo, :]), identity)
-        nrow(g) > 1 || continue
-        g_dups = g._row[2:end]
-        df[g_dups, :calibration_id] .= missing
-        push!.(df[g_dups, :issues], "duplicate rectification")
-        if any(c -> !allequal(g[!, c]), other)
-            push!.(df[g_dups, :issues], "same rectification with conflicting parameters")
+    for g in groupby(@view(candidates[isvideo, :]), [:file, :start, :stop, :extrinsic, :center, :north])
+        dups = reject_duplicates!(df, g)
+        if !isempty(dups) && any(c -> !allequal(g[!, c]), other)
+            push!.(df[dups, :issues], "same rectification with conflicting parameters")
         end
     end
 end

--- a/test/VerifyRectifications/test_structural.jl
+++ b/test/VerifyRectifications/test_structural.jl
@@ -113,6 +113,39 @@
         @test !flagged(df, 2, "duplicate rectification")
     end
 
+    @testset "a duplicate loses its calibration_id" begin
+        # Nulling it is what stops anything downstream joining a run onto a rectification that was
+        # rejected — and it is why the report names the duplicate's row without an id.
+        df, out = load_capturing("s_dupid.csv", [videorow(calibration_id = "keep"),
+                                                 videorow(calibration_id = "drop")])
+        @test df.calibration_id[1] == "keep"
+        @test ismissing(df.calibration_id[2])
+        @test occursin("row 2: duplicate rectification", out)
+    end
+
+    @testset "three identical rows: the first is kept, both others flagged" begin
+        # Which of a duplicate set survives is load-bearing: the first occurrence in csv order.
+        df = check("s_dup3.csv", [videorow(calibration_id = "a"),
+                                  videorow(calibration_id = "b"),
+                                  videorow(calibration_id = "c")])
+        @test !flagged(df, 1, "duplicate rectification")
+        @test flagged(df, 2, "duplicate rectification")
+        @test flagged(df, 3, "duplicate rectification")
+        @test df.calibration_id[1] == "a"
+        @test ismissing(df.calibration_id[2]) && ismissing(df.calibration_id[3])
+    end
+
+    @testset "the video and non-video halves are judged separately" begin
+        # One csv holding both kinds, each with its own duplicate. A video row and a matlab row can
+        # never be duplicates of each other, and each half keeps its own first occurrence.
+        df = check("s_dupmixed.csv", [videorow(calibration_id = "v1"), videorow(calibration_id = "v2"),
+                                      matlabrow(calibration_id = "m1"), matlabrow(calibration_id = "m2")])
+        @test !flagged(df, 1, "duplicate rectification")
+        @test flagged(df, 2, "duplicate rectification")
+        @test !flagged(df, 3, "duplicate rectification")
+        @test flagged(df, 4, "duplicate rectification")
+    end
+
     @testset "negative control: same file+type, different extrinsic is fine" begin
         df = check("s_ok.csv", [videorow(calibration_id = "n1", extrinsic = "00:00:01"),
                                 videorow(calibration_id = "n2", extrinsic = "00:00:03")])


### PR DESCRIPTION
Candidate **14**, done in the order you asked: coverage first, then equivalence, then the change.

## 1. Coverage of the existing branches

Better than the ledger implies. Already covered: video duplicate with matching params, with conflicting `checker_size` / `yadif` / `aspect`, non-duplicate when an identity field differs, `only_scale` and `matlab` duplicate/non-duplicate, path-spelling canonicalisation, and — the one the ledger flagged as risky — **rows already carrying issues being excluded from comparison**.

Three genuine gaps, all in semantics the old code encoded implicitly and nothing asserted. **I wrote these against the old implementation and confirmed them passing before touching anything**, so they characterise existing behaviour rather than the new code:

- **the duplicate's `:calibration_id` is nulled** — which is what stops a run joining onto a rejected rectification, and why the report names the row without an id
- **three identical rows: the first is kept and *both* others flagged** — "which of a duplicate set survives" is exactly what the ledger warned was easy to lose
- **the video and non-video halves are judged separately** — one CSV holding both kinds, each with its own duplicate

## 2. Equivalence

Fixed cases only prove the cases I thought of, so I also ran a **differential test**: the old implementation (copied verbatim) and the new one over the same 4,000 randomly generated frames, drawn from a deliberately tiny value space so collisions and `missing`s are common, with a third of rows arriving pre-flagged.

```
4000/4000 random frames: identical calibration_id and issues
```

Plus the full suite: **1044 / 1044**.

## 3. The change

`parentindices` replaces the shadow column outright. I verified first that it flattens through nested views — a group of `@view(@view(df[mask,:])[mask2,:])` reports indices into `df` itself, in CSV order — which is the whole basis of the refactor.

Both halves become one `groupby` sharing a `reject_duplicates!`:

```julia
candidates = @view df[isempty.(df.issues), :]
isvideo = coalesce.(candidates.type .== "video", false)

for g in groupby(@view(candidates[.!isvideo, :]), Not(:calibration_id, :issues))
    reject_duplicates!(df, g)
end
```

Gone: the frame copy, the `:_row` column, `nonunique`, and two of the three boolean masks.

## Numbers

**src/ code lines ±0** (2096 → 2096) against an estimated −20 — the extracted helper costs what the bookkeeping saved. The gain is that the index arithmetic is gone, not that the file is shorter.

**1044 / 1044 pass** (8m44s with coverage), up 12. Coverage 99.02%.

One thing caught along the way: `parentindices` is owned by `Base`, not `DataFrames`, and importing it from `DataFrames` failed `check_all_explicit_imports_via_owners`. Fixed.

Rebased onto `main` with #81; the `DESIGN-HISTORY.md` edits are in different sections, so it merged cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7