### PR TITLE
Hand OpenCV the frame size the way the points are written

### DIFF
--- a/src/Rectifications/detect_fit.jl
+++ b/src/Rectifications/detect_fit.jl
@@ -12,6 +12,13 @@ end
 """
     fit_model
 Wraps OpenCV function to fit a camera model to given object and image points.
+
+`sz` is the extent of the image points' two coordinates, in the order the points carry them —
+`(height, width)` for the transposed view everything here works in (see `_detect_corners`). It
+reaches OpenCV as `imageSize`, which seeds the principal point at its centre; with a single view
+that seed is also the answer, since `CALIB_FIX_PRINCIPAL_POINT` pins it there. Passing it the
+other way round therefore fits the extrinsics-only rectification around a principal point
+reflected across the frame diagonal.
 """
 function fit_model(sz, objpoints, imgpointss, n_corners, radial_parameters, aspect)
     cammat = convert(Matrix{Float64}, I(3))

--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -194,7 +194,11 @@ end
 # extrinsic frame is always the LAST view) and compose the transform pipeline off its pose.
 function _rectification(file, extrinsic, imgpointss, width, height, n_corners, checker_size, aspect, radial_parameters, center, north, diagnostic)
     objpoints = XYZ.(Tuple.(CartesianIndices((0:(n_corners[1] - 1), 0:(n_corners[2] - 1), 0:0))))
-    k, Rs, ts, frow, fcol, crow, ccol = fit_model((width, height), objpoints, imgpointss, n_corners, radial_parameters, aspect)
+    # (height, width), not (width, height): every point handed to OpenCV lives in the TRANSPOSED
+    # view (see `get_corners` — the frame goes in as `reshape(img, 1, h, w)` and OpenCV.jl's `Mat`
+    # axes are `(channels, cols, rows)`), so coordinate 1 of a corner is its row and spans `height`.
+    # `fit_model`'s `sz` is the extent of those two coordinates, in their own order.
+    k, Rs, ts, frow, fcol, crow, ccol = fit_model((height, width), objpoints, imgpointss, n_corners, radial_parameters, aspect)
     extrinsic_index = length(imgpointss)
     extrinsic_corners = imgpointss[extrinsic_index]
     R = Rs[extrinsic_index]

--- a/test/Rectifications/test_calibration.jl
+++ b/test/Rectifications/test_calibration.jl
@@ -112,4 +112,60 @@
         @test reproj_rms(res, views) < 0.2
     end
 
+    # --- the transposed-frame convention, and the single-view fit that depends on it (#92) -----
+
+    # Everything here hands OpenCV the frame transposed (`reshape(img, 1, h, w)` against `Mat`'s
+    # `(channels, cols, rows)` axes), so a detected corner's coordinate 1 is its ROW. The frames
+    # above are square-ish and their synthetic points are built to match, so neither notices which
+    # way round the two extents go. These two do.
+    @testset "detected corners are (row, col)" begin
+        Hf, Wf = 300, 640                      # deliberately wide: a column index can exceed the height
+        inner = (7, 6)                         # 7 corners across, 6 down => pattern (6, 7) in (row, col)
+        small = checkerboard(inner; sq = 30, m = 20)
+        h, w = size(small, 2), size(small, 3)
+        img = fill(0xff, 1, Hf, Wf)            # float the board in a wide white canvas
+        r0, c0 = (Hf - h) ÷ 2, (Wf - w) ÷ 2
+        img[1, r0 .+ (1:h), c0 .+ (1:w)] .= small[1, :, :]
+
+        det = R._detect_corners(img, (inner[2], inner[1]))
+        @test det !== missing
+        @test size(det) == (inner[2], inner[1])
+        # coordinate 1 is the row: it stays inside the height and never reaches the width
+        @test maximum(p -> p[1], det) < Hf
+        # coordinate 2 is the column: it runs past the height, which no row index could
+        @test maximum(p -> p[2], det) > Hf
+    end
+
+    # The extrinsics-only rectification fits one view, so `CALIB_FIX_PRINCIPAL_POINT` pins the
+    # principal point at the centre of the `imageSize` it was given and never moves it. Handing that
+    # size in the wrong order reflects the principal point across the frame diagonal, and the pose
+    # absorbs the difference as a distortion of the recovered board: ~4% here, and worse the more
+    # oblique the view. Asserted on the rectification rather than on the intrinsics, so it covers the
+    # call site in `_rectification` and not just `fit_model`'s own handling.
+    @testset "single-view rectification recovers the board grid" begin
+        Wf, Hf = 640, 480                      # width != height, or the two orders coincide
+        ncr = (6, 7)
+        objs = R.XYZ.(Tuple.(CartesianIndices((0:(ncr[1] - 1), 0:(ncr[2] - 1), 0:0))))
+        f = 900.0
+        crow_true, ccol_true = (Hf - 1) / 2, (Wf - 1) / 2
+        Rm = SMatrix{3,3,Float64}(RotationVec(0.35, -0.22, 0.08))
+        tvec = SVector(-2.4, -3.0, 12.0)
+        # The board seen obliquely, in the detector's own (row, col) convention. Named apart from
+        # the `project` above: a method definition for a name already local to the enclosing scope
+        # extends that function rather than shadowing it, and the extra captured variable would
+        # then be unassigned on the earlier calls.
+        oblique(Xo) = (Xc = Rm * SVector{3,Float64}(Xo) + tvec;
+                       R.RowCol(f * Xc[1] / Xc[3] + crow_true, f * Xc[2] / Xc[3] + ccol_true))
+        corners = reshape(map(oblique, objs), ncr)
+
+        checker = 1.0
+        rect = R._rectification("unused.mp4", 0.0, [corners], Wf, Hf, ncr, checker, 1.0, 0,
+                                missing, missing, nothing)
+        metric = map(rect.image2real, corners)
+        down   = vec([hypot((metric[i + 1, j] - metric[i, j])...) for i in 1:ncr[1] - 1, j in 1:ncr[2]])
+        across = vec([hypot((metric[i, j + 1] - metric[i, j])...) for i in 1:ncr[1], j in 1:ncr[2] - 1])
+        # a correct fit reproduces the board exactly (residual ~1e-7 checker units)
+        @test maximum(abs, vcat(down, across) .- checker) < 1e-4
+    end
+
 end


