### PR TITLE
Scenario csv names are generated, not invented (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -793,6 +793,29 @@ already built. Timed, the entire generator set costs about 2.5 s — against `qu
 ExplicitImports) at 71 s, `PawsomeTracker` at 56 s and `Rectifications` at 26 s. A fixture cache
 would have added machinery to save well under 1% of the run, so the duplicate encodes stay.
 
+### Scenario csv names are generated, not invented (#68)
+
+Every gateway scenario is loaded as its own csv, so each of 255 `check` calls used to open with a
+hand-invented filename: `v_ncorn11.csv`, `p_center_ovf.csv`, `s_dupyadif.csv`, `t_sar2_c.csv`. The
+name encoded nothing the row beside it did not already say, it had to be unique within `DATADIR`,
+and inventing one was a step between having a case and writing it.
+
+`check(rows; …)` now generates `case_N.csv` from a counter. The two-argument form stays for a test
+that is about the file itself. What each line says is now only the thing being tested:
+
+```julia
+@test flagged(check([videorow(n_corners = (1, 1))]), 1, "n_corners must all be at least 3")
+```
+
+What this deliberately is *not* is a table driver. Turning these into `(override, message)` rows
+would swallow the per-case comments — which are load-bearing arithmetic, not archaeology, and were
+kept for that reason when the test comments were trimmed — and would report a failure against the
+loop rather than the case. The shape was already a table; it just had a redundant column.
+
+Three loops that built their names by interpolation (`"vm_$name.csv"`) gained a `@testset "$name"`
+instead: the variable existed only to name a file, and two of the three loops had no per-iteration
+testset at all, so a failure did not say which case produced it.
+
 ### JET runs only on the pinned Julia minor
 
 JET couples to compiler internals, so a new Julia release must not be able to break the suite

--- a/test/VerifyRectifications/helpers.jl
+++ b/test/VerifyRectifications/helpers.jl
@@ -141,8 +141,14 @@ function check(name, rows; strict = false, header = HEADER, defaults = (;), issu
     VRect.load_rectifications(DATADIR, csv; strict, defaults, issues_dir)
 end
 
+# Each scenario is loaded as its own csv, so the name only has to be unique within DATADIR — the
+# suite generates it. Name one explicitly only when the test is about the file itself.
+const CASE = Ref(0)
+check(rows; kw...) = check("case_$(CASE[] += 1).csv", rows; kw...)
+
 "Like `check`, but also capture what the load prints to stdout. Returns (result, output)."
 load_capturing(name, rows; kw...) = capturing(() -> check(name, rows; kw...))
+load_capturing(rows; kw...) = capturing(() -> check(rows; kw...))
 
 # A clean load returns Vector{RectificationMethod}; a load with issues keeps the df's :issues.
 clean(df) = !hasproperty(df, :issues) || all(isempty, df.issues)

--- a/test/VerifyRectifications/test_defaults.jl
+++ b/test/VerifyRectifications/test_defaults.jl
@@ -2,33 +2,33 @@
     # The hierarchy under test: csv cell → defaults kwarg → hardcoded/probed value.
 
     @testset "kwarg fills a blank cell; a csv cell wins" begin
-        cs = check("d_check.csv", [videorow(checker_size = missing)]; defaults = (checker_size = 7.5,))
+        cs = check([videorow(checker_size = missing)]; defaults = (checker_size = 7.5,))
         @test cs isa Vector
         @test only(cs).checker_size == 7.5
-        cs = check("d_check2.csv", [videorow(checker_size = 4)]; defaults = (checker_size = 7.5,))
+        cs = check([videorow(checker_size = 4)]; defaults = (checker_size = 7.5,))
         @test only(cs).checker_size == 4.0
         # n_corners: the hardcoded default (7, 10) would fail detection on the 5×8 board — a clean
         # load proves the kwarg (not the hardcoded value) filled the blank cell
-        cs = check("d_nc.csv", [videorow(n_corners = missing)]; defaults = (n_corners = (5, 8),))
+        cs = check([videorow(n_corners = missing)]; defaults = (n_corners = (5, 8),))
         @test cs isa Vector
         @test only(cs).n_corners == (5, 8)
     end
 
     @testset "yadif kwarg beats the probe" begin
         # board.mp4 is progressive (the probe would impute false); a global yadif wins when blank
-        cs = check("d_yadif.csv", [videorow(yadif = missing)]; defaults = (yadif = true,))
+        cs = check([videorow(yadif = missing)]; defaults = (yadif = true,))
         @test cs isa Vector
         @test only(cs).yadif == true
     end
 
     @testset "bad overrides fail fast; bad values are verified per row" begin
         # non-whitelisted keys: the intrinsic window and only_scale's scale are per-row only
-        @test_throws ArgumentError check("d_unknown.csv", [videorow()]; defaults = (start = 0,))
-        @test_throws ArgumentError check("d_scale.csv", [scalerow()]; defaults = (scale = 9.5,))
+        @test_throws ArgumentError check([videorow()]; defaults = (start = 0,))
+        @test_throws ArgumentError check([scalerow()]; defaults = (scale = 9.5,))
         # unconvertible value
-        @test_throws ArgumentError check("d_badtype.csv", [videorow()]; defaults = (n_corners = "5x8",))
+        @test_throws ArgumentError check([videorow()]; defaults = (n_corners = "5x8",))
         # a convertible but nonsensical value flows into the normal verification
-        @test flagged(check("d_range.csv", [videorow(checker_size = missing)]; defaults = (checker_size = -1,)),
+        @test flagged(check([videorow(checker_size = missing)]; defaults = (checker_size = -1,)),
                       1, "checker_size must be larger than zero")
     end
 end

--- a/test/VerifyRectifications/test_extrinsic_index.jl
+++ b/test/VerifyRectifications/test_extrinsic_index.jl
@@ -22,27 +22,27 @@
             @test occursin(k, issue)                 # names the offending field
         end
         # end-to-end: such a file is flagged and load_rectifications does not throw
-        @test flagged(check("ei_badpose.csv", [matlabrow(matlab_file = "badpose_TranslationVectors.mat")]),
+        @test flagged(check([matlabrow(matlab_file = "badpose_TranslationVectors.mat")]),
                       1, "expected an N×3 matrix")
     end
 
     @testset "in-range index loads clean (both boundaries)" begin
-        @test clean(check("ei_min.csv", [matlabrow(extrinsic_index = 1)]))                    # low boundary
-        @test clean(check("ei_max.csv", [matlabrow(extrinsic_index = MATLAB_N_EXTRINSICS)]))  # high boundary (pins ≤ N)
+        @test clean(check([matlabrow(extrinsic_index = 1)]))                    # low boundary
+        @test clean(check([matlabrow(extrinsic_index = MATLAB_N_EXTRINSICS)]))  # high boundary (pins ≤ N)
     end
 
     @testset "index must be larger than zero" begin
-        @test flagged(check("ei_zero.csv", [matlabrow(extrinsic_index = 0)]),  1, "extrinsic_index must be larger than zero")
-        @test flagged(check("ei_neg.csv",  [matlabrow(extrinsic_index = -1)]), 1, "extrinsic_index must be larger than zero")
+        @test flagged(check([matlabrow(extrinsic_index = 0)]),  1, "extrinsic_index must be larger than zero")
+        @test flagged(check([matlabrow(extrinsic_index = -1)]), 1, "extrinsic_index must be larger than zero")
     end
 
     @testset "index past the number of poses is flagged" begin
-        df = check("ei_big.csv", [matlabrow(extrinsic_index = MATLAB_N_EXTRINSICS + 1)])
+        df = check([matlabrow(extrinsic_index = MATLAB_N_EXTRINSICS + 1)])
         @test flagged(df, 1, "exceeds the number of extrinsics")
     end
 
     @testset "translation/rotation pose-count mismatch is flagged" begin
-        df = check("ei_mismatch.csv", [matlabrow(matlab_file = ART.mismatch_mat)])
+        df = check([matlabrow(matlab_file = ART.mismatch_mat)])
         @test flagged(df, 1, "disagree on the number of extrinsics")
     end
 end

--- a/test/VerifyRectifications/test_extrinsics.jl
+++ b/test/VerifyRectifications/test_extrinsics.jl
@@ -1,23 +1,23 @@
 @testset "extrinsic corner detection" begin
     @testset "checkerboard -> corners detected (no issue)" begin
         # board.mp4 is a checkerboard with n_corners (5,8); detection succeeds, row stays clean.
-        @test clean(check("e_ok.csv", [videorow()]))
+        @test clean(check([videorow()]))
     end
 
     @testset "corner detection with blur > 0" begin
         # exercises the gblur branch of `extract`; detection still succeeds on the checkerboard.
-        @test clean(check("e_blur.csv", [videorow(blur = 1)]))
+        @test clean(check([videorow(blur = 1)]))
     end
 
     @testset "blank video -> no corners detected" begin
-        df = check("e_none.csv", [videorow(file = ART.video, n_corners = (5, 8))])
+        df = check([videorow(file = ART.video, n_corners = (5, 8))])
         @test flagged(df, 1, "no corners detected")
     end
 
     @testset "a throwing detection is caught as an issue, never thrown" begin
         # corrupt.mp4 fails the probe (width/height stay missing), so the frame read inside
         # extrinsic_issue throws; the catch turns that into an issue instead of aborting the load.
-        df = check("e_corrupt.csv", [videorow(file = ART.corrupt)])
+        df = check([videorow(file = ART.corrupt)])
         @test flagged(df, 1, "issue with corner detection")
         # ...and it says what happened, in one sentence. Interpolating the raw exception dumped the
         # entire failed ffmpeg `Cmd` — environment block and all, ~8 kB of it — straight into the
@@ -40,7 +40,7 @@
         idir = mktempdir()
         # a stale file proves the folder is wiped at the start of each run
         touch(joinpath(idir, "stale.png"))
-        df = check("e_dump.csv", [videorow(file = ART.video, n_corners = (5, 8))]; issues_dir = idir)
+        df = check([videorow(file = ART.video, n_corners = (5, 8))]; issues_dir = idir)
         @test flagged(df, 1, "no corners detected")
         @test flagged(df, 1, "saved the extrinsic frame")          # the message points at the file
         pngs = filter(endswith(".png"), readdir(idir))

--- a/test/VerifyRectifications/test_filesystem.jl
+++ b/test/VerifyRectifications/test_filesystem.jl
@@ -1,25 +1,25 @@
 @testset "filesystem" begin
     @testset "path does not exist" begin
-        df = check("fs_dir.csv", [videorow(path = "no_such_dir")])
+        df = check([videorow(path = "no_such_dir")])
         @test flagged(df, 1, "path does not exist")
     end
 
     @testset "file does not exist" begin
-        df = check("fs_file.csv", [videorow(file = "no_such_file.mp4")])
+        df = check([videorow(file = "no_such_file.mp4")])
         @test flagged(df, 1, "file does not exist")
     end
 
     @testset "a path naming the video itself says so (#33)" begin
         # The targeted message runs first and nulls :path, so the existence check does not also
         # fire with the misleading "path does not exist".
-        df = check("fs_pathisfile.csv", [videorow(path = ART.board)])
+        df = check([videorow(path = ART.board)])
         @test flagged(df, 1, "path is a file, not a folder")
         @test !flagged(df, 1, "path does not exist")
     end
 
     @testset "matlab_file does not exist" begin
         # the .mat path is resolved/checked against path just like the source video `file`
-        df = check("fs_matf.csv", [matlabrow(matlab_file = "no_such_file.mat")])
+        df = check([matlabrow(matlab_file = "no_such_file.mat")])
         @test flagged(df, 1, "matlab_file does not exist")
     end
 end

--- a/test/VerifyRectifications/test_happy.jl
+++ b/test/VerifyRectifications/test_happy.jl
@@ -1,12 +1,12 @@
 @testset "happy path" begin
     @testset "fully valid video validates clean" begin
-        df = check("h_video.csv", [videorow()])
+        df = check([videorow()])
         @test clean(df)
     end
 
     @testset "mixed valid (video + matlab + only_scale), strict returns a df without throwing" begin
         # strict=true would throw if any row had an issue
-        df = check("h_mixed.csv", [videorow(), matlabrow(), scalerow()]; strict = true)
+        df = check([videorow(), matlabrow(), scalerow()]; strict = true)
         @test clean(df)
     end
 end

--- a/test/VerifyRectifications/test_integration.jl
+++ b/test/VerifyRectifications/test_integration.jl
@@ -9,31 +9,35 @@ using StaticArrays: SVector
 
     @testset "only_scale, with and without center/north" begin
         for (name, r) in (("cn", scalerow()), ("nocn", scalerow(center = missing, north = missing)))
-            cs = check("int_scale_$name.csv", [r])
-            @test cs isa Vector                          # clean load ⇒ structs, not an issues df
-            rect = Rectification(only(cs))
-            p = [100.0, 120.0]
-            @test rect.real2image(rect.image2real(p)) ≈ p    # the maps invert each other
-            @test rect.ratio == 9.5                          # only_scale carries the scale through
-            @test (rect.width, rect.height) == (640, 480)    # probed source-video frame size
+            @testset "$name" begin
+                cs = check([r])
+                @test cs isa Vector                          # clean load ⇒ structs, not an issues df
+                rect = Rectification(only(cs))
+                p = [100.0, 120.0]
+                @test rect.real2image(rect.image2real(p)) ≈ p    # the maps invert each other
+                @test rect.ratio == 9.5                          # only_scale carries the scale through
+                @test (rect.width, rect.height) == (640, 480)    # probed source-video frame size
+            end
         end
     end
 
     @testset "video, with and without center/north" begin
         for (name, r) in (("cn", videorow()), ("nocn", videorow(center = missing, north = missing)))
-            cs = check("int_video_$name.csv", [r])
-            @test cs isa Vector
-            rect = Rectification(only(cs))               # full pipeline: reads, detects, fits
-            @test rect.image2real isa Function
-            @test rect.real2image isa Function
-            @test (rect.width, rect.height) == (500, 376)
+            @testset "$name" begin
+                cs = check([r])
+                @test cs isa Vector
+                rect = Rectification(only(cs))           # full pipeline: reads, detects, fits
+                @test rect.image2real isa Function
+                @test rect.real2image isa Function
+                @test (rect.width, rect.height) == (500, 376)
+            end
         end
     end
 
     @testset "matlab ⇒ rectification read from the .mat parameters" begin
         # consistent.mat is a fronto-parallel pinhole (see make_matlab_consistent): pose 1 sits at
         # Z = 100 with f = 500, so one pixel spans Z/f = 0.2 of the .mat's world units.
-        cs = check("int_matlab.csv", [matlabrow(matlab_file = ART.consistent_mat)])
+        cs = check([matlabrow(matlab_file = ART.consistent_mat)])
         @test cs isa Vector
         @test only(cs) isa VRect.MATLAB
         rect = Rectification(only(cs))
@@ -47,7 +51,7 @@ using StaticArrays: SVector
         # both window bounds blank is a valid, supported configuration: it selects the
         # Video{Missing} variant, whose Rectification fits pose + focal from the single extrinsic
         # frame and disregards lens aberrations (zero distortion).
-        cs = check("int_video_extonly.csv", [videorow(start = missing, stop = missing)])
+        cs = check([videorow(start = missing, stop = missing)])
         @test cs isa Vector
         c = only(cs)
         @test c isa VRect.Video{Missing}

--- a/test/VerifyRectifications/test_intrinsics.jl
+++ b/test/VerifyRectifications/test_intrinsics.jl
@@ -6,18 +6,18 @@
 
     @testset "window on the board portion loads clean" begin
         # 0, 0.9, 1.8 — three samples, all on the board
-        @test clean(check("i_ok.csv", [mixedrow()]))
+        @test clean(check([mixedrow()]))
     end
 
     @testset "window over cornerless footage is flagged" begin
         # 2.5, 3.5, 4.5 — three samples, all on the testsrc tail
-        df = check("i_none.csv", [mixedrow(start = "2.5", stop = "4.5", temporal_step = 1)])
+        df = check([mixedrow(start = "2.5", stop = "4.5", temporal_step = 1)])
         @test flagged(df, 1, "fewer than 3 frames with detectable corners")
     end
 
     @testset "window with only 2 detectable frames is flagged" begin
         # 0, 1, 2, 3, 4 — only 0 and 1 land on the board: 2 detections < 3
-        df = check("i_two.csv", [mixedrow(start = "0", stop = "4", temporal_step = 1)])
+        df = check([mixedrow(start = "0", stop = "4", temporal_step = 1)])
         @test flagged(df, 1, "fewer than 3 frames with detectable corners")
     end
 
@@ -40,7 +40,7 @@
     @testset "rows that already failed the extrinsic check are not re-scanned" begin
         # video.mp4 has no corners anywhere: the extrinsic check flags it first, and the (expensive)
         # window scan must then skip the row instead of piling on a second issue.
-        df = check("i_skip.csv", [videorow(file = ART.video)])
+        df = check([videorow(file = ART.video)])
         @test flagged(df, 1, "no corners detected")
         @test !flagged(df, 1, "fewer than 3 frames with detectable corners")
     end

--- a/test/VerifyRectifications/test_parsing.jl
+++ b/test/VerifyRectifications/test_parsing.jl
@@ -3,7 +3,7 @@
     # asserted issue is the only thing under test (other checks pass).
 
     @testset "wrong type value" begin
-        df = check("p_type.csv", [videorow(type = "bogus")])
+        df = check([videorow(type = "bogus")])
         @test flagged(df, 1, "wrong type")
     end
 
@@ -11,71 +11,71 @@
         # A bad type skips parse_{video,matlab,only_scale}!, which are the only emitters of the
         # per-field "… is missing" issues. So a sparse bad-type row (only :type set) should come out
         # with *just* "wrong type" — no cascade of missing-field issues — and load without error.
-        df = check("p_type_bare.csv", [row(type = "bogus")])
+        df = check([row(type = "bogus")])
         @test flagged(df, 1, "wrong type")
         @test !flagged(df, 1, "calibration_id is missing")
         @test !flagged(df, 1, "file is missing")
     end
 
     @testset "missing required fields" begin
-        @test flagged(check("p_id.csv",    [videorow(calibration_id = missing)]), 1, "calibration_id is missing")
-        @test flagged(check("p_file.csv",  [videorow(file = missing)]),           1, "file is missing")
-        @test flagged(check("p_scale.csv", [scalerow(scale = missing)]),          1, "scale is missing")
-        @test flagged(check("p_extr.csv",  [videorow(extrinsic = missing)]),      1, "extrinsic is missing")
+        @test flagged(check([videorow(calibration_id = missing)]), 1, "calibration_id is missing")
+        @test flagged(check([videorow(file = missing)]),           1, "file is missing")
+        @test flagged(check([scalerow(scale = missing)]),          1, "scale is missing")
+        @test flagged(check([videorow(extrinsic = missing)]),      1, "extrinsic is missing")
         # parse_matlab! / parse_only_scale! are separate hand-written field lists; assert the required
         # fields shared with video are wired in those branches too (not just in parse_video!).
-        @test flagged(check("p_id_mat.csv",   [matlabrow(calibration_id = missing)]), 1, "calibration_id is missing")
-        @test flagged(check("p_file_mat.csv", [matlabrow(file = missing)]),           1, "file is missing")
+        @test flagged(check([matlabrow(calibration_id = missing)]), 1, "calibration_id is missing")
+        @test flagged(check([matlabrow(file = missing)]),           1, "file is missing")
         # matlab_file (the .mat) is the matlab-only required path field, separate from the source video `file`
-        @test flagged(check("p_matf_mat.csv", [matlabrow(matlab_file = missing)]),    1, "matlab_file is missing")
+        @test flagged(check([matlabrow(matlab_file = missing)]),    1, "matlab_file is missing")
         # extrinsic_index is the matlab-only required field added alongside the MATLAB struct's extrinsic_index
-        @test flagged(check("p_ei_mat.csv",   [matlabrow(extrinsic_index = missing)]), 1, "extrinsic_index is missing")
+        @test flagged(check([matlabrow(extrinsic_index = missing)]), 1, "extrinsic_index is missing")
         # extrinsic is now mandatory for ALL types (it lives in the shared Source struct), not just video
-        @test flagged(check("p_extr_mat.csv", [matlabrow(extrinsic = missing)]),      1, "extrinsic is missing")
-        @test flagged(check("p_extr_sc.csv",  [scalerow(extrinsic = missing)]),       1, "extrinsic is missing")
-        @test flagged(check("p_id_sc.csv",    [scalerow(calibration_id = missing)]),  1, "calibration_id is missing")
-        @test flagged(check("p_file_sc.csv",  [scalerow(file = missing)]),            1, "file is missing")
+        @test flagged(check([matlabrow(extrinsic = missing)]),      1, "extrinsic is missing")
+        @test flagged(check([scalerow(extrinsic = missing)]),       1, "extrinsic is missing")
+        @test flagged(check([scalerow(calibration_id = missing)]),  1, "calibration_id is missing")
+        @test flagged(check([scalerow(file = missing)]),            1, "file is missing")
     end
 
     @testset "blank (whitespace-only) cell is treated as missing" begin
         # a required field reports "is missing" rather than silently becoming an empty string
-        @test flagged(check("p_blank_id.csv",   [videorow(calibration_id = "   ")]), 1, "calibration_id is missing")
-        @test flagged(check("p_blank_file.csv", [videorow(file = "   ")]),           1, "file is missing")
+        @test flagged(check([videorow(calibration_id = "   ")]), 1, "calibration_id is missing")
+        @test flagged(check([videorow(file = "   ")]),           1, "file is missing")
         # an optional field falls back to its default ("." for path) and still resolves
-        @test clean(check("p_blank_path.csv", [videorow(path = "  ")]))
+        @test clean(check([videorow(path = "  ")]))
     end
 
     @testset "wrong formats" begin
-        @test flagged(check("p_center.csv",  [videorow(center = "abc")]),            1, "wrong center format")
+        @test flagged(check([videorow(center = "abc")]),            1, "wrong center format")
         # a coordinate that overflows Int64 must be a graceful "wrong format", not an uncaught OverflowError
-        @test flagged(check("p_center_ovf.csv", [videorow(center = "(10000000000000000000,1)", north = missing)]), 1, "wrong center format")
-        @test flagged(check("p_north.csv",   [videorow(north = "1;2")]),             1, "wrong north format")
-        @test flagged(check("p_time.csv",    [videorow(extrinsic = "not_a_time")]),  1, "wrong extrinsic format")
-        @test flagged(check("p_ncorn.csv",   [videorow(n_corners = "five")]),        1, "wrong n_corners format")
-        @test flagged(check("p_check.csv",   [videorow(checker_size = "big")]),      1, "wrong checker_size format")
-        @test flagged(check("p_radial.csv",  [videorow(radial_parameters = "2.5")]), 1, "wrong radial_parameters format")
-        @test flagged(check("p_aspect.csv",  [videorow(aspect = "wide")]),           1, "wrong aspect format")
+        @test flagged(check([videorow(center = "(10000000000000000000,1)", north = missing)]), 1, "wrong center format")
+        @test flagged(check([videorow(north = "1;2")]),             1, "wrong north format")
+        @test flagged(check([videorow(extrinsic = "not_a_time")]),  1, "wrong extrinsic format")
+        @test flagged(check([videorow(n_corners = "five")]),        1, "wrong n_corners format")
+        @test flagged(check([videorow(checker_size = "big")]),      1, "wrong checker_size format")
+        @test flagged(check([videorow(radial_parameters = "2.5")]), 1, "wrong radial_parameters format")
+        @test flagged(check([videorow(aspect = "wide")]),           1, "wrong aspect format")
         # malformed center/north on the non-video types (same shared parseto!/mytryparse path, for symmetry)
-        @test flagged(check("p_center_mat.csv", [matlabrow(center = "abc")]), 1, "wrong center format")
-        @test flagged(check("p_north_sc.csv",   [scalerow(north = "1;2")]),   1, "wrong north format")
+        @test flagged(check([matlabrow(center = "abc")]), 1, "wrong center format")
+        @test flagged(check([scalerow(north = "1;2")]),   1, "wrong north format")
         # extrinsic_index must parse as an Int (matlab only)
-        @test flagged(check("p_ei_fmt.csv",      [matlabrow(extrinsic_index = "two")]), 1, "wrong extrinsic_index format")
+        @test flagged(check([matlabrow(extrinsic_index = "two")]), 1, "wrong extrinsic_index format")
     end
 
     @testset "start/stop must be paired (both directions)" begin
-        @test flagged(check("p_pair1.csv", [videorow(start = "00:00:02", stop = missing)]),     1, "both present or both missing")
-        @test flagged(check("p_pair2.csv", [videorow(start = missing, stop = "00:00:08")]),     1, "both present or both missing")
+        @test flagged(check([videorow(start = "00:00:02", stop = missing)]),     1, "both present or both missing")
+        @test flagged(check([videorow(start = missing, stop = "00:00:08")]),     1, "both present or both missing")
     end
 
     @testset "a filled column irrelevant to the row's type is flagged" begin
-        @test flagged(check("p_irr_vid.csv",  [videorow(scale = 9.5)]),         1, "scale is not used by type video")
-        @test flagged(check("p_irr_vid2.csv", [videorow(extrinsic_index = 1)]), 1, "extrinsic_index is not used by type video")
-        @test flagged(check("p_irr_mat.csv",  [matlabrow(checker_size = 4)]),   1, "checker_size is not used by type matlab")
-        @test flagged(check("p_irr_sc.csv",   [scalerow(n_corners = (5, 8))]),  1, "n_corners is not used by type only_scale")
+        @test flagged(check([videorow(scale = 9.5)]),         1, "scale is not used by type video")
+        @test flagged(check([videorow(extrinsic_index = 1)]), 1, "extrinsic_index is not used by type video")
+        @test flagged(check([matlabrow(checker_size = 4)]),   1, "checker_size is not used by type matlab")
+        @test flagged(check([scalerow(n_corners = (5, 8))]),  1, "n_corners is not used by type only_scale")
         # blank cells in irrelevant columns stay fine — mixed-type CSVs share one header
-        @test clean(check("p_irr_ok.csv", [videorow(), matlabrow(), scalerow()]))
+        @test clean(check([videorow(), matlabrow(), scalerow()]))
         # a bad type still short-circuits: no irrelevant-column cascade on top of "wrong type"
-        df = check("p_irr_badtype.csv", [videorow(type = "bogus")])
+        df = check([videorow(type = "bogus")])
         @test flagged(df, 1, "wrong type")
         @test !flagged(df, 1, "is not used by type")
     end
@@ -85,27 +85,27 @@
         # ignored — so it looked exactly like a wrong-type column and made a filled comment a hard
         # error under the default strict mode. It must be accepted on every type.
         note = "measured the board twice; second run looked better"
-        @test clean(check("p_com_vid.csv", [videorow(comment = note)]))
-        @test clean(check("p_com_mat.csv", [matlabrow(comment = note)]))
-        @test clean(check("p_com_sc.csv",  [scalerow(comment = note)]))
+        @test clean(check([videorow(comment = note)]))
+        @test clean(check([matlabrow(comment = note)]))
+        @test clean(check([scalerow(comment = note)]))
         # a comment on one row of a mixed-type file, blank on the others, is also fine
-        @test clean(check("p_com_mix.csv", [videorow(), matlabrow(comment = note), scalerow()]))
+        @test clean(check([videorow(), matlabrow(comment = note), scalerow()]))
         # and the check it was caught by still works — the exemption is for `comment` alone
-        @test flagged(check("p_com_still.csv", [videorow(comment = note, scale = 9.5)]),
+        @test flagged(check([videorow(comment = note, scale = 9.5)]),
                       1, "scale is not used by type video")
     end
 
     @testset "north without center" begin
         # verify_center2north is called from a separate branch of parse_row per type; assert all three
         # call sites, not just video (the matlab/only_scale wiring was the original 2.1 bug).
-        @test flagged(check("p_n2c.csv",       [videorow(center = missing, north = (250, 1))]), 1, "supplying north without center")
-        @test flagged(check("p_n2c_mat.csv",   [matlabrow(center = missing, north = (160, 1))]), 1, "supplying north without center")
-        @test flagged(check("p_n2c_scale.csv", [scalerow(center = missing, north = (320, 1))]),  1, "supplying north without center")
+        @test flagged(check([videorow(center = missing, north = (250, 1))] ), 1, "supplying north without center")
+        @test flagged(check([matlabrow(center = missing, north = (160, 1))]), 1, "supplying north without center")
+        @test flagged(check([scalerow(center = missing, north = (320, 1))]),  1, "supplying north without center")
     end
 
     @testset "defaults applied (with correct values) when optional fields omitted" begin
-        df = check("p_defaults.csv", [videorow(n_corners = missing, checker_size = missing,
-                                               temporal_step = missing, radial_parameters = missing, blur = missing)])
+        df = check([videorow(n_corners = missing, checker_size = missing,
+                             temporal_step = missing, radial_parameters = missing, blur = missing)])
         @test df.n_corners[1]         == (7, 10)
         @test df.checker_size[1]      == 4.0
         @test df.temporal_step[1]     == 2.0
@@ -115,17 +115,17 @@
 
     @testset "whitespace is trimmed from string fields" begin
         # a stray space in a hand-edited cell must not break matching.
-        @test clean(check("p_ws_type.csv", [videorow(type = "video ")]))          # "video " -> video, not "wrong type"
-        @test clean(check("p_ws_file.csv", [videorow(file = " " * ART.board)]))    # " board.mp4" still resolves
+        @test clean(check([videorow(type = "video ")]))          # "video " -> video, not "wrong type"
+        @test clean(check([videorow(file = " " * ART.board)]))    # " board.mp4" still resolves
         # leading/trailing space on an id is trimmed, so two such ids collide and the repeat is caught
-        df = check("p_ws_id.csv", [videorow(calibration_id = "dup",  extrinsic = "00:00:01"),
-                                   videorow(calibration_id = "dup ", extrinsic = "00:00:03")])
+        df = check([videorow(calibration_id = "dup",  extrinsic = "00:00:01"),
+                    videorow(calibration_id = "dup ", extrinsic = "00:00:03")])
         @test flagged(df, 2, "calibration_id must not repeat")
     end
 
     @testset "extrinsic accepts seconds and HH:MM:SS" begin
-        @test clean(check("p_secs.csv",  [videorow(extrinsic = "1.0")]))
-        @test clean(check("p_clock.csv", [videorow(extrinsic = "00:00:01")]))
+        @test clean(check([videorow(extrinsic = "1.0")]))
+        @test clean(check([videorow(extrinsic = "00:00:01")]))
     end
 
     @testset "type defaults to video when column absent or empty" begin

--- a/test/VerifyRectifications/test_reading.jl
+++ b/test/VerifyRectifications/test_reading.jl
@@ -24,12 +24,12 @@
         # probe_video's catch returns the message string; assert it directly, then end-to-end through
         # load_rectifications for both types (both reach probe_video via read_video_metadata!).
         @test VRect.probe_video(joinpath(DATADIR, ART.corrupt)) isa String
-        @test flagged(check("r_corrupt.csv",  [videorow(file = ART.corrupt)]), 1, "issue reading from video file")
-        @test flagged(check("r_corrupts.csv", [scalerow(file = ART.corrupt)]), 1, "issue reading from video file")
+        @test flagged(check([videorow(file = ART.corrupt)]), 1, "issue reading from video file")
+        @test flagged(check([scalerow(file = ART.corrupt)]), 1, "issue reading from video file")
     end
 
     @testset "non-mat file is flagged" begin
-        df = check("r_badmat.csv", [matlabrow(matlab_file = ART.bad_mat)])
+        df = check([matlabrow(matlab_file = ART.bad_mat)])
         @test flagged(df, 1, "missing \"MATLAB\" magic bytes")
     end
 
@@ -41,7 +41,7 @@
         # an unreadable path (here: absent) is a SystemError from `read`, reported as an issue
         @test VRect.matlab_magic_issue(joinpath(DATADIR, "definitely_not_here.mat")) isa String
         # end-to-end: a non-mat file is flagged and has :matlab_file nulled (the source video :file is fine)
-        df = check("r_mat_magic.csv", [matlabrow(matlab_file = ART.bad_mat)])
+        df = check([matlabrow(matlab_file = ART.bad_mat)])
         @test flagged(df, 1, "missing \"MATLAB\" magic bytes")
         @test ismissing(df.matlab_file[1])
     end
@@ -50,7 +50,7 @@
         # Every row now reads its source video to fill the shared Source width/height/aspect, so a
         # corrupt only_scale video is flagged even when center/north are absent (a lazy skip
         # optimization is gone).
-        df = check("r_corrupt_skip.csv", [scalerow(file = ART.corrupt, center = missing, north = missing)])
+        df = check([scalerow(file = ART.corrupt, center = missing, north = missing)])
         @test flagged(df, 1, "issue reading from video file")
     end
 
@@ -64,11 +64,11 @@
         @test VRect.read_matlab(joinpath(DATADIR, ART.bad_mat))                          isa String  # unreadable / not a mat
 
         # end-to-end: a structurally-complete matlab row loads clean...
-        @test clean(check("r_mat_ok.csv", [matlabrow()]))                 # good.mat has all fields
-        @test clean(check("r_mat_nested.csv", [matlabrow(matlab_file = ART.nested_mat)]))
+        @test clean(check([matlabrow()]))                 # good.mat has all fields
+        @test clean(check([matlabrow(matlab_file = ART.nested_mat)]))
 
         # ...while a file missing required fields is flagged, names the missing fields, and has :matlab_file nulled.
-        df = check("r_mat_partial.csv", [matlabrow(matlab_file = ART.partial_mat)])
+        df = check([matlabrow(matlab_file = ART.partial_mat)])
         @test flagged(df, 1, "missing required calibration field(s)")
         @test flagged(df, 1, "TranslationVectors")
         @test flagged(df, 1, "RotationVectors")
@@ -78,7 +78,7 @@
     @testset "matlab ImageSize must match the source video dimensions" begin
         # good.mat ImageSize is (640,480); pairing it with board.mp4 (500×376) as the source video
         # makes the cross-check fail. (matlabrow's default source video.mp4 is 640×480 and passes.)
-        df = check("r_mat_dimmismatch.csv", [matlabrow(file = ART.board)])
+        df = check([matlabrow(file = ART.board)])
         @test flagged(df, 1, "does not match the source video dimensions")
     end
 
@@ -86,15 +86,15 @@
         # "." and "./." resolve to the same dir, so both rows point at one physical .mat. The reading
         # passes group on the canonical (realpath) matlab_file, so the file is read once and the result
         # is applied to every spelling — here a structure failure is reported on both rows.
-        df = check("r_canon_mat.csv", [matlabrow(calibration_id = "c1", path = ".",   matlab_file = ART.partial_mat, center = missing, north = missing),
-                                       matlabrow(calibration_id = "c2", path = "./.", matlab_file = ART.partial_mat, center = missing, north = missing)])
+        df = check([matlabrow(calibration_id = "c1", path = ".",   matlab_file = ART.partial_mat, center = missing, north = missing),
+                    matlabrow(calibration_id = "c2", path = "./.", matlab_file = ART.partial_mat, center = missing, north = missing)])
         @test flagged(df, 1, "missing required calibration field(s)")
         @test flagged(df, 2, "missing required calibration field(s)")
 
         # likewise a video read (dimension) applied across spellings: an out-of-bounds center is caught
         # on both rows from the one read.
-        df = check("r_canon_vid.csv", [videorow(calibration_id = "v1", path = ".",   center = (9000, 9000)),
-                                       videorow(calibration_id = "v2", path = "./.", center = (9000, 9000))])
+        df = check([videorow(calibration_id = "v1", path = ".",   center = (9000, 9000)),
+                    videorow(calibration_id = "v2", path = "./.", center = (9000, 9000))])
         @test flagged(df, 1, "center cannot be larger than the dimensions")
         @test flagged(df, 2, "center cannot be larger than the dimensions")
     end
@@ -161,6 +161,6 @@
             @test VRect.matlab_dimension(MAT.matread(p)) isa String
         end
         # end-to-end: such a file is flagged, and load_rectifications does not throw
-        @test flagged(check("r_badimsize.csv", [matlabrow(matlab_file = "badimsize_three_elem.mat")]), 1, "ImageSize is malformed")
+        @test flagged(check([matlabrow(matlab_file = "badimsize_three_elem.mat")]), 1, "ImageSize is malformed")
     end
 end

--- a/test/VerifyRectifications/test_strict.jl
+++ b/test/VerifyRectifications/test_strict.jl
@@ -1,17 +1,17 @@
 @testset "strict mode & issue report" begin
     @testset "strict=true throws when issues exist" begin
-        @test_throws "there were issues" check("st_throw.csv", [scalerow(scale = -1)]; strict = true)
+        @test_throws "there were issues" check([scalerow(scale = -1)]; strict = true)
     end
 
     @testset "issue report is printed with no trailing separator" begin
-        df, out = load_capturing("st_msg.csv", [scalerow(scale = -1)])
+        df, out = load_capturing([scalerow(scale = -1)])
         @test occursin("row 1 (calibration_id: s): scale must be larger than zero", out)
         @test !occursin("scale must be larger than zero,", out)   # join(issues, ", ") adds no trailing separator
         @test hasproperty(df, :issues)                            # non-strict returns the df with :issues retained
     end
 
     @testset "a blank calibration_id falls back to the plain row label" begin
-        _, out = load_capturing("st_blank_id.csv", [scalerow(calibration_id = missing, scale = -1)])
+        _, out = load_capturing([scalerow(calibration_id = missing, scale = -1)])
         @test occursin("row 1: ", out)
         @test !occursin("(calibration_id", out)
     end

--- a/test/VerifyRectifications/test_structural.jl
+++ b/test/VerifyRectifications/test_structural.jl
@@ -2,8 +2,8 @@
     @testset "duplicate rectification_id" begin
         # same id, but otherwise different (different extrinsic) so it is NOT also a duplicate rectification.
         # nonunique flags the repeat (row 2), keeping the first occurrence's id.
-        df = check("s_dupid.csv", [videorow(calibration_id = "dup", extrinsic = "00:00:01"),
-                                   videorow(calibration_id = "dup", extrinsic = "00:00:03")])
+        df = check([videorow(calibration_id = "dup", extrinsic = "00:00:01"),
+                    videorow(calibration_id = "dup", extrinsic = "00:00:03")])
         @test flagged(df, 2, "calibration_id must not repeat")
         @test !flagged(df, 1, "calibration_id must not repeat")
     end
@@ -12,14 +12,14 @@
         # `file` is always a source video now, so any types can share one physical video — there is no
         # longer a "conflicting types" rule. A video + only_scale (different types) on the same file
         # load clean and are not duplicates.
-        df = check("s_vidscale.csv", [videorow(calibration_id = "c1", file = ART.board),
-                                      scalerow(calibration_id = "c2", file = ART.board, center = (100, 100), north = (100, 1), scale = 9.5)])
+        df = check([videorow(calibration_id = "c1", file = ART.board),
+                    scalerow(calibration_id = "c2", file = ART.board, center = (100, 100), north = (100, 1), scale = 9.5)])
         @test clean(df)
     end
 
     @testset "a row with a bad type is flagged" begin
-        df = check("s_badtype.csv", [videorow(calibration_id = "z1", file = ART.board),
-                                     videorow(calibration_id = "z2", file = ART.board, type = "bogus")])
+        df = check([videorow(calibration_id = "z1", file = ART.board),
+                    videorow(calibration_id = "z2", file = ART.board, type = "bogus")])
         @test isempty(df.issues[1])              # the valid row is unaffected by its bad-type sibling
         @test flagged(df, 2, "wrong type")
     end
@@ -27,8 +27,8 @@
     @testset "duplicate rectification (identical rows)" begin
         # identical in every column except calibration_id -> second is flagged as a duplicate, and since
         # the non-identity params also match it does NOT get the conflicting-parameters issue.
-        df = check("s_dupcal.csv", [videorow(calibration_id = "a"),
-                                    videorow(calibration_id = "b")])
+        df = check([videorow(calibration_id = "a"),
+                    videorow(calibration_id = "b")])
         @test flagged(df, 2, "duplicate rectification")
         @test !flagged(df, 2, "same rectification with conflicting parameters")
     end
@@ -37,8 +37,8 @@
         # Same identity (file, start, stop, extrinsic, center, north) but a different
         # checker_size: still the same rectification, so the 2nd is a duplicate; and because a
         # non-identity parameter disagrees, the duplicate also gets the conflicting-parameters issue.
-        df = check("s_dupconflict.csv", [videorow(calibration_id = "k1", checker_size = 4),
-                                         videorow(calibration_id = "k2", checker_size = 8)])
+        df = check([videorow(calibration_id = "k1", checker_size = 4),
+                    videorow(calibration_id = "k2", checker_size = 8)])
         @test flagged(df, 2, "duplicate rectification")
         @test flagged(df, 2, "same rectification with conflicting parameters")
         @test !flagged(df, 1, "duplicate rectification")
@@ -48,24 +48,24 @@
     @testset "video duplicate with conflicting yadif is also flagged" begin
         # yadif is not part of the identity key but two same-identity rows must agree on it: board is
         # progressive (probed false), so an explicit yadif = true on the copy is a parameter conflict.
-        df = check("s_dupyadif.csv", [videorow(calibration_id = "y1"),
-                                      videorow(calibration_id = "y2", yadif = true)])
+        df = check([videorow(calibration_id = "y1"),
+                    videorow(calibration_id = "y2", yadif = true)])
         @test flagged(df, 2, "duplicate rectification")
         @test flagged(df, 2, "same rectification with conflicting parameters")
     end
 
     @testset "video duplicate with conflicting aspect is also flagged" begin
         # likewise aspect: probed 1.0 on row 1, explicit 2.0 on the same-identity copy.
-        df = check("s_dupaspect.csv", [videorow(calibration_id = "a1"),
-                                       videorow(calibration_id = "a2", aspect = 2.0)])
+        df = check([videorow(calibration_id = "a1"),
+                    videorow(calibration_id = "a2", aspect = 2.0)])
         @test flagged(df, 2, "duplicate rectification")
         @test flagged(df, 2, "same rectification with conflicting parameters")
     end
 
     @testset "video NOT a duplicate when an identity field differs" begin
         # center is part of the identity key, so differing center -> distinct rectifications, no flags.
-        df = check("s_vidcenter.csv", [videorow(calibration_id = "i1", center = (250, 180)),
-                                       videorow(calibration_id = "i2", center = (240, 170))])
+        df = check([videorow(calibration_id = "i1", center = (250, 180)),
+                    videorow(calibration_id = "i2", center = (240, 170))])
         @test !flagged(df, 2, "duplicate rectification")
         @test !flagged(df, 2, "same rectification with conflicting parameters")
     end
@@ -73,20 +73,20 @@
     @testset "only_scale duplicate = identical except id/issues" begin
         # only_scale: same iff every field matches (id aside). Identical -> 2nd duplicate;
         # differ on any field (here scale) -> not a duplicate.
-        dup = check("s_dupscale.csv", [scalerow(calibration_id = "s1"), scalerow(calibration_id = "s2")])
+        dup = check([scalerow(calibration_id = "s1"), scalerow(calibration_id = "s2")])
         @test flagged(dup, 2, "duplicate rectification")
         @test !flagged(dup, 1, "duplicate rectification")
-        diff = check("s_diffscale.csv", [scalerow(calibration_id = "s1", scale = 9.5),
-                                         scalerow(calibration_id = "s2", scale = 10.5)])
+        diff = check([scalerow(calibration_id = "s1", scale = 9.5),
+                      scalerow(calibration_id = "s2", scale = 10.5)])
         @test !flagged(diff, 2, "duplicate rectification")
     end
 
     @testset "matlab duplicate = identical except id/issues" begin
-        dup = check("s_dupmat.csv", [matlabrow(calibration_id = "m1"), matlabrow(calibration_id = "m2")])
+        dup = check([matlabrow(calibration_id = "m1"), matlabrow(calibration_id = "m2")])
         @test flagged(dup, 2, "duplicate rectification")
         @test !flagged(dup, 1, "duplicate rectification")
-        diff = check("s_diffmat.csv", [matlabrow(calibration_id = "m1", center = (160, 120)),
-                                       matlabrow(calibration_id = "m2", center = (100, 100))])
+        diff = check([matlabrow(calibration_id = "m1", center = (160, 120)),
+                      matlabrow(calibration_id = "m2", center = (100, 100))])
         @test !flagged(diff, 2, "duplicate rectification")
     end
 
@@ -95,8 +95,8 @@
         # The raw joined :path/:file strings differ, so without canonicalization these escape
         # the duplicate-rectification check; verify_unique_calibrations! realpaths the key columns
         # (in a copy) so the second row is still flagged.
-        df = check("s_duppath.csv", [videorow(calibration_id = "p1", path = "."),
-                                     videorow(calibration_id = "p2", path = "./.")])
+        df = check([videorow(calibration_id = "p1", path = "."),
+                    videorow(calibration_id = "p2", path = "./.")])
         @test flagged(df, 2, "duplicate rectification")
         @test !flagged(df, 1, "duplicate rectification")
     end
@@ -105,8 +105,8 @@
         # two DISTINCT matlab rows (different centers) that are both out of bounds: each center gets
         # nulled by the bounds check, which would make the rows look identical. Uniqueness
         # skips rows that already carry issues, so neither gets a spurious "duplicate rectification".
-        df = check("s_nodup_nulled.csv", [matlabrow(calibration_id = "a", center = (600, 600), north = missing),
-                                          matlabrow(calibration_id = "b", center = (700, 700), north = missing)])
+        df = check([matlabrow(calibration_id = "a", center = (600, 600), north = missing),
+                    matlabrow(calibration_id = "b", center = (700, 700), north = missing)])
         @test flagged(df, 1, "center cannot be larger than the dimensions")
         @test flagged(df, 2, "center cannot be larger than the dimensions")
         @test !flagged(df, 1, "duplicate rectification")
@@ -116,8 +116,8 @@
     @testset "a duplicate loses its calibration_id" begin
         # Nulling it is what stops anything downstream joining a run onto a rectification that was
         # rejected — and it is why the report names the duplicate's row without an id.
-        df, out = load_capturing("s_dupid.csv", [videorow(calibration_id = "keep"),
-                                                 videorow(calibration_id = "drop")])
+        df, out = load_capturing([videorow(calibration_id = "keep"),
+                                  videorow(calibration_id = "drop")])
         @test df.calibration_id[1] == "keep"
         @test ismissing(df.calibration_id[2])
         @test occursin("row 2: duplicate rectification", out)
@@ -125,9 +125,9 @@
 
     @testset "three identical rows: the first is kept, both others flagged" begin
         # Which of a duplicate set survives is load-bearing: the first occurrence in csv order.
-        df = check("s_dup3.csv", [videorow(calibration_id = "a"),
-                                  videorow(calibration_id = "b"),
-                                  videorow(calibration_id = "c")])
+        df = check([videorow(calibration_id = "a"),
+                    videorow(calibration_id = "b"),
+                    videorow(calibration_id = "c")])
         @test !flagged(df, 1, "duplicate rectification")
         @test flagged(df, 2, "duplicate rectification")
         @test flagged(df, 3, "duplicate rectification")
@@ -138,8 +138,8 @@
     @testset "the video and non-video halves are judged separately" begin
         # One csv holding both kinds, each with its own duplicate. A video row and a matlab row can
         # never be duplicates of each other, and each half keeps its own first occurrence.
-        df = check("s_dupmixed.csv", [videorow(calibration_id = "v1"), videorow(calibration_id = "v2"),
-                                      matlabrow(calibration_id = "m1"), matlabrow(calibration_id = "m2")])
+        df = check([videorow(calibration_id = "v1"), videorow(calibration_id = "v2"),
+                    matlabrow(calibration_id = "m1"), matlabrow(calibration_id = "m2")])
         @test !flagged(df, 1, "duplicate rectification")
         @test flagged(df, 2, "duplicate rectification")
         @test !flagged(df, 3, "duplicate rectification")
@@ -147,8 +147,8 @@
     end
 
     @testset "negative control: same file+type, different extrinsic is fine" begin
-        df = check("s_ok.csv", [videorow(calibration_id = "n1", extrinsic = "00:00:01"),
-                                videorow(calibration_id = "n2", extrinsic = "00:00:03")])
+        df = check([videorow(calibration_id = "n1", extrinsic = "00:00:01"),
+                    videorow(calibration_id = "n2", extrinsic = "00:00:03")])
         @test clean(df)
     end
 end

--- a/test/VerifyRectifications/test_values.jl
+++ b/test/VerifyRectifications/test_values.jl
@@ -2,78 +2,78 @@
     # baseline board.mp4 has dimension (500, 376); each row overrides one field.
 
     @testset "center bounds" begin
-        @test flagged(check("v_cs.csv",  [videorow(center = (0, 0))]),     1, "center cannot be smaller than 1")
-        @test flagged(check("v_cl.csv",  [videorow(center = (600, 600))]), 1, "center cannot be larger than the dimensions")
+        @test flagged(check([videorow(center = (0, 0))]),     1, "center cannot be smaller than 1")
+        @test flagged(check([videorow(center = (600, 600))]), 1, "center cannot be larger than the dimensions")
         # only one coordinate out of bounds still trips any(.>)
-        @test flagged(check("v_c1.csv",  [videorow(center = (600, 100))]), 1, "center cannot be larger than the dimensions")
+        @test flagged(check([videorow(center = (600, 100))]), 1, "center cannot be larger than the dimensions")
         # center == dimension is allowed (the check is strict >)
-        @test clean(check("v_cb.csv",    [videorow(center = (500, 376))]))
+        @test clean(check([videorow(center = (500, 376))]))
     end
 
     @testset "north bounds" begin
-        @test flagged(check("v_ns.csv", [videorow(north = (0, 0))]),     1, "north cannot be smaller than 1")
-        @test flagged(check("v_nl.csv", [videorow(north = (600, 600))]), 1, "north cannot be larger than the dimensions")
+        @test flagged(check([videorow(north = (0, 0))]),     1, "north cannot be smaller than 1")
+        @test flagged(check([videorow(north = (600, 600))]), 1, "north cannot be larger than the dimensions")
     end
 
     # A clean load returns Vector{RectificationMethod}; the scenario row is element 1, and center/north
     # now live in the shared Source struct, so inspect df[1].source.center / df[1].source.north.
     # center/north are optional and never imputed: omitted values stay missing.
     @testset "both omitted stays missing" begin
-        df = check("v_nocn.csv", [videorow(center = missing, north = missing)])
+        df = check([videorow(center = missing, north = missing)])
         @test clean(df)
         @test df[1].source.center === missing
         @test df[1].source.north  === missing
     end
 
     @testset "north omitted with center given stays missing" begin
-        df = check("v_north.csv", [videorow(north = missing)])   # center (250,180)
+        df = check([videorow(north = missing)])   # center (250,180)
         @test clean(df)
         @test df[1].source.center == (250, 180)
         @test df[1].source.north  === missing
     end
 
     @testset "scalar field ranges" begin
-        @test flagged(check("v_scale.csv",  [scalerow(scale = -1)]),              1, "scale must be larger than zero")
-        @test flagged(check("v_check.csv",  [videorow(checker_size = 0)]),        1, "checker_size must be larger than zero")
-        @test flagged(check("v_radial.csv", [videorow(radial_parameters = 4)]),   1, "radial_parameters must be 1, 2, or 3")
-        @test flagged(check("v_radial0.csv",[videorow(radial_parameters = 0)]),   1, "radial_parameters must be 1, 2, or 3")
-        @test flagged(check("v_blur.csv",   [videorow(blur = -1)]),               1, "blur must be larger than or equal to zero")
+        @test flagged(check([scalerow(scale = -1)]),              1, "scale must be larger than zero")
+        @test flagged(check([videorow(checker_size = 0)]),        1, "checker_size must be larger than zero")
+        @test flagged(check([videorow(radial_parameters = 4)]),   1, "radial_parameters must be 1, 2, or 3")
+        @test flagged(check([videorow(radial_parameters = 0)]),   1, "radial_parameters must be 1, 2, or 3")
+        @test flagged(check([videorow(blur = -1)]),               1, "blur must be larger than or equal to zero")
         # OpenCV's findChessboardCorners requires both pattern dimensions strictly bigger than 2,
         # so the bound is ≥ 3 — checked here rather than caught out of the detector.
-        @test flagged(check("v_ncorn.csv",  [videorow(n_corners = (0, 5))]),      1, "n_corners must all be at least 3")
-        @test flagged(check("v_ncorn1.csv", [videorow(n_corners = (1, 5))]),      1, "n_corners must all be at least 3")
-        @test flagged(check("v_ncorn11.csv",[videorow(n_corners = (1, 1))]),      1, "n_corners must all be at least 3")
-        @test flagged(check("v_ncorn2.csv", [videorow(n_corners = (2, 5))]),      1, "n_corners must all be at least 3")
-        @test flagged(check("v_ncorn22.csv",[videorow(n_corners = (2, 2))]),      1, "n_corners must all be at least 3")
-        @test flagged(check("v_step.csv",   [videorow(temporal_step = 0)]),       1, "temporal_step must be larger than zero")
-        @test flagged(check("v_aspect0.csv",[videorow(aspect = 0)]),              1, "aspect must be larger than zero")
-        @test flagged(check("v_aspectn.csv",[videorow(aspect = -1.2)]),           1, "aspect must be larger than zero")
+        @test flagged(check([videorow(n_corners = (0, 5))]),      1, "n_corners must all be at least 3")
+        @test flagged(check([videorow(n_corners = (1, 5))]),      1, "n_corners must all be at least 3")
+        @test flagged(check([videorow(n_corners = (1, 1))]),      1, "n_corners must all be at least 3")
+        @test flagged(check([videorow(n_corners = (2, 5))]),      1, "n_corners must all be at least 3")
+        @test flagged(check([videorow(n_corners = (2, 2))]),      1, "n_corners must all be at least 3")
+        @test flagged(check([videorow(temporal_step = 0)]),       1, "temporal_step must be larger than zero")
+        @test flagged(check([videorow(aspect = 0)]),              1, "aspect must be larger than zero")
+        @test flagged(check([videorow(aspect = -1.2)]),           1, "aspect must be larger than zero")
     end
 
     @testset "extrinsic timing" begin
-        @test flagged(check("v_eneg.csv", [videorow(extrinsic = "-1")]),         1, "extrinsic must be larger than or equal to zero")
-        @test flagged(check("v_edur.csv", [videorow(extrinsic = "00:01:00")]),   1, "extrinsic must come before the video duration")
+        @test flagged(check([videorow(extrinsic = "-1")]),         1, "extrinsic must be larger than or equal to zero")
+        @test flagged(check([videorow(extrinsic = "00:01:00")]),   1, "extrinsic must come before the video duration")
         # the bound is strict: seeking at exactly the duration yields no frame, so == is rejected too
         d = VRect.probe_video(joinpath(DATADIR, ART.board)).duration
-        @test flagged(check("v_edur_eq.csv", [videorow(extrinsic = string(d))]), 1, "extrinsic must come before the video duration")
+        @test flagged(check([videorow(extrinsic = string(d))]), 1, "extrinsic must come before the video duration")
     end
 
     @testset "temporal_step too short" begin
-        df = check("v_short.csv", [videorow(start = "00:00:00", stop = "00:00:01", temporal_step = 2)])
+        df = check([videorow(start = "00:00:00", stop = "00:00:01", temporal_step = 2)])
         @test flagged(df, 1, "temporal_step too short")
     end
 
     @testset "calibs window" begin
         # baseline video is VIDEO_DURATION (5) s.
-        @test flagged(check("v_wneg.csv", [videorow(start = "-1", stop = "00:00:04")]),
+        @test flagged(check([videorow(start = "-1", stop = "00:00:04")]),
                       1, "start must be larger than or equal to zero")
-        @test flagged(check("v_winv.csv", [videorow(start = "00:00:04", stop = "00:00:01")]),
+        @test flagged(check([videorow(start = "00:00:04", stop = "00:00:01")]),
                       1, "start must come before stop")
         # a window that runs past the end of the video is caught
-        @test flagged(check("v_wdur.csv", [videorow(start = "00:00:01", stop = "00:10:00")]),
+        @test flagged(check([videorow(start = "00:00:01", stop = "00:10:00")]),
                       1, "stop can not come after video duration")
         # an inverted window must NOT also emit the misleading "temporal_step too short"
-        @test !flagged(check("v_winv2.csv", [videorow(start = "00:00:04", stop = "00:00:01")]),
+        @test !flagged(check([videorow(start = "00:00:04", stop = "00:00:01")]),
                        1, "temporal_step too short")
     end
 end

--- a/test/VerifyRectifications/test_video_metadata.jl
+++ b/test/VerifyRectifications/test_video_metadata.jl
@@ -26,7 +26,7 @@
     @testset "missing yadif/width/height are imputed onto the Video struct" begin
         # A clean load returns Vector{Video}; with the columns left blank they are filled from the probe.
         probed = VRect.probe_video(joinpath(DATADIR, ART.board))
-        result = check("vm_impute.csv", [videorow()])
+        result = check([videorow()])
         @test result isa Vector
         v = first(result)
         @test v.yadif == false                       # board is progressive (yadif stays on Video)
@@ -39,7 +39,7 @@
         # board is progressive, but an explicit yadif cell must be kept verbatim, not overwritten.
         # width/height have no CSV column, so they always come from the probe (the real frame size).
         probed = VRect.probe_video(joinpath(DATADIR, ART.board))
-        result = check("vm_provided.csv", [videorow(yadif = true)])
+        result = check([videorow(yadif = true)])
         @test result isa Vector
         v = first(result)
         @test v.yadif == true                         # provided, not the probed false
@@ -48,12 +48,12 @@
     end
 
     @testset "a non-boolean yadif is a parse issue, never thrown" begin
-        @test flagged(check("vm_yadif_bad.csv", [videorow(yadif = "maybe")]), 1, "wrong yadif format")
+        @test flagged(check([videorow(yadif = "maybe")]), 1, "wrong yadif format")
     end
 
     @testset "a CSV-supplied aspect wins over the probe" begin
         # board.mp4 has square pixels (probe aspect 1.0); an explicit CSV aspect must be kept verbatim.
-        result = check("vm_aspect_provided.csv", [videorow(aspect = 2.0)])
+        result = check([videorow(aspect = 2.0)])
         @test result isa Vector
         @test first(result).source.aspect == 2.0
     end
@@ -64,11 +64,13 @@
         # structs, so inspect c[1].source.width/height.
         probed = VRect.probe_video(joinpath(DATADIR, ART.video))   # video.mp4: 640×480
         for (name, r) in (("scale", scalerow()), ("matlab", matlabrow()))
-            c = check("vm_$name.csv", [r])
-            @test c isa Vector
-            @test c[1].source.width  == probed.width
-            @test c[1].source.height == probed.height
-            @test !hasproperty(c[1], :yadif)                     # yadif is only on the Video struct
+            @testset "$name" begin
+                c = check([r])
+                @test c isa Vector
+                @test c[1].source.width  == probed.width
+                @test c[1].source.height == probed.height
+                @test !hasproperty(c[1], :yadif)                 # yadif is only on the Video struct
+            end
         end
     end
 end

--- a/test/VerifyRuns/helpers.jl
+++ b/test/VerifyRuns/helpers.jl
@@ -55,8 +55,14 @@ function check(name, rows; strict = false, header = HEADER, defaults = (;))
     VR.load_runs(DATADIR, csv; strict, defaults)
 end
 
+# Each scenario is loaded as its own csv, so the name only has to be unique within DATADIR — the
+# suite generates it. Name one explicitly only when the test is about the file itself.
+const CASE = Ref(0)
+check(rows; kw...) = check("case_$(CASE[] += 1).csv", rows; kw...)
+
 "Like `check`, but also capture what the load prints to stdout. Returns (result, output)."
 load_capturing(name, rows; kw...) = capturing(() -> check(name, rows; kw...))
+load_capturing(rows; kw...) = capturing(() -> check(rows; kw...))
 
 # A clean load returns Vector{Run}; a load with issues returns a DataFrame carrying :issues.
 clean(x) = x isa Vector{VR.Run}

--- a/test/VerifyRuns/test_defaults.jl
+++ b/test/VerifyRuns/test_defaults.jl
@@ -2,33 +2,33 @@
     # The hierarchy under test: csv cell → defaults kwarg → hardcoded/probed value.
 
     @testset "kwarg fills a blank cell; a csv cell wins" begin
-        runs = check("d_tw.csv", [runrow()]; defaults = (target_width = 60,))
+        runs = check([runrow()]; defaults = (target_width = 60,))
         @test clean(runs)
         @test only(runs).source.target_width == 60.0
-        runs = check("d_tw2.csv", [runrow(target_width = 30)]; defaults = (target_width = 60,))
+        runs = check([runrow(target_width = 30)]; defaults = (target_width = 60,))
         @test only(runs).source.target_width == 30.0
     end
 
     @testset "fps kwarg beats the probe" begin
         # a.mp4 runs at 30 fps (the probe would impute 30); a global fps wins when the cell is
         # blank, and still passes the ≤ video-frame-rate check
-        runs = check("d_fps.csv", [runrow()]; defaults = (fps = 15,))
+        runs = check([runrow()]; defaults = (fps = 15,))
         @test clean(runs)
         @test only(runs).source.fps == 15.0
     end
 
     @testset "window_size accepts a scalar or a (w, h) tuple" begin
-        @test only(check("d_win.csv",  [runrow()]; defaults = (window_size = 31,))).source.window_size == 31
-        @test only(check("d_win2.csv", [runrow()]; defaults = (window_size = (31, 41),))).source.window_size == (31, 41)
+        @test only(check([runrow()]; defaults = (window_size = 31,))).source.window_size == 31
+        @test only(check([runrow()]; defaults = (window_size = (31, 41),))).source.window_size == (31, 41)
     end
 
     @testset "bad overrides fail fast; bad values are verified per row" begin
         # non-whitelisted key (the temporal window is per-row only)
-        @test_throws ArgumentError check("d_unknown.csv", [runrow()]; defaults = (start = 0,))
+        @test_throws ArgumentError check([runrow()]; defaults = (start = 0,))
         # unconvertible value
-        @test_throws ArgumentError check("d_badtype.csv", [runrow()]; defaults = (darker_target = "yes",))
+        @test_throws ArgumentError check([runrow()]; defaults = (darker_target = "yes",))
         # a convertible but nonsensical value flows into the normal verification
-        @test flagged(check("d_range.csv", [runrow()]; defaults = (target_width = -5,)),
+        @test flagged(check([runrow()]; defaults = (target_width = -5,)),
                       1, "target_width must be larger than zero")
     end
 end

--- a/test/VerifyRuns/test_filesystem.jl
+++ b/test/VerifyRuns/test_filesystem.jl
@@ -1,16 +1,16 @@
 @testset "filesystem" begin
     @testset "path does not exist" begin
-        @test flagged(check("fs_dir.csv", [runrow(path = "no_such_dir")]), 1, "path does not exist")
+        @test flagged(check([runrow(path = "no_such_dir")]), 1, "path does not exist")
     end
 
     @testset "file does not exist" begin
-        @test flagged(check("fs_file.csv", [runrow(file = "no_such_file.mp4")]), 1, "file does not exist")
+        @test flagged(check([runrow(file = "no_such_file.mp4")]), 1, "file does not exist")
     end
 
     @testset "a path naming the video itself says so (#33)" begin
         # The targeted message runs first and nulls :path, so the existence check does not also
         # fire with the misleading "path does not exist".
-        df = check("fs_pathisfile.csv", [runrow(path = ART.a)])
+        df = check([runrow(path = ART.a)])
         @test flagged(df, 1, "path is a file, not a folder")
         @test !flagged(df, 1, "path does not exist")
     end

--- a/test/VerifyRuns/test_gatekeeper.jl
+++ b/test/VerifyRuns/test_gatekeeper.jl
@@ -2,7 +2,7 @@
 # without error. Short (1 s) clips keep this fast while still exercising the real track call.
 @testset "gatekeeper: a verified run drives track()" begin
     @testset "single-file run" begin
-        runs = check("gk_single.csv", [runrow(run_id = "g1", start = "0", stop = "1", target_width = "20")])
+        runs = check([runrow(run_id = "g1", start = "0", stop = "1", target_width = "20")])
         @test clean(runs)
         t, ij = VR.track(only(runs))
         @test length(t) == length(ij)
@@ -10,8 +10,8 @@
     end
 
     @testset "segmented run across two videos" begin
-        runs = check("gk_seg.csv", [runrow(run_id = "g2", file = ART.a, start = "0", stop = "1", start_location = "(100, 100)"),
-                                    runrow(run_id = "g2", file = ART.b, start = "0", stop = "1")])
+        runs = check([runrow(run_id = "g2", file = ART.a, start = "0", stop = "1", start_location = "(100, 100)"),
+                      runrow(run_id = "g2", file = ART.b, start = "0", stop = "1")])
         @test clean(runs)
         t, ij = VR.track(only(runs))
         @test length(t) == length(ij) > 0

--- a/test/VerifyRuns/test_happy.jl
+++ b/test/VerifyRuns/test_happy.jl
@@ -1,6 +1,6 @@
 @testset "happy path" begin
     @testset "fully valid run validates clean and returns a Run" begin
-        runs = check("h_one.csv", [runrow(start = "0", stop = "4", target_width = "20")])
+        runs = check([runrow(start = "0", stop = "4", target_width = "20")])
         @test clean(runs)
         @test runs isa Vector{VR.Run}
         @test length(runs) == 1
@@ -9,9 +9,9 @@
 
     @testset "several valid runs, strict returns them without throwing" begin
         # strict=true would throw if any row had an issue
-        runs = check("h_many.csv", [runrow(run_id = "a", file = ART.a),
-                                    runrow(run_id = "b", file = ART.b, fps = "24"),
-                                    runrow(run_id = "c", file = ART.a, start_location = "(320, 240)")];
+        runs = check([runrow(run_id = "a", file = ART.a),
+                      runrow(run_id = "b", file = ART.b, fps = "24"),
+                      runrow(run_id = "c", file = ART.a, start_location = "(320, 240)")];
                      strict = true)
         @test runs isa Vector{VR.Run}
         @test length(runs) == 3

--- a/test/VerifyRuns/test_parsing.jl
+++ b/test/VerifyRuns/test_parsing.jl
@@ -3,32 +3,32 @@
     # the only thing under test (other checks pass).
 
     @testset "missing required fields" begin
-        @test flagged(check("p_file.csv", [runrow(file = missing)]),   1, "file is missing")
+        @test flagged(check([runrow(file = missing)]),   1, "file is missing")
     end
 
     @testset "calibration_id is required" begin
         # a run is always rectified against a calibration (Fromage joins on calibration_id), so a
         # run without one has nothing to rectify against and is flagged rather than left missing.
-        @test only(check("cal_set.csv", [runrow(calibration_id = "cal_42")])).calibration_id == "cal_42"
-        @test flagged(check("cal_missing.csv", [runrow(calibration_id = missing)]), 1, "calibration_id is missing")
-        @test flagged(check("cal_blank.csv",   [runrow(calibration_id = "   ")]),   1, "calibration_id is missing")
+        @test only(check([runrow(calibration_id = "cal_42")])).calibration_id == "cal_42"
+        @test flagged(check([runrow(calibration_id = missing)]), 1, "calibration_id is missing")
+        @test flagged(check([runrow(calibration_id = "   ")]),   1, "calibration_id is missing")
     end
 
     @testset "run_id is all-or-nothing" begin
         # all rows blank (missing or whitespace-only) ⇒ clean, each row its own run, id = row number
-        runs = check("p_id_none.csv",
+        runs = check(
                      [runrow(run_id = missing), runrow(run_id = "   "), runrow(run_id = missing)])
         @test clean(runs)
         @test all(r -> length(r.files) == 1, runs)
         @test [r.run_id for r in runs] == ["1", "2", "3"]
 
         # all rows named ⇒ clean, ids used as-is
-        runs2 = check("p_id_all.csv", [runrow(run_id = "x"), runrow(run_id = "y")])
+        runs2 = check([runrow(run_id = "x"), runrow(run_id = "y")])
         @test clean(runs2)
         @test [r.run_id for r in runs2] == ["x", "y"]
 
         # mixed ⇒ every blank row is flagged, the named row is not
-        df = check("p_id_mixed.csv",
+        df = check(
                    [runrow(run_id = missing), runrow(run_id = "   "), runrow(run_id = "given")])
         @test flagged(df, 1, "either every row has a run_id or none does")
         @test flagged(df, 2, "either every row has a run_id or none does")
@@ -36,35 +36,35 @@
 
         # the collision this rule forecloses: an explicit "3" plus a blank row must not merge
         # into a bogus multi-segment run — the mixed file is rejected outright
-        df2 = check("p_id_collide.csv", [runrow(run_id = "3", file = ART.a),
-                                         runrow(run_id = missing, file = ART.b)])
+        df2 = check([runrow(run_id = "3", file = ART.a),
+                     runrow(run_id = missing, file = ART.b)])
         @test flagged(df2, 2, "either every row has a run_id or none does")
         @test !flagged(df2, 1, "either every row has a run_id or none does")
     end
 
     @testset "blank (whitespace-only) cell is treated as missing" begin
-        @test flagged(check("p_blank_file.csv", [runrow(file = "   ")]),   1, "file is missing")
+        @test flagged(check([runrow(file = "   ")]),   1, "file is missing")
         # an optional field falls back to its default ("." for path) and still resolves
-        @test clean(check("p_blank_path.csv", [runrow(path = "  ")]))
+        @test clean(check([runrow(path = "  ")]))
     end
 
     @testset "wrong formats" begin
-        @test flagged(check("p_start.csv",  [runrow(start = "not_a_time")]),          1, "wrong start format")
-        @test flagged(check("p_stop.csv",   [runrow(stop = "nope")]),                 1, "wrong stop format")
-        @test flagged(check("p_tw.csv",     [runrow(target_width = "big")]),          1, "wrong target_width format")
-        @test flagged(check("p_sl.csv",     [runrow(start_location = "abc")]),        1, "wrong start_location format")
-        @test flagged(check("p_sl2.csv",    [runrow(start_location = "1;2")]),        1, "wrong start_location format")
+        @test flagged(check([runrow(start = "not_a_time")]),          1, "wrong start format")
+        @test flagged(check([runrow(stop = "nope")]),                 1, "wrong stop format")
+        @test flagged(check([runrow(target_width = "big")]),          1, "wrong target_width format")
+        @test flagged(check([runrow(start_location = "abc")]),        1, "wrong start_location format")
+        @test flagged(check([runrow(start_location = "1;2")]),        1, "wrong start_location format")
         # a coordinate that overflows Int64 is a graceful "wrong format", not an uncaught OverflowError
-        @test flagged(check("p_sl_ovf.csv", [runrow(start_location = "(10000000000000000000,1)")]), 1, "wrong start_location format")
-        @test flagged(check("p_win.csv",    [runrow(window_size = "wide")]),          1, "wrong window_size format")
-        @test flagged(check("p_fps.csv",    [runrow(fps = "fast")]),                  1, "wrong fps format")
-        @test flagged(check("p_isf.csv",    [runrow(initial_search_factor = "x")]),   1, "wrong initial_search_factor format")
-        @test flagged(check("p_sc.csv",     [runrow(scale = "big")]),                 1, "wrong scale format")
-        @test flagged(check("p_dark.csv",   [runrow(darker_target = "maybe")]),       1, "wrong darker_target format")
+        @test flagged(check([runrow(start_location = "(10000000000000000000,1)")]), 1, "wrong start_location format")
+        @test flagged(check([runrow(window_size = "wide")]),          1, "wrong window_size format")
+        @test flagged(check([runrow(fps = "fast")]),                  1, "wrong fps format")
+        @test flagged(check([runrow(initial_search_factor = "x")]),   1, "wrong initial_search_factor format")
+        @test flagged(check([runrow(scale = "big")]),                 1, "wrong scale format")
+        @test flagged(check([runrow(darker_target = "maybe")]),       1, "wrong darker_target format")
     end
 
     @testset "defaults applied (with correct values) when optional fields omitted" begin
-        runs = check("p_defaults.csv", [runrow()])   # only run_id + calibration_id + file set
+        runs = check([runrow()])   # only run_id + calibration_id + file set
         @test clean(runs)
         r = only(runs)
         @test length(r.files) == 1                    # one csv row ⇒ one segment
@@ -79,13 +79,13 @@
     end
 
     @testset "start/stop accept seconds and HH:MM:SS" begin
-        @test clean(check("p_secs.csv",  [runrow(start = "1.0", stop = "3.5")]))
-        @test clean(check("p_clock.csv", [runrow(start = "00:00:01", stop = "00:00:03")]))
-        @test only(only(check("p_clock2.csv", [runrow(start = "00:00:02")])).starts) == 2.0
+        @test clean(check([runrow(start = "1.0", stop = "3.5")]))
+        @test clean(check([runrow(start = "00:00:01", stop = "00:00:03")]))
+        @test only(only(check([runrow(start = "00:00:02")])).starts) == 2.0
     end
 
     @testset "whitespace is trimmed from string fields" begin
-        @test clean(check("p_ws_file.csv", [runrow(file = " " * ART.a)]))   # " a.mp4" still resolves
+        @test clean(check([runrow(file = " " * ART.a)]))   # " a.mp4" still resolves
     end
 
     @testset "MyWindow: Int or (w,h) (this gateway's own cell type)" begin

--- a/test/VerifyRuns/test_segments.jl
+++ b/test/VerifyRuns/test_segments.jl
@@ -1,8 +1,8 @@
 @testset "segmented runs (grouping by run_id)" begin
 
     @testset "rows sharing a run_id fold into one run, in CSV order" begin
-        runs = check("seg_two.csv", [runrow(run_id = "s", file = ART.a, start = "0", stop = "4", start_location = "(100, 100)"),
-                                     runrow(run_id = "s", file = ART.b, start = "1", stop = "7")])
+        runs = check([runrow(run_id = "s", file = ART.a, start = "0", stop = "4", start_location = "(100, 100)"),
+                      runrow(run_id = "s", file = ART.b, start = "1", stop = "7")])
         @test clean(runs)
         @test length(runs) == 1
         r = only(runs)
@@ -15,8 +15,8 @@
     end
 
     @testset "distinct run_ids stay separate runs" begin
-        runs = check("seg_distinct.csv", [runrow(run_id = "x", file = ART.a),
-                                          runrow(run_id = "y", file = ART.b)])
+        runs = check([runrow(run_id = "x", file = ART.a),
+                      runrow(run_id = "y", file = ART.b)])
         @test clean(runs)
         @test length(runs) == 2
         @test all(r -> length(r.files) == 1, runs)
@@ -24,59 +24,59 @@
     end
 
     @testset "segments must agree on run-level parameters" begin
-        df = check("seg_conflict.csv", [runrow(run_id = "c", file = ART.a, target_width = "20"),
-                                        runrow(run_id = "c", file = ART.b, target_width = "30")])
+        df = check([runrow(run_id = "c", file = ART.a, target_width = "20"),
+                    runrow(run_id = "c", file = ART.b, target_width = "30")])
         @test flagged(df, 1, "run segments disagree on target_width")
         @test flagged(df, 2, "run segments disagree on target_width")
     end
 
     @testset "segments must agree on background_length (a run-level parameter)" begin
-        df = check("seg_bl.csv", [runrow(run_id = "b", file = ART.a, background_length = "30"),
-                                  runrow(run_id = "b", file = ART.b, background_length = "40")])
+        df = check([runrow(run_id = "b", file = ART.a, background_length = "30"),
+                    runrow(run_id = "b", file = ART.b, background_length = "40")])
         @test flagged(df, 1, "run segments disagree on background_length")
         @test flagged(df, 2, "run segments disagree on background_length")
     end
 
     @testset "segments must agree on the video's pixel dimensions" begin
         # width/height live on the run-level Source, so mixed-dimension segments are rejected
-        df = check("seg_dim.csv", [runrow(run_id = "d", file = ART.a),
-                                   runrow(run_id = "d", file = ART.small)])
+        df = check([runrow(run_id = "d", file = ART.a),
+                    runrow(run_id = "d", file = ART.small)])
         @test flagged(df, 1, "run segments disagree on dimension")
         @test flagged(df, 2, "run segments disagree on dimension")
     end
 
     @testset "a run's segments must agree on calibration_id (required on every row)" begin
         # all segments share the same calibration_id ⇒ clean, carried onto the run
-        runs = check("seg_cal_same.csv", [runrow(run_id = "s", file = ART.a, calibration_id = "cal_1"),
-                                          runrow(run_id = "s", file = ART.b, calibration_id = "cal_1")])
+        runs = check([runrow(run_id = "s", file = ART.a, calibration_id = "cal_1"),
+                      runrow(run_id = "s", file = ART.b, calibration_id = "cal_1")])
         @test clean(runs)
         @test length(only(runs).files) == 2
         @test only(runs).calibration_id == "cal_1"
 
         # omitting it is not allowed: every such segment row is flagged at parse time
-        df0 = check("seg_cal_none.csv", [runrow(run_id = "s", file = ART.a, calibration_id = missing),
-                                         runrow(run_id = "s", file = ART.b, calibration_id = missing)])
+        df0 = check([runrow(run_id = "s", file = ART.a, calibration_id = missing),
+                     runrow(run_id = "s", file = ART.b, calibration_id = missing)])
         @test flagged(df0, 1, "calibration_id is missing")
         @test flagged(df0, 2, "calibration_id is missing")
 
         # two different values ⇒ flagged on every segment
-        df = check("seg_cal_diff.csv", [runrow(run_id = "s", file = ART.a, calibration_id = "cal_1"),
-                                        runrow(run_id = "s", file = ART.b, calibration_id = "cal_2")])
+        df = check([runrow(run_id = "s", file = ART.a, calibration_id = "cal_1"),
+                    runrow(run_id = "s", file = ART.b, calibration_id = "cal_2")])
         @test flagged(df, 1, "run segments disagree on calibration_id")
         @test flagged(df, 2, "run segments disagree on calibration_id")
 
         # one set, one missing: the omission itself is the issue; the consistency check only
         # compares otherwise-clean rows, so no "disagree" is stacked on top of it
-        df2 = check("seg_cal_partial.csv", [runrow(run_id = "s", file = ART.a, calibration_id = "cal_1"),
-                                            runrow(run_id = "s", file = ART.b, calibration_id = missing)])
+        df2 = check([runrow(run_id = "s", file = ART.a, calibration_id = "cal_1"),
+                     runrow(run_id = "s", file = ART.b, calibration_id = missing)])
         @test flagged(df2, 2, "calibration_id is missing")
         @test !flagged(df2, 1, "run segments disagree on calibration_id")
     end
 
     @testset "a single bad segment fails the whole run load" begin
         # second segment points at a missing file: the load reports it (non-strict ⇒ returns the df)
-        df = check("seg_badfile.csv", [runrow(run_id = "b", file = ART.a),
-                                       runrow(run_id = "b", file = "no_such.mp4")])
+        df = check([runrow(run_id = "b", file = ART.a),
+                    runrow(run_id = "b", file = "no_such.mp4")])
         @test df isa AbstractDataFrame
         @test flagged(df, 2, "file does not exist")
     end
@@ -87,8 +87,8 @@
         # run — and a later call with a *different* `center` then silently kept the first one, because
         # the coalesce saw a non-missing first element.
         # (`isequal`, not `==`: comparing vectors that contain `missing` yields `missing`.)
-        runs = check("seg_nomutate.csv", [runrow(run_id = "m", file = ART.a, start_location = missing),
-                                          runrow(run_id = "m", file = ART.b)])
+        runs = check([runrow(run_id = "m", file = ART.a, start_location = missing),
+                      runrow(run_id = "m", file = ART.b)])
         r = only(runs)
         @test length(r.files) == 2
         before = copy(r.start_locations)
@@ -115,7 +115,7 @@
         # A single-video run used to carry its start_location as an immutable scalar field, so this
         # could not go wrong at arity 1. It is a one-element vector now, and every run takes the
         # same imputation path, so the guarantee has to be asserted here too.
-        r = only(check("seg_nomutate_one.csv", [runrow(run_id = "o", start_location = missing)]))
+        r = only(check([runrow(run_id = "o", start_location = missing)]))
         @test length(r.files) == 1
         @test all(ismissing, r.start_locations)
         sls = VR.impute_start_location(r, (7, 9))

--- a/test/VerifyRuns/test_strict.jl
+++ b/test/VerifyRuns/test_strict.jl
@@ -1,10 +1,10 @@
 @testset "strict mode & issue report" begin
     @testset "strict=true throws when issues exist" begin
-        @test_throws "there were issues" check("st_throw.csv", [runrow(target_width = "-1")]; strict = true)
+        @test_throws "there were issues" check([runrow(target_width = "-1")]; strict = true)
     end
 
     @testset "issue report is printed; non-strict returns the df with :issues" begin
-        df, out = load_capturing("st_msg.csv", [runrow(target_width = "-1")])
+        df, out = load_capturing([runrow(target_width = "-1")])
         @test occursin("row 1 (run_id: r): target_width must be larger than zero", out)
         @test !occursin("target_width must be larger than zero,", out)   # join adds no trailing separator
         @test df isa AbstractDataFrame
@@ -12,7 +12,7 @@
     end
 
     @testset "auto-assigned run_ids are not repeated in the issue report" begin
-        _, out = load_capturing("st_auto.csv", [row(calibration_id = "c", file = ART.a, target_width = "-1")])
+        _, out = load_capturing([row(calibration_id = "c", file = ART.a, target_width = "-1")])
         @test occursin("row 1: target_width must be larger than zero", out)
         @test !occursin("run_id", out)
     end

--- a/test/VerifyRuns/test_tracking.jl
+++ b/test/VerifyRuns/test_tracking.jl
@@ -14,7 +14,7 @@
     seg2,  seg2_exp  = make_target_video("t_seg2"; sar = 2//1, nsegments = 3)
 
     @testset "defaults: imputed stop/fps/window, frame-center start" begin
-        runs = check("t_base.csv", [runrow(file = only(base))])
+        runs = check([runrow(file = only(base))])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test length(ij) == 50                       # stop imputed from the full 2 s at 25 fps
@@ -23,37 +23,37 @@
 
     @testset "start_location sources" begin
         # explicit CSV cell
-        runs = check("t_sl_csv.csv", [runrow(file = only(base), start_location = "(55, 50)")])
+        runs = check([runrow(file = only(base), start_location = "(55, 50)")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, base_exp) < 1
         # the `center` keyword (what Fromage passes from the rectification)
-        runs = check("t_sl_ctr.csv", [runrow(file = only(base))])
+        runs = check([runrow(file = only(base))])
         @test clean(runs)
         _, ij = VR.track(only(runs); center = (55, 50))
         @test tracking_rmse(ij, base_exp) < 1
     end
 
     @testset "window_size sources" begin
-        runs = check("t_win_i.csv", [runrow(file = only(base), window_size = "31")])
+        runs = check([runrow(file = only(base), window_size = "31")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, base_exp) < 1
-        runs = check("t_win_t.csv", [runrow(file = only(base), window_size = "(31, 21)")])
+        runs = check([runrow(file = only(base), window_size = "(31, 21)")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, base_exp) < 1
     end
 
     @testset "lighter target on dark background" begin
-        runs = check("t_light.csv", [runrow(file = only(light), darker_target = "false")])
+        runs = check([runrow(file = only(light), darker_target = "false")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, light_exp) < 1
     end
 
     @testset "requested fps below the video's rate" begin
-        runs = check("t_fps.csv", [runrow(file = only(base), fps = "12.5")])
+        runs = check([runrow(file = only(base), fps = "12.5")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test length(ij) == 25                       # every other frame
@@ -62,7 +62,7 @@
 
     @testset "start/stop sub-window" begin
         # the start_location must be where the target is at t = start (frame 10), not at t = 0
-        runs = check("t_sub.csv", [runrow(file = only(base), start = "0.4", stop = "1.6", start_location = "(32, 50)")])
+        runs = check([runrow(file = only(base), start = "0.4", stop = "1.6", start_location = "(32, 50)")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test length(ij) == 30
@@ -71,7 +71,7 @@
 
     @testset "downscaled tracking (scale = 0.5)" begin
         # coordinates come back in the *original* stored-frame pixels regardless of scale
-        runs = check("t_scale.csv", [runrow(file = only(base), scale = "0.5")])
+        runs = check([runrow(file = only(base), scale = "0.5")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, base_exp) < 1
@@ -83,24 +83,24 @@
         # is a 10 px disc, so scale 0.1 is the smallest legal value (a 10×10 working frame). The
         # tolerance is loose because precision at the boundary is inherently about 1/scale — the
         # assertion is that the track stays within the target's own radius rather than wandering.
-        runs = check("t_scale_min.csv", [runrow(file = only(base), target_width = "10", scale = "0.1")])
+        runs = check([runrow(file = only(base), target_width = "10", scale = "0.1")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, base_exp) < 5
     end
 
     @testset "anamorphic (sar ≠ 1)" begin
-        for (slug, label, files, exp) in (("sar05", "sar 1/2 (stored 200×100)", sar05, sar05_exp),
-                                          ("sar2",  "sar 2 (stored 50×100)",    sar2,  sar2_exp))
+        for (label, files, exp) in (("sar 1/2 (stored 200×100)", sar05, sar05_exp),
+                                    ("sar 2 (stored 50×100)",    sar2,  sar2_exp))
             @testset "$label" begin
                 # explicit display-space start_location; for sar 2 its x (55) exceeds the *stored*
                 # width (50) — valid, because bounds are display-space (width × sar)
-                runs = check("t_$slug.csv", [runrow(file = only(files), start_location = "(55, 50)")])
+                runs = check([runrow(file = only(files), start_location = "(55, 50)")])
                 @test clean(runs)
                 _, ij = VR.track(only(runs))
                 @test tracking_rmse(ij, exp) < 1
                 # frame-center default must be the *display* center, sar-corrected
-                runs = check("t_$(slug)_c.csv", [runrow(file = only(files))])
+                runs = check([runrow(file = only(files))])
                 @test clean(runs)
                 _, ij = VR.track(only(runs))
                 @test tracking_rmse(ij, exp) < 1
@@ -108,10 +108,10 @@
         end
         # display-space bounds, both directions: the sar-1/2 video stores 200×100 but displays
         # 100×100, so x = 150 is out; the sar-2 video stores 50×100 but displays 100×100, so x = 80 is in
-        @test flagged(check("t_sar_oob.csv", [runrow(file = only(sar05), start_location = "(150, 50)")]), 1, "start_location is outside the frame")
-        @test clean(check("t_sar_inb.csv",   [runrow(file = only(sar2),  start_location = "(80, 50)")]))
+        @test flagged(check([runrow(file = only(sar05), start_location = "(150, 50)")]), 1, "start_location is outside the frame")
+        @test clean(check([runrow(file = only(sar2),  start_location = "(80, 50)")]))
         # anamorphic and downscaled at once
-        runs = check("t_sar_sc.csv", [runrow(file = only(sar2), start_location = "(55, 50)", scale = "0.5")])
+        runs = check([runrow(file = only(sar2), start_location = "(55, 50)", scale = "0.5")])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, sar2_exp) < 1
@@ -122,7 +122,7 @@
         # from where the previous segment ended (keyframe-aligned 17 + 17 + 16 frames)
         rows = [runrow(run_id = "s", file = f, start_location = i == 1 ? "(55, 50)" : missing)
                 for (i, f) in enumerate(seg)]
-        runs = check("t_seg.csv", rows)
+        runs = check(rows)
         @test clean(runs)
         r = only(runs)
         @test length(r.files) == 3
@@ -130,7 +130,7 @@
         @test length(ij) == 50
         @test tracking_rmse(ij, seg_exp) < 1
         # anamorphic segmented run, frame-center start
-        runs = check("t_seg2.csv", [runrow(run_id = "s2", file = f) for f in seg2])
+        runs = check([runrow(run_id = "s2", file = f) for f in seg2])
         @test clean(runs)
         _, ij = VR.track(only(runs))
         @test tracking_rmse(ij, seg2_exp) < 1.5

--- a/test/VerifyRuns/test_values.jl
+++ b/test/VerifyRuns/test_values.jl
@@ -2,76 +2,76 @@
     # baseline a.mp4 is 640×480, 5 s, 30 fps; each row overrides one field.
 
     @testset "start_location bounds" begin
-        @test flagged(check("v_sl_small.csv", [runrow(start_location = "(0, 100)")]),   1, "start_location cannot be smaller than 1")
-        @test flagged(check("v_sl_big.csv",   [runrow(start_location = "(700, 100)")]), 1, "start_location is outside the frame")
+        @test flagged(check([runrow(start_location = "(0, 100)")]),   1, "start_location cannot be smaller than 1")
+        @test flagged(check([runrow(start_location = "(700, 100)")]), 1, "start_location is outside the frame")
         # only one coordinate out of bounds still trips it
-        @test flagged(check("v_sl_y.csv",     [runrow(start_location = "(100, 700)")]), 1, "start_location is outside the frame")
+        @test flagged(check([runrow(start_location = "(100, 700)")]), 1, "start_location is outside the frame")
         # on the boundary is allowed (checks are strict < 1 and > dimension)
-        @test clean(check("v_sl_edge.csv",    [runrow(start_location = "(640, 480)")]))
+        @test clean(check([runrow(start_location = "(640, 480)")]))
     end
 
     @testset "scalar field ranges" begin
-        @test flagged(check("v_tw.csv",   [runrow(target_width = "-3")]),           1, "target_width must be larger than zero")
-        @test flagged(check("v_tw0.csv",  [runrow(target_width = "0")]),            1, "target_width must be larger than zero")
-        @test flagged(check("v_win.csv",  [runrow(window_size = "0")]),             1, "window_size must be larger than zero")
-        @test flagged(check("v_wint.csv", [runrow(window_size = "(0, 5)")]),        1, "window_size must be larger than zero")
-        @test flagged(check("v_isf.csv",  [runrow(initial_search_factor = "0")]),   1, "initial_search_factor must be larger than zero")
+        @test flagged(check([runrow(target_width = "-3")]),           1, "target_width must be larger than zero")
+        @test flagged(check([runrow(target_width = "0")]),            1, "target_width must be larger than zero")
+        @test flagged(check([runrow(window_size = "0")]),             1, "window_size must be larger than zero")
+        @test flagged(check([runrow(window_size = "(0, 5)")]),        1, "window_size must be larger than zero")
+        @test flagged(check([runrow(initial_search_factor = "0")]),   1, "initial_search_factor must be larger than zero")
     end
 
     @testset "scale must be in (0, 1]" begin
-        @test flagged(check("v_sc0.csv",   [runrow(scale = "0")]),    1, "scale must be larger than zero")
-        @test flagged(check("v_scneg.csv", [runrow(scale = "-0.5")]), 1, "scale must be larger than zero")
+        @test flagged(check([runrow(scale = "0")]),    1, "scale must be larger than zero")
+        @test flagged(check([runrow(scale = "-0.5")]), 1, "scale must be larger than zero")
         # > 1 would artificially enlarge the frames
-        @test flagged(check("v_schi.csv",  [runrow(scale = "1.5")]),  1, "scale cannot be larger than one")
-        @test clean(check("v_sc1.csv",     [runrow(scale = "1")]))      # exactly one (no scaling) is allowed
-        @test clean(check("v_sclo.csv",    [runrow(scale = "0.5")]))
+        @test flagged(check([runrow(scale = "1.5")]),  1, "scale cannot be larger than one")
+        @test clean(check([runrow(scale = "1")]))      # exactly one (no scaling) is allowed
+        @test clean(check([runrow(scale = "0.5")]))
     end
 
     @testset "the scaled target width must span at least one pixel" begin
         # each factor is individually valid; the product is degenerate
-        @test flagged(check("v_sctw.csv",  [runrow(target_width = "2", scale = "0.1")]), 1, "smaller than one pixel")
+        @test flagged(check([runrow(target_width = "2", scale = "0.1")]), 1, "smaller than one pixel")
         # scale omitted (defaults to 1): a sub-pixel target_width alone also trips it
-        @test flagged(check("v_sctw2.csv", [runrow(target_width = "0.5")]),              1, "smaller than one pixel")
+        @test flagged(check([runrow(target_width = "0.5")]),              1, "smaller than one pixel")
         # exactly one pixel is allowed
-        @test clean(check("v_sctw3.csv",   [runrow(target_width = "2", scale = "0.5")]))
+        @test clean(check([runrow(target_width = "2", scale = "0.5")]))
     end
 
     @testset "background_length is 0 (no subtraction) or at least 25" begin
         # blank cell ⇒ the hardcoded default (mirrors PawsomeTracker's own)
-        @test only(check("v_bl_blank.csv", [runrow()])).source.background_length == 250
+        @test only(check([runrow()])).source.background_length == 250
         # 0 is a real mode: background subtraction off
-        runs = check("v_bl0.csv", [runrow(background_length = "0")])
+        runs = check([runrow(background_length = "0")])
         @test clean(runs)
         @test only(runs).source.background_length == 0
-        @test clean(check("v_bl25.csv", [runrow(background_length = "25")]))    # the boundary is allowed
+        @test clean(check([runrow(background_length = "25")]))    # the boundary is allowed
         # 1–24 and negatives are rejected by the same check
         msg = "background_length must be 0 (disables background subtraction) or at least 25"
-        @test flagged(check("v_bl1.csv",   [runrow(background_length = "1")]),  1, msg)
-        @test flagged(check("v_bl24.csv",  [runrow(background_length = "24")]), 1, msg)
-        @test flagged(check("v_blneg.csv", [runrow(background_length = "-5")]), 1, msg)
+        @test flagged(check([runrow(background_length = "1")]),  1, msg)
+        @test flagged(check([runrow(background_length = "24")]), 1, msg)
+        @test flagged(check([runrow(background_length = "-5")]), 1, msg)
         # a non-integer cell fails at parse time, before the range check
-        @test flagged(check("v_blfmt.csv", [runrow(background_length = "2.5")]), 1, "wrong background_length format")
+        @test flagged(check([runrow(background_length = "2.5")]), 1, "wrong background_length format")
     end
 
     @testset "the temporal window must contain at least one frame" begin
         # 0.05 s at 5 fps → round(5 × 0.05) = 0 frames
-        @test flagged(check("v_nf0.csv", [runrow(stop = "0.05", fps = "5")]), 1, "too short to contain a single frame")
+        @test flagged(check([runrow(stop = "0.05", fps = "5")]), 1, "too short to contain a single frame")
         # 0.2 s at 5 fps → exactly one frame, allowed
-        @test clean(check("v_nf1.csv",   [runrow(stop = "0.2", fps = "5")]))
+        @test clean(check([runrow(stop = "0.2", fps = "5")]))
     end
 
     @testset "fps must be positive and not exceed the video's rate" begin
-        @test flagged(check("v_fps0.csv", [runrow(fps = "0")]),  1, "fps must be larger than zero")
-        @test flagged(check("v_fpshi.csv",[runrow(fps = "60")]), 1, "fps cannot exceed the video frame rate")
-        @test clean(check("v_fpseq.csv",  [runrow(fps = "30")]))   # == video rate is allowed
-        @test clean(check("v_fpslo.csv",  [runrow(fps = "10")]))   # below is fine
+        @test flagged(check([runrow(fps = "0")]),  1, "fps must be larger than zero")
+        @test flagged(check([runrow(fps = "60")]), 1, "fps cannot exceed the video frame rate")
+        @test clean(check([runrow(fps = "30")]))   # == video rate is allowed
+        @test clean(check([runrow(fps = "10")]))   # below is fine
     end
 
     @testset "temporal window" begin
-        @test flagged(check("v_sneg.csv", [runrow(start = "-1")]),                1, "start must be larger than or equal to zero")
-        @test flagged(check("v_order.csv",[runrow(start = "4", stop = "2")]),     1, "start must come before stop")
-        @test flagged(check("v_sdur.csv", [runrow(stop = "99")]),                 1, "stop can not come after video duration")
+        @test flagged(check([runrow(start = "-1")]),                1, "start must be larger than or equal to zero")
+        @test flagged(check([runrow(start = "4", stop = "2")]),     1, "start must come before stop")
+        @test flagged(check([runrow(stop = "99")]),                 1, "stop can not come after video duration")
         # an inverted window must not also emit a "stop after duration" cascade for an in-range stop
-        @test !flagged(check("v_order2.csv", [runrow(start = "4", stop = "2")]),  1, "stop can not come after")
+        @test !flagged(check([runrow(start = "4", stop = "2")]),  1, "stop can not come after")
     end
 end

--- a/test/VerifyRuns/test_video_metadata.jl
+++ b/test/VerifyRuns/test_video_metadata.jl
@@ -1,25 +1,25 @@
 @testset "video metadata (probe + imputation)" begin
     @testset "stop and fps are imputed from the video" begin
-        r = only(check("vm_impute.csv", [runrow()]))   # stop & fps omitted
+        r = only(check([runrow()]))   # stop & fps omitted
         @test only(r.stops) ≈ VIDEO_DURATION atol = 0.1 # ← container duration (5 s)
         @test r.source.fps == 30.0                      # ← video frame rate
     end
 
     @testset "the video's pixel dimensions are carried onto the run's Source" begin
-        r = only(check("vm_dims.csv", [runrow()]))
+        r = only(check([runrow()]))
         @test r.source.width  == 640                    # ← probed from the video itself
         @test r.source.height == 480
         @test r.source.sar    == 1                      # square pixels; anamorphic: test_tracking.jl
     end
 
     @testset "CSV values win over imputation" begin
-        r = only(check("vm_explicit.csv", [runrow(stop = "3", fps = "15")]))
+        r = only(check([runrow(stop = "3", fps = "15")]))
         @test only(r.stops) == 3.0
         @test r.source.fps == 15.0
     end
 
     @testset "corrupt/unreadable video is reported" begin
-        @test flagged(check("vm_corrupt.csv", [runrow(file = ART.corrupt)]), 1, "issue reading from video file")
+        @test flagged(check([runrow(file = ART.corrupt)]), 1, "issue reading from video file")
     end
 
     @testset "parse_framerate: tryparse semantics, never a throw" begin


### PR DESCRIPTION
Candidate **15**.

## The change

Every gateway scenario is loaded as its own csv, so each of **255** `check` calls opened with a hand-invented filename: `v_ncorn11.csv`, `p_center_ovf.csv`, `s_dupyadif.csv`, `t_sar2_c.csv`. The name encoded nothing the row beside it did not already say, it had to be unique within `DATADIR`, and inventing one was a step between having a case and writing it.

`check(rows; …)` now generates `case_N.csv` from a counter. The two-argument form stays for a test that is about the file itself.

```julia
# before
@test flagged(check("v_ncorn11.csv", [videorow(n_corners = (1, 1))]), 1, "n_corners must all be at least 3")
# after
@test flagged(check([videorow(n_corners = (1, 1))]), 1, "n_corners must all be at least 3")
```

Blocks were re-aligned on the row-index column afterwards, so they still read as the tables they are:

```julia
@test flagged(check([videorow(center = "abc")]),            1, "wrong center format")
@test flagged(check([videorow(north = "1;2")]),             1, "wrong north format")
@test flagged(check([videorow(extrinsic = "not_a_time")]),  1, "wrong extrinsic format")
@test flagged(check([videorow(n_corners = "five")]),        1, "wrong n_corners format")
```

## What I deliberately did not build

The ledger proposed "a driver that generates the name from the testset and an index" turning each case into `(override, expected message)`. I did the name-generation half and **not** the table driver.

Two reasons. It would swallow the per-case comments — and #69 established those are load-bearing arithmetic rather than archaeology, which is exactly why they survived the comment trim (`# a coordinate that overflows Int64 must be a graceful "wrong format", not an uncaught OverflowError`). And a failure inside a driver loop reports against the loop, not the case, which trades away the diagnostics your priority ordering puts first.

The shape was already a table. It just had a redundant column.

## One improvement that fell out

Three loops built their csv name by interpolation (`"vm_$name.csv"`, `"int_scale_$name.csv"`, `"t_$slug.csv"`). The variable existed *only* to name a file — and **two of the three had no per-iteration testset at all**, so a failure in them did not say which case produced it. They now carry `@testset "$name"` instead.

## Numbers

**test/ code lines +12** against an estimated ±0 — the helper overloads and the three testset wrappers. **4.1 KB of text removed** (204,395 → 200,310 characters), which is the metric that actually matches what changed.

**1044 / 1044 pass** (7m47s with coverage) — the same count as `main`, which is what a change that adds and removes no assertions should show. Coverage 99.02%.

**Rebased onto `main` with #82.** Git merged the hunks without a conflict, but that was not the end of it: #82's three new testsets arrived carrying explicit filenames (`s_dup3.csv`, `s_dupmixed.csv`, `s_dupid.csv`), which this PR's convention removes — so they were stripped too, and `load_capturing` gained the same auto-naming overload since one of them uses it. A clean rebase is not the same as a correct one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7
