### PR TITLE
The innermost parallel layer is gone (#68)

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -83,6 +83,31 @@ transient by definition and a few retries ride out residual blips even under the
 `tmap(...; ntasks = n)` and can go away — but measure against the real share, not the test
 suite.**
 
+### The innermost parallel layer is gone (#68)
+
+`detect` filtered its search window with `imfilter!(CPUThreads(Algorithm.FIR()), …)` — the
+innermost of five nested layers of parallelism, threading a 21×21 output window against a 29×29
+kernel. It is `CPU1` now.
+
+The benchmark harness priced it first: 281.6 µs threaded against 284.2 µs serial **on 32 threads**
+— within 1%, because there is not enough work in one window to pay for the split. End to end, over
+100 interleaved samples per arm, `track` on the shared fixture came out at min 108.8 / p25 111.4 ms
+threaded against min 108.4 / p25 111.7 ms serial: indistinguishable. (Sequential A-then-B runs made
+the serial arm look 21% slower; interleaving the rounds showed that was load on the machine, not
+the change. Identical minima with divergent upper quantiles is what that always looks like.)
+
+The results are **bitwise identical**, not merely close: `CPU1(FIR)` and `CPUThreads(FIR)` produce
+the same `Float64`s from the same window, and 200 tracked coordinates across four scenarios —
+explicit start, frame-centre search, `background_length = 0`, and a three-segment run — compare
+equal bit for bit against the previous revision.
+
+The resource argument cannot simply be dropped: `imfilter!` has no method taking `inds` without
+one, so `ComputationalResources` remains a dependency.
+
+This removes one layer. The other four — `tmap` over runs, `Threads.@spawn` for intrinsics, `tmap`
+over intrinsic timestamps, and the `tmap` pairs in verification — still nest, and `READ_SEM` still
+exists because of them. Those need the real share to judge.
+
 ### ffmpeg commands bake their environment into the `Cmd`
 
 Commands interpolate the *called* `FFMPEG.ffmpeg()` / `FFMPEG.ffprobe()` (the non-do-block form),
@@ -902,6 +927,7 @@ in the way. End-to-end throughput is covered by the `"macro"` group.
 
 The first run answered the question it was built for. On 32 threads, `CPUThreads` and `CPU1` come
 out within 1% of each other (282 μs against 284 μs): the innermost layer of parallelism buys
-nothing at this window size. The same run priced the other open question — the bisection inverse
+nothing at this window size, and has since been removed. Both are still benchmarked, because that
+comparison is the evidence for the choice. The same run priced the other open question — the bisection inverse
 costs 274 μs per 640 pixels against 3.3 μs for the forward map, about 428 ns a pixel, which is the
 budget a polynomial root has to beat.

--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -11,7 +11,7 @@ using ColorTypes: Gray
 using FixedPointNumbers: N0f8
 using ImageTransformations: imresize!, warp, WarpedView
 using RelocatableFolders: @path
-using ComputationalResources: CPUThreads
+using ComputationalResources: CPU1
 using DataStructures: CircularBuffer
 using StaticArrays: SVector, SDiagonal
 using OpenCV: OpenCV
@@ -289,7 +289,11 @@ function detect(guess, stack, j, h, img, radii, buff, kernel, sz, scale, bkgd_re
         img.data[bkgd_indices] .= Gray{Float32}.(slice[bkgd_indices]) .- Gray{Float32}.(bkgd_reduce(stack[bkgd_indices, :], dims = 3))
     end
     window_indices = UnitRange.(guess .- radii, guess .+ radii)
-    imfilter!(CPUThreads(Algorithm.FIR()), buff, img, kernel, NoPad(), window_indices)
+    # Serial on purpose. This is the innermost of five nested layers of parallelism, and on a
+    # 21×21 window with a 29×29 kernel the threaded resource is worth nothing measurable — see
+    # DESIGN-HISTORY.md. `CPU1(FIR)` is bitwise identical to `CPUThreads(FIR)`, and the resource
+    # argument cannot simply be dropped: `imfilter!` has no method taking `inds` without one.
+    imfilter!(CPU1(Algorithm.FIR()), buff, img, kernel, NoPad(), window_indices)
     v = view(buff, window_indices...)
     clamp!(v, 0, Inf)
     # the confidence gate (see GATE_FRACTION above): hold the last position when the response


### PR DESCRIPTION
Candidate **06**, first layer. All four of your expectations held — here is the evidence for each.

## Cleaner

```julia
imfilter!(CPU1(Algorithm.FIR()), buff, img, kernel, NoPad(), window_indices)
```

One layer of five removed. The comment above it now records *why* it is serial, so nobody re-threads it on the assumption that threading is free.

One thing that did **not** work out: I hoped to drop the resource argument entirely and lose `ComputationalResources` as a dependency — it is used in exactly one place. `imfilter!` has no method taking `inds` without a resource (and the no-resource path dispatches the kernel differently, so it would not have been bitwise identical anyway). The dependency stays.

## Bitwise identical

Two levels of check:

- **The call itself.** `CPU1(FIR)` and `CPUThreads(FIR)` produce the same `Float64`s from the same window and kernel — compared as raw bits, not with `≈`.
- **End to end.** 200 tracked coordinates across four scenarios — explicit start location, frame-centre search, `background_length = 0`, and a three-segment run — compare equal **bit for bit** against `main`, from a fixture generated once and read by both revisions.

## Insignificantly longer

| | min | p10 | p25 | median |
|---|---|---|---|---|
| `main` (`CPUThreads`) | 108.8 | 110.0 | 111.4 | 117.7 ms |
| this branch (`CPU1`) | **108.4** | 110.8 | 111.7 | **115.9 ms** |

100 samples per arm, rounds interleaved. Indistinguishable — the branch is nominally *faster* on min and median, which is noise in the other direction.

**Worth flagging how nearly I got this wrong.** Run sequentially — all of `main`, then all of the branch — the serial arm looked **21% slower** (median 114.6 → 138.4 ms). Interleaving the rounds made the difference vanish. Identical minima with divergent upper quantiles is the signature of load on the machine rather than a real regression, and I would have reported a fake slowdown had I stopped at the first measurement.

The microbenchmark agrees independently: 281.6 µs threaded against 284.2 µs serial **on 32 threads**, over the tracker's real 21×21 window and 29×29 DoG kernel. There is not enough work in one window to pay for the split.

## All tests pass

**1164 / 1164** (8m40s with coverage). Coverage 99.17%.

## What is left

Four layers still nest — `tmap` over runs, `Threads.@spawn` for intrinsics, `tmap` over intrinsic timestamps, and the `tmap` pairs in verification — and `READ_SEM` still exists because of them. Those are the ones that need your real data; ready when you are.

Both benchmark entries stay in the harness, since that comparison is the evidence for the choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpSek4bow2cUfZQmHELZT7