### PR TITLE
The issues folder is added to, never wiped (#86)

### DIFF
--- a/docs/src/results.md
+++ b/docs/src/results.md
@@ -39,6 +39,18 @@ Things to look for:
 - The arena should look right in the top-down view: straight edges straight, circles circular. A warped arena means a bad calibration.
 - The trace should look like a plausible path for your animal.
 
+## The issues folder
+
+If a calibration fails detection — the checkerboard or the AprilTags can't be found in its extrinsic frame — Fromage saves that exact frame so you can see what it saw. The message in the report tells you where it went, e.g.:
+
+```
+row 2 (calibration_id: morning): only 4 of 6 AprilTags detected at the extrinsic frame — saved the extrinsic frame to results_dir/issues/2026-08-20T14-22-05/board_t1.0s.png for inspection
+```
+
+Each run gets its own time-stamped folder under `results_dir/issues`, named for the moment it started, so the folder holds exactly the frames of that run and older runs stay where they are. Nothing here is ever deleted: the folder is yours to clean out whenever you like.
+
+Open the frame and look at it — a blurry, over-exposed, or half-out-of-shot board is usually the whole story, and the fix is a different `extrinsic` timestamp or a better calibration video.
+
 ## Working with the results in Julia
 
 `main` returns a `DataFrame` with one row per run:

--- a/src/Fromage.jl
+++ b/src/Fromage.jl
@@ -1,11 +1,13 @@
 module Fromage
 
 # The four packages of the tracking ecosystem, consolidated as submodules (one repo, one version,
-# one test suite; see the README). Include order matters: ShareIO is first because all three
+# one test suite; see the README). Include order matters: Paths is first because both `main` and
+# VerifyRectifications derive their output folders from it, ShareIO next because all three
 # share-reading paths depend on it, Rectifications is used by VerifyRectifications and (for the
 # `RowCol` alias) by PawsomeTracker, PawsomeTracker by VerifyRuns, and the three shared modules by
 # both gateways -- Parsing (CSV-cell machinery), Probing (ffprobe plumbing) and Gateway (the csv ->
 # verified DataFrame pipeline the two gateways run in common).
+include("paths.jl")
 include("shareio.jl")
 include("Rectifications/Rectifications.jl")
 include("PawsomeTracker/PawsomeTracker.jl")
@@ -15,6 +17,7 @@ include("gateway.jl")
 include("VerifyRectifications/VerifyRectifications.jl")
 include("VerifyRuns/VerifyRuns.jl")
 
+using .Paths: results_dir
 using .Rectifications: Rectification
 using .PawsomeTracker: track
 using .VerifyRectifications: load_rectifications, RectificationMethod

--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -11,6 +11,7 @@ using DataFrames: AbstractDataFrame, ByRow, DataFrame, Not, allowmissing!, compl
 using ..Gateway: backfill!, blank!, read_per_file!, read_rows, report_issues, resolve_paths!,
     verify!
 using ..Parsing: Parsing, MyTemporal, parseto!
+using ..Paths: DEFAULT_ISSUES_DIR, run_issues_dir
 using ..Probing: frame_geometry, is_interlaced, no_video_stream, parse_sample_aspect, probe_fields
 using MAT: MAT, matread
 using OhMyThreads: OhMyThreads, tmap
@@ -27,15 +28,17 @@ include("parsers.jl")
 include("verifications.jl")
 
 # `issues_dir` is where the extrinsic frame of a calibration that fails checkerboard/AprilTag
-# detection is dumped for inspection (see `verifications!`); it is emptied at the start of every run.
-function load_rectifications(file; strict = true, defaults = (;), issues_dir = joinpath("results_dir", "issues"))
+# detection is dumped for inspection (see `verifications!`). Every run writes into a new time-stamped
+# folder of its own inside it, so what a run dumped is exactly what its folder holds; nothing here is
+# ever deleted, including anything the user keeps in the folder they name.
+function load_rectifications(file; strict = true, defaults = (;), issues_dir = DEFAULT_ISSUES_DIR)
     data_path = dirname(file)
     load_rectifications(data_path, file; strict, defaults, issues_dir)
 end
 
 # `defaults` globally replaces the hardcoded fallbacks of the whitelisted rectification parameters
 # (see DEFAULTS in parsers.jl); the hierarchy is csv cell → `defaults` → hardcoded/probed value.
-function load_rectifications(data_path, file; strict = true, defaults = (;), issues_dir = joinpath("results_dir", "issues"))
+function load_rectifications(data_path, file; strict = true, defaults = (;), issues_dir = DEFAULT_ISSUES_DIR)
     defaults = resolve_defaults(defaults)   # fail fast on unknown keys / unconvertible values
     csvrows = read_rows(file, COLUMNS, "calibration")
 

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -237,14 +237,14 @@ function extrinsic_issue(file, extrinsic, yadif, blur, width, height, n_corners)
     end
 end
 
-# Save the frame that failed detection into `issues_dir` (created on demand) for the user to
-# inspect, named by the video and extrinsic timestamp — e.g. `board_t1.0s.png`. `get_frame` reads
-# the frame lazily; best effort throughout, returning `nothing` if anything goes wrong.
-function save_issue_frame(issues_dir, file, extrinsic, get_frame)
+# Save the frame that failed detection into this run's issues folder (created on demand) for the
+# user to inspect, named by the video and extrinsic timestamp — e.g. `board_t1.0s.png`. `get_frame`
+# reads the frame lazily; best effort throughout, returning `nothing` if anything goes wrong.
+function save_issue_frame(run_dir, file, extrinsic, get_frame)
     try
         image = get_frame()
-        mkpath(issues_dir)
-        path = joinpath(issues_dir, string(first(splitext(basename(file))), "_t", extrinsic, "s.png"))
+        mkpath(run_dir)
+        path = joinpath(run_dir, string(first(splitext(basename(file))), "_t", extrinsic, "s.png"))
         FileIO.save(path, image)
         return path
     catch e
@@ -262,7 +262,7 @@ function note_saved_frame(issue, saved)
     return string(issue, " — saved the extrinsic frame to ", saved, " for inspection")
 end
 
-function verify_extrinsics!(df::AbstractDataFrame, issues_dir)
+function verify_extrinsics!(df::AbstractDataFrame, run_dir)
     # :file is the canonical resolved path, so grouping on it corner-detects a file reached via different
     # spellings once per (extrinsic, blur, n_corners).
     videos = subset(df, :type => ByRow(passmissing(==("video"))); view = true, skipmissing = true)
@@ -273,7 +273,7 @@ function verify_extrinsics!(df::AbstractDataFrame, issues_dir)
     for (g, k, issue) in zip(gs, ks, issues)
         isnothing(issue) && continue
         # dump the frame the detector saw (deinterlaced/blurred) so the user can see what went wrong
-        saved = save_issue_frame(issues_dir, k.file, k.extrinsic, () -> extrinsic_gray_frame(k.file, k.extrinsic, _vf(k.yadif, k.blur), k.width, k.height))
+        saved = save_issue_frame(run_dir, k.file, k.extrinsic, () -> extrinsic_gray_frame(k.file, k.extrinsic, _vf(k.yadif, k.blur), k.width, k.height))
         blank!(g, :extrinsic)
         push!.(g.issues, note_saved_frame(issue, saved))
     end
@@ -325,7 +325,7 @@ end
 # `family` must be detectable and their metric fit must converge (coplanar, not mis-detected). Reads
 # real frames, so it runs only on otherwise-clean apriltag rows, grouped so one physical file is
 # checked once per (extrinsic, apriltags, family, checker_size).
-function verify_apriltag_extrinsics!(df::AbstractDataFrame, issues_dir)
+function verify_apriltag_extrinsics!(df::AbstractDataFrame, run_dir)
     tags = subset(df, :type => ByRow(passmissing(==("apriltag"))); view = true, skipmissing = true)
     clean = subset(tags, :issues => ByRow(isempty); view = true)
     usable = dropmissing(clean, [:file, :extrinsic, :apriltags, :family, :checker_size]; view = true)
@@ -335,7 +335,7 @@ function verify_apriltag_extrinsics!(df::AbstractDataFrame, issues_dir)
     for (g, k, issue) in zip(gs, ks, issues)
         isnothing(issue) && continue
         # dump the extrinsic frame the tag detector saw so the user can see what went wrong
-        saved = save_issue_frame(issues_dir, k.file, k.extrinsic, () -> collect(PawsomeTracker.read_frame_at(k.file, k.extrinsic)))
+        saved = save_issue_frame(run_dir, k.file, k.extrinsic, () -> collect(PawsomeTracker.read_frame_at(k.file, k.extrinsic)))
         blank!(g, :extrinsic)
         push!.(g.issues, note_saved_frame(issue, saved))
     end
@@ -386,11 +386,13 @@ function verify_unique_calibrations!(df::AbstractDataFrame)
     end
 end
 
-function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath("results_dir", "issues"))
+function verifications!(df::AbstractDataFrame, data_path, issues_dir = DEFAULT_ISSUES_DIR)
 
