### PR TITLE
Pin the distortion inverse's accuracy; decline the polynomial root (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -173,9 +173,42 @@ the smallest positive root of `g'`, and the inverse is solved by bracketed bisec
 point beyond the fold (the peripheral "donut" region) has no physical preimage, so its radius is
 clamped to the fold with a warning.
 
-`inv_lens_distortion` runs per pixel, inside the warp of every diagnostic frame — which is why it
-is a bisection rather than a general root solve, despite the equation being a degree-7 polynomial
-that `Polynomials` could root directly. If that is ever revisited, benchmark it.
+### Rooting the polynomial was measured and declined (#68)
+
+The claim that used to stand here — that `inv_lens_distortion` "runs per pixel, inside the warp of
+every diagnostic frame" — is **wrong**, and it is worth stating plainly because it is what made
+this candidate look urgent. Every `warp` in the package composes `real2image`, which uses the
+*forward* `distort`. The inverse is reached only through `image2real`, and that is applied once per
+tracked coordinate (`map(rectification.image2real, ij)`), once per written diagnostic frame for the
+marker, and a handful of times when a rectification is built. For a 30-minute run at 25 fps that is
+45,000 calls, not 300,000 per frame.
+
+The equation is a degree-7 polynomial and `Polynomials` is already a dependency, so the
+companion-matrix version was written and measured against the bisection solver over the same sweep
+of frame sizes, fields of view and distortion regimes:
+
+| | bisection | polynomial root |
+|---|---|---|
+| worst residual over the sweep | 1.3e-11 px | **8.8e-13 px** |
+| 640 inversions | **286 µs** | 3,573 µs |
+| allocations | **3** | 21,763 |
+
+The root solver is 15× more accurate and 12.5× slower. Both numbers are real, and the accuracy one
+does not matter: 1.3e-11 pixels is ten orders of magnitude finer than the ~1 pixel RMSE of the
+tracking it feeds, so the extra digits buy nothing a caller could observe. The cost does show up —
+about 250 ms rather than 20 ms per long run, and 34 allocations per call inside `tmap`-parallel
+tracking. Declined.
+
+The fallback the candidate suggested does not survive either. Dropping the bracket-doubling branch
+is unsafe: it runs when `rstar` is `Inf`, and `g(r) < r` there whenever a coefficient is negative,
+so `rd` is not always an upper bound. Cutting the 200-iteration cap changes nothing — the
+`b - a < 1e-14` exit fires after about 47 halvings, so the cap never binds.
+
+What did come out of this is a test. `test_lens_distortion.jl` now sweeps observed pixels across
+frames from 100×100 to 2000×2000 at two fields of view and five distortion regimes, requiring each
+recovered point to map back onto the pixel it came from to within 1e-9 **pixels** — the unit the
+accuracy has to be judged in, since the solver works in normalized coordinates and the error a
+caller feels is scaled by the focal length. Any future replacement has to clear that bar.
 
 ### `n_corners` must be at least 3 in both dimensions
 

--- a/test/Rectifications/test_lens_distortion.jl
+++ b/test/Rectifications/test_lens_distortion.jl
@@ -54,6 +54,36 @@
               SVector(0.3, 0.0) atol = 1e-9
     end
 
+    @testset "inverse accuracy in pixels, 100×100 to 2000×2000 frames" begin
+        # `inv_lens_distortion` receives NORMALIZED camera coordinates — (pixel − principal point)
+        # / focal, see `obj2img` — so the error a caller actually feels is the normalized error
+        # times the focal length. This sweeps observed pixels across whole frames, at two fields of
+        # view, and requires the recovered point to map back onto the pixel it came from. The
+        # tolerance is therefore in PIXELS, which is the unit the accuracy has to be judged in.
+        #
+        # The bisection solver's measured worst residual over this entire sweep is 1.3e-11 px; the
+        # bound below leaves two orders of magnitude of headroom, so it states a requirement rather
+        # than pinning one implementation — but any replacement has to meet it. See DESIGN-HISTORY.
+        frames = ((100, 100), (320, 240), (640, 480), (1280, 720), (1920, 1080), (2000, 2000))
+        for (w, h) in frames, fov in (1.4, 0.7),
+                k in ((), (-0.1,), (0.15,), (-0.28, 0.09), (0.1, -0.02, 0.005))
+            f = fov * max(w, h)              # focal length; 0.7 is the wide lens, the harder case
+            rstar = R._first_critical(k)
+            gmax = isfinite(rstar) ? rstar * R.lens_distortion_factor(rstar, k) : Inf
+            worst, n = 0.0, 0
+            for px in range(0, w; length = 12), py in range(0, h; length = 12)
+                v2 = SVector((py - h / 2) / f, (px - w / 2) / f)   # observed pixel, normalized
+                norm(v2) < gmax || continue          # past the fold there is no physical preimage
+                v = R.inv_lens_distortion(v2, k, rstar)
+                worst = max(worst, norm(R.lens_distortion(v, k) - v2) * f)
+                n += 1
+            end
+            # none of these regimes folds inside the frame, so the sweep cannot silently shrink
+            @test n == 144
+            @test worst < 1e-9
+        end
+    end
+
     @testset "inv_lens_distortion beyond the fold" begin
         # NOTE: the clamp warning uses `maxlog = 1`, so it fires only once per process.
         # This must be the FIRST beyond-fold call in the suite — the round-trips above stay


### PR DESCRIPTION
Candidate **13**. The swap does not land; the accuracy requirement you asked for does.

## First, the premise was wrong

`inv_lens_distortion` **does not run per warp pixel.** Every `warp` in the package composes `real2image`, which uses the *forward* `distort`. The inverse is reached only through `image2real`:

- once per tracked coordinate — `map(rectification.image2real, ij)`
- once per written diagnostic frame, for the marker
- a handful of times when a rectification is built

For a 30-minute run at 25 fps that is **45,000 calls, not 300,000 per frame**. The old `DESIGN-HISTORY.md` note asserting otherwise is corrected in this PR — it is what made this candidate look urgent.

## The measurement

Companion-matrix root of the degree-7 polynomial, against the bisection solver, over the same sweep of frame sizes, fields of view and distortion regimes:

| | bisection | polynomial root |
|---|---|---|
| worst residual over the sweep | 1.3e-11 px | **8.8e-13 px** |
| 640 inversions | **286 µs** | 3,573 µs |
| allocations | **3** | 21,763 |

**15× more accurate, 12.5× slower.** Both numbers are real — and the accuracy one is unusable. 1.3e-11 pixels is ten orders of magnitude finer than the ~1 px RMSE of the tracking it feeds; the extra digits are not observable by any caller. The cost is: ~250 ms rather than ~20 ms per long run, and 34 allocations per call inside `tmap`-parallel tracking.

Declined.

## The suggested fallback doesn't survive either

The ledger's plan B was "keep bisection, drop the bracket-doubling branch, and cut the iteration cap".

- **Dropping the doubling is unsafe.** It runs when `rstar` is `Inf`, and `g(r) < r` there whenever a coefficient is negative — so `rd` is *not* always an upper bound on the root. Removing it would silently return a wrong radius for mixed-sign coefficients.
- **Cutting the cap changes nothing.** The `b - a < 1e-14` exit fires after ~47 halvings, so the 200 cap never binds.

## What does land: the accuracy test you asked for

`test_lens_distortion.jl` now sweeps **observed pixels across whole frames from 100×100 to 2000×2000**, at two fields of view (`f = 1.4·max(w,h)` for a long lens, `0.7·` for a wide one — the harder case), across five distortion regimes including a realistic barrel `(-0.28, 0.09)`.

The tolerance is **in pixels**, which is the unit this has to be judged in: the solver works in normalized camera coordinates (`(pixel − principal point) / focal`, per `obj2img`), so the error a caller feels is the normalized error scaled by the focal length. A tolerance in normalized units would mean different pixel errors at different focal lengths.

Each recovered point must map back onto the pixel it came from to within **1e-9 px**. The current solver's measured worst over the entire sweep is 1.3e-11 px, so there are two orders of magnitude of headroom — the bound states a requirement rather than pinning today's implementation, but any replacement has to clear it.

Each combination also asserts `n == 144`, so the sweep cannot silently shrink if a future regime starts folding inside the frame.

## Numbers

**+120 assertions** (1044 → 1164). No `src/` change at all. Coverage 99.17%.

**1164 / 1164 pass** (7m48s with coverage).

If you want the polynomial version anyway — the accuracy is genuinely better and the cost is a quarter-second per long run — say so and I'll open it as a separate PR; it is written and measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7