### PR TITLE
Windows has no signals, so the killed-reader test forks there

### DIFF
--- a/test/shareio.jl
+++ b/test/shareio.jl
@@ -74,10 +74,22 @@ const S = ShareIO
         # `exit -1` is what a signalled process reports, and it is uninformative. 137 (SIGKILL, the
         # OOM killer's signature) must be legible: 48 concurrent decoders against 27 GiB files is
         # exactly the shape that would provoke it, and it must never be confused with the share.
+        #
+        # A signal is the one POSIX thing in this module, so this is the one test that has to fork.
+        # Windows has no `termsignal` — Julia reports 0 there — and MSYS's `sh` surfaces its own
+        # kill as the raw wait status (9 << 8 = 2304) in the exit code instead. The share is a
+        # Linux mount and the signal branch is what production exercises; all Windows owes us is
+        # that the kill still arrives as a legible `ShareReadError` rather than a silent success.
         e = grab(() -> S.capture(`sh -c 'kill -9 $$'`, "ffmpeg could not read it"; tries = 1))
         @test e isa S.ShareReadError
-        @test e.signal == 9
-        @test occursin("killed by signal 9", sprint(showerror, e))
+        if Sys.isunix()
+            @test e.signal == 9
+            @test occursin("killed by signal 9", sprint(showerror, e))
+        else
+            @test e.signal == 0
+            @test e.exitcode != 0
+            @test occursin("ffmpeg could not read it", sprint(showerror, e))
+        end
     end
 
     @testset "a persistent failure propagates after the last try" begin


### PR DESCRIPTION
Fixes the two Windows failures in the `Test` run on `main` ([32398163352](https://github.com/yakir12/Fromage.jl/actions/runs/32398163352)) — both `windows-latest` jobs (Julia 1.11 and 1), Linux and macOS green.

## What failed

`test/shareio.jl:79-80`, in `"a killed reader names its signal"`:

```
Expression: e.signal == 9
 Evaluated: 0 == 9

Expression: occursin("killed by signal 9", sprint(showerror, e))
 Evaluated: occursin("killed by signal 9", "ffmpeg could not read it (exit 2304)")
```

## Why

The test spawns `sh -c 'kill -9 $$'` and asserts the resulting `ShareReadError` carries `signal == 9`. That premise is POSIX-only:

- Windows has no signals, so Julia's `Process.termsignal` is always `0` — hence `0 == 9`.
- MSYS's `sh` surfaces its own kill as the raw *wait status* (`9 << 8` = 2304) in the exit code instead — hence `(exit 2304)`.

So on Windows the failure was still detected and still reported; it just cannot be reported as a signal, because there isn't one.

## The fix

The test forks. The signal branch is unchanged and still runs everywhere the share actually lives (the CIFS mount is Linux), so the behaviour #68 added — a SIGKILL being legible, and never confused with the share — keeps its full assertions. Windows asserts what is true there: the kill still arrives as a `ShareReadError` naming a non-zero exit, rather than as a silent success.

`src/shareio.jl` is deliberately untouched. Reporting no signal on a platform that has none is correct behaviour, not something to paper over in the product code.

## Testing

`test/shareio.jl` runs green in full on Linux — 32/32, unchanged from before. The Windows branch was verified against the exact values CI recorded (`exitcode = 2304`, `signal = 0`, empty stderr): `showerror` reproduces the CI string `"ffmpeg could not read it (exit 2304)"` byte-for-byte, all three new assertions hold on it, and both old assertions fail on it. Windows is **not** covered by this PR's own CI (see the note below), so the full 2x3 matrix was dispatched manually against this branch to confirm on real runners: [run 32402966017](https://github.com/yakir12/Fromage.jl/actions/runs/32402966017).

## Note, separately

This reached `main` because `TestOnPRs.yml` runs only `ubuntu-latest` / Julia 1, while `Test.yml` runs the full 2x3 matrix on push — so Windows is never exercised before merge. That's a deliberate latency trade-off and I haven't touched it, but it means any Windows-only breakage will keep landing on `main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Kd3MgK2re9StMn1Tb9Xwz