-    # The issues folder is fully transient: it reflects only the current verification run, so it is
-    # wiped up front and recreated lazily by save_issue_frame.
-    rm(issues_dir; recursive = true, force = true)
+    # This run's frames go in a folder of their own, named for the moment the run started, so the
+    # folder reflects only this run without anything being deleted to make that true — `issues_dir`
+    # itself is the caller's, and Fromage only ever adds to it (#86). save_issue_frame creates the
+    # folder on the first frame it dumps, so a run that finds nothing to report writes nothing.
+    run_dir = run_issues_dir(issues_dir)
 
     verify_unique_ids!(df)
 
@@ -443,14 +445,14 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = joinpath(
 
     # the extrinsic time stamp must actually yield a detectable frame; only meaningful once the
     # time stamp itself has been range-checked above
-    verify_extrinsics!(df, issues_dir)
+    verify_extrinsics!(df, run_dir)
 
     # the calibs window must actually contain ≥ 3 detectable-corner frames; runs after
     # verify_extrinsics! so rows whose extrinsic already failed are skipped, not re-scanned
     verify_intrinsics!(df)
 
     # apriltag rows: the extrinsic frame must yield a valid shared reference (tags detectable + coplanar)
-    verify_apriltag_extrinsics!(df, issues_dir)
+    verify_apriltag_extrinsics!(df, run_dir)
 
     verify_unique_calibrations!(df)
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,5 +1,3 @@
-const results_dir = "results_dir"
-
 # Every segment shares one resolution, codec and quality (see diagnose.jl), so a single ffmpeg
 # concat-demuxer call stream-copies them into the final video, rewriting timestamps monotonically.
 #
@@ -54,8 +52,10 @@ end
 # — asserted so the union doesn't leak downstream (JET flags e.g. `length(::DataFrame)` otherwise).
 function gather_rectifications(data_path, calibs_file, defaults, calibration_ids = nothing)
     mkpath(results_dir)
-    cs = load_rectifications(joinpath(data_path, calibs_file); defaults,
-        issues_dir = joinpath(results_dir, "issues"))::Vector{RectificationMethod}
+    # `issues_dir` is left at its default, which Paths derives from `results_dir` — the frames a
+    # failing calibration dumps land under the same output folder as everything else.
+    cs = load_rectifications(joinpath(data_path, calibs_file);
+        defaults)::Vector{RectificationMethod}
     return filter_ids!(cs, calibration_ids, :calibration_id, "calibration_ids")
 end
 

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -1,0 +1,37 @@
+# Where Fromage writes what it produces. `main`'s output folder and the gateway's issues folder each
+# used to carry their own "results_dir" literal with nothing keeping the two in step, so both are
+# derived here — before any submodule is defined — and there is one string to change.
+module Paths
+
+using Dates: format, now, @dateformat_str
+
+# Every output lands under this folder, created in the folder Julia was started in (see
+# docs/src/results.md): the tracks, the diagnostic videos, and the issue frames below.
+const results_dir = "results_dir"
+
+# The parent of the per-run issue folders (see `run_issues_dir`), and the default a caller who names
+# no folder of their own gets.
+const DEFAULT_ISSUES_DIR = joinpath(results_dir, "issues")
+
+# One folder per verification run, named for the moment the run started, so a run's folder holds
+# exactly what that run dumped — with nothing deleted to keep it that way. Fromage never removes
+# anything from the issues folder: cleaning it out is the user's call, not a side effect of running
+# a verification (#86).
+#
+# Nothing is created here: `save_issue_frame` mkpaths the folder when it dumps its first frame, so a
+# run with nothing to report leaves no trace at all. The counter is what makes back-to-back runs
+# distinct — it skips a second that already has a folder. Two runs starting within the same second
+# and both dumping frames would land in one folder (unwritten folders cannot be counted), but a
+# verification run reads video off disk before it can fail a detection, so that race isn't reachable.
+function run_issues_dir(issues_dir)
+    stamp = format(now(), dateformat"yyyy-mm-dd\THH-MM-SS")
+    dir = joinpath(issues_dir, stamp)
+    n = 1
+    while ispath(dir)
+        n += 1
+        dir = joinpath(issues_dir, string(stamp, '_', n))
+    end
+    return dir
+end
+
+end

--- a/test/VerifyRectifications/test_extrinsics.jl
+++ b/test/VerifyRectifications/test_extrinsics.jl
@@ -44,14 +44,15 @@
 
     @testset "a failing extrinsic frame is dumped to the issues folder" begin
         idir = mktempdir()
-        # a stale file proves the folder is wiped at the start of each run
+        # a file of the caller's own proves the folder they named is only ever added to (#86)
         touch(joinpath(idir, "stale.png"))
         df = check([videorow(file = ART.video, n_corners = (5, 8))]; issues_dir = idir)
         @test flagged(df, 1, "no corners detected")
         @test flagged(df, 1, "saved the extrinsic frame")          # the message points at the file
-        pngs = filter(endswith(".png"), readdir(idir))
-        @test !("stale.png" in pngs)                               # emptied at the start of the run
+        @test isfile(joinpath(idir, "stale.png"))                  # nothing of the caller's is removed
+        run_dir = only(filter(isdir, readdir(idir; join = true)))   # this run's own folder
+        pngs = filter(endswith(".png"), readdir(run_dir; join = true))
         @test length(pngs) == 1                                    # exactly the one failing frame
-        @test filesize(joinpath(idir, only(pngs))) > 0             # a real, non-empty image
+        @test filesize(only(pngs)) > 0                             # a real, non-empty image
     end
 end

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -239,6 +239,8 @@ end
     @test length(lines) == nframes + 1 && lines[1] == "time,x,y"
     diag = joinpath(outdir, "results_dir", "diagnostic.mp4")
     @test isfile(diag) && filesize(diag) > 0
+    # nothing failed detection, so no frame was dumped — and the issues folder was never created
+    @test !ispath(joinpath(outdir, "results_dir", "issues"))
 end
 
 @testset "AprilTag: registered stack survives a large pan, the rolling phase, and tag loss" begin
@@ -339,18 +341,51 @@ end
 
 @testset "AprilTag calibration: failing extrinsic frame is dumped to the issues folder" begin
     # the video has four tags; asking for six fails detection at the extrinsic frame, and the frame
-    # is dumped to the issues folder (pointed at a temp dir) for the user to inspect.
+    # is dumped to the issues folder (pointed at a temp dir) for the user to inspect. Each run dumps
+    # into a time-stamped folder of its own, and Fromage never deletes anything in the folder it was
+    # given (#86): a second run adds a second folder, leaving the first run's frame — and whatever
+    # the user keeps there — untouched.
     dir = mktempdir(); idir = mktempdir()
+    keepsake = joinpath(idir, "my_notes.txt")          # the user's own file, in the folder they named
+    write(keepsake, "hands off")
     vid, _, _, _ = make_apriltag_video(dir, "drone")
     open(joinpath(dir, "calibs.csv"), "w") do io
         println(io, "calibration_id,type,file,extrinsic,apriltags,family,checker_size")
         println(io, "drone,apriltag,$vid,0,6,tag36h11,12")
     end
-    df = Fromage.VerifyRectifications.load_rectifications(dir, joinpath(dir, "calibs.csv"); strict = false, issues_dir = idir)
+    verify() = Fromage.VerifyRectifications.load_rectifications(dir, joinpath(dir, "calibs.csv"); strict = false, issues_dir = idir)
+    run_dirs() = filter(isdir, readdir(idir; join = true))
+    frames(d) = filter(endswith(".png"), readdir(d; join = true))
+
+    df = verify()
     @test any(m -> occursin("only 4 of 6 AprilTags", m), only(df.issues))
     @test any(m -> occursin("saved the extrinsic frame", m), only(df.issues))
-    pngs = filter(endswith(".png"), readdir(idir))
-    @test length(pngs) == 1 && filesize(joinpath(idir, only(pngs))) > 0
+    first_run = only(run_dirs())
+    @test length(frames(first_run)) == 1 && filesize(only(frames(first_run))) > 0
+
+    df2 = verify()
+    @test any(m -> occursin("saved the extrinsic frame", m), only(df2.issues))
+    both = run_dirs()
+    @test length(both) == 2 && first_run in both       # the second run added a folder, it didn't replace one
+    @test all(d -> length(frames(d)) == 1, both)       # each folder holds only its own run's frame
+    @test isfile(only(frames(first_run)))              # the first run's frame survived the second run
+    @test read(keepsake, String) == "hands off"        # and so did the user's file
+end
+
+@testset "issue folders never collide" begin
+    # run_issues_dir names a folder for the second the run started and counts past any folder that
+    # second already has, which is what keeps back-to-back runs apart. It only names the folder —
+    # save_issue_frame creates it — so a run with nothing to report leaves the issues folder alone.
+    P = Fromage.Paths
+    d = mktempdir()
+    a = P.run_issues_dir(d); mkpath(a)
+    b = P.run_issues_dir(d); mkpath(b)
+    c = P.run_issues_dir(d)
+    @test allunique((a, b, c))
+    @test all(==(d) ∘ dirname, (a, b, c))
+    @test !ispath(c)
+    # no colons in the stamp: these paths have to be creatable on Windows too
+    @test !occursin(':', basename(a))
 end
 
 @testset "reference_frame reports failures, and only the builder throws" begin


### PR DESCRIPTION
Closes #86.

## The problem

`verifications!` opened with:

```julia
rm(issues_dir; recursive = true, force = true)
```

`issues_dir` is a public kwarg on `load_rectifications`, so the path being recursively force-deleted is whatever the caller passed — and its default was a *relative* `joinpath("results_dir", "issues")`, resolved against the process cwd. Three hazards in one line:

1. **Caller-controlled destruction.** Passing `results_dir` instead of `results_dir/issues` — the only difference from what `main` passes — wiped every track csv and diagnostic video. `force = true` removed the usual guardrail.
2. **Wrong-cwd destruction.** `load_rectifications("calibs.csv")` from a REPL deleted `./results_dir/issues` wherever you happened to be. The literal was duplicated in three places, disconnected from `const results_dir` in `main.jl`, with nothing keeping them in step.
3. **It deleted more than the package owned, and too early.** Only `save_issue_frame` ever writes there, but the wipe took the whole tree — user notes, annotated copies, subfolders — before any validation ran, so a run that died immediately had already destroyed the previous run's evidence.

The precompile workload calls `load_rectifications` with that default, so **precompiling the package ran the `rm` as well**.

## The fix

Freshness by construction rather than by deletion. Each run dumps into a folder named for the second it started:

```
results_dir/issues/2026-08-20T14-22-05/board_t1.0s.png
```

so the folder reflects exactly one run without anything being deleted to make that true. Nothing in the folder the caller named is ever removed — cleaning it out is the user's call, not a side effect of running a verification. A counter (`…_2`) disambiguates a second that already has a folder, which is what keeps back-to-back runs apart, and the stamp has no colons so the paths are creatable on Windows.

`save_issue_frame` still `mkpath`s on demand, so **a run with nothing to report now writes nothing at all** — the old wipe fired unconditionally. Precompilation is inert.

The three `"results_dir"`-derived literals collapse into a new `Paths` module (`results_dir`, `DEFAULT_ISSUES_DIR`, `run_issues_dir`), included ahead of the submodules that read it, so the drift that made hazard 2 possible can't recur.

## Tests

- `test/VerifyRectifications/test_extrinsics.jl` asserted the old contract — a planted `stale.png` had to be *gone* after a run. It now asserts the opposite, which is the regression test for this issue.
- `test/fromage.jl`: two consecutive runs each get their own folder, the first run's frame and a user file both survive the second; a clean end-to-end run creates no issues folder at all; `run_issues_dir` names collision-free, colon-free folders and creates nothing.

## Verification

- Full suite on 1.12.7: **1199/1199**, 6m09s.
- JET on the pinned 1.11.9 (the minor that gates it): **passes**, no reports against Fromage's modules.

## Docs

`docs/src/results.md` gains a short "The issues folder" section — the folder existed but was undocumented.