### PR TITLE
Name the coverage file by the input codecov-action v7 actually has

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -53,5 +53,8 @@ jobs:
       - uses: codecov/codecov-action@v7
         if: ${{ inputs.run_codecov }}
         with:
-          file: lcov.info
+          # `files`, plural: v7 renamed the singular `file`, and an unknown input is only a
+          # warning, so the old name was silently ignored and the upload fell back to searching
+          # the tree. That happened to find lcov.info, which is why coverage still worked.
+          files: lcov.info
           token: ${{ secrets.codecov_token }}


### PR DESCRIPTION
Fixes the second issue surfaced by the `Test` runs — the annotation on every build:

```
! Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', …, 'files', …]
```

## Why

`.github/workflows/ReusableTest.yml` passed `file: lcov.info` to `codecov/codecov-action@v7`. v7 renamed that input to the plural `files`, and an unrecognised input is only a warning, not an error — so the value was silently dropped and the uploader ran with no file flag at all:

```
./codecov upload-coverage -t <redacted> --git-service github --gcov-executable gcov
```

## Impact: smaller than it looks

Coverage was **not** being lost. With no file specified the uploader falls back to `CC_DISABLE_SEARCH: false` and searches the tree, which found the right file anyway:

```
info -- > /home/runner/work/Fromage.jl/Fromage.jl/lcov.info
info -- Your upload is now queued for processing.
```

So this restores the configuration's intent rather than repairing a broken upload: the report stops depending on auto-discovery happening to pick the correct file, and the warning disappears.

## Testing

`ReusableTest.yml` parses, and the codecov step now resolves to `{'files': 'lcov.info', 'token': …}`. Unlike #89, this one *is* covered by the PR's own CI — `TestOnPRs.yml` matches on `.github/workflows/**` and runs `ubuntu-latest` with `run_codecov: true`, which is exactly the path that executes this step. The check to watch is that the "Unexpected input(s)" annotation is gone and the upload names the file explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Kd3MgK2re9StMn1Tb9Xwz