### PR DESCRIPTION
Closes #92.

`fit_model` was given the frame size as `(width, height)`. It reaches OpenCV as `imageSize`, and
every point that reaches OpenCV here lives in a **transposed** view — `get_corners` passes the frame
as `reshape(img, 1, h, w)` and OpenCV.jl's `Mat` axes are `(channels, cols, rows)`, so OpenCV's x is
our row. The rest of the file applies that transposition consistently (`RowCol`, the `frow`/`crow`
names, the `n_corners` order, the `objpoints` iteration order); `sz` was the one place it did not.

### Scope: `from_extrinsic` only

`imageSize` seeds the principal point at its centre. With several views that is just a starting
guess and the optimiser recovers the truth — **`from_video` was never affected**, which is why the
end-to-end rectification test has always passed. With exactly one view, `fit_model` adds
`CALIB_FIX_PRINCIPAL_POINT` and OpenCV pins it there permanently. One view is exactly
`from_extrinsic`: the rectification a calibs row selects by leaving `start` and `stop` blank.

⚠️ **This changes results.** Any extrinsics-only calibration processed before this will produce
different — correct — real-world coordinates afterwards.

### Measured

Noise-free synthetic 1080p, true principal point `(539.5, 959.5)`:

| | before | after |
|---|---|---|
| principal point | `(959.5, 539.5)` | `(539.5, 959.5)` |
| reproj RMS, mild pose (0.15 rad) | 3.14 px | 3e-5 px |
| reproj RMS, oblique pose (0.6 rad) | 7.06 px | 3e-5 px |
| `image2real` divergence across the frame | 8.5% / 41% of extent | — |

### Why no existing test caught it

`test_calibration.jl`'s two `fit_model` testsets synthesise image points already centred on `W/2` in
coordinate 1, rather than deriving them from a detected image — so they encode the wrong convention
as ground truth and pass either way. Both are also multi-view, where the principal point is free.
The bounds assertion on `_detect_corners` (`p[1] ≤ size(board, 3)`) is satisfied by any row index
too, so it can't discriminate.

Two tests added:

1. **`detected corners are (row, col)`** — floats a board in a deliberately wide 300×640 canvas.
   Coordinate 1 tops out at 224.5 (inside the height) while coordinate 2 reaches 409.5 (past it), so
   the two cannot be confused. This is a convention lock: it passes before and after, and fires if
   the reshape or the `Mat` layout assumption ever changes.
2. **`single-view rectification recovers the board grid`** — an obliquely-viewed board through
   `_rectification` itself, so it covers the call site and not just `fit_model`. Asserts every
   adjacent-corner spacing equals `checker_size`. Before the fix the grid is distorted by 4.2%
   against a 1e-4 bar; after, the residual is ~1e-7.

I ran the second test against unfixed `main` first to confirm it actually fails there.

### Verification

Local suite: **1204 passed, 0 failed** (7m54s, `JULIA_NUM_THREADS=16`, `coverage = true`). The one
changed executable line is hit 7× in the `.cov` output — the rest of the diff is comments and a
docstring. Both new testsets are confirmed executed in `test_calibration.jl`'s own coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHn1sFycGkKrJko33MxBbQ