### PR TITLE
Two DESIGN-HISTORY entries describe code that no longer exists

### DIFF
--- a/DESIGN-HISTORY.md
+++ b/DESIGN-HISTORY.md
@@ -446,9 +446,15 @@ imputation path, so the guarantee is asserted at both arities.
 
 The stored frame is squeezed horizontally by the sample aspect ratio (`stored x = display x / sar`).
 Window sizes arrive in display pixels and their column extent is converted to stored pixels,
-otherwise an anamorphic (sar < 1) target fills its own search window. `start_location` and a
-rectification's `center`/`north` are likewise display-pixel conventions and are bounds-checked
-against the display width, `width × sar`.
+otherwise an anamorphic (sar < 1) target fills its own search window. `start_location` is likewise
+a display-pixel convention and is bounds-checked against the display width, `width × sar`.
+
+A rectification's `center`/`north` were described here as being handled the same way. They are not.
+They are bounds-checked against the *stored* width (`:dimension`, straight from ffprobe, with no
+`sar` applied), and `fix_coordinate` scales them by `aspect` where the tracker's `get_guess` divides
+by it — so the two halves of the pipeline disagree about which direction `sar` goes for the same
+user-supplied value. All of it is invisible at `sar = 1`, which is why it has stood; #36 tracks
+getting aspect ratio right across the whole system.
 
 ### One diagnostic writer, three scenes (#68)
 
@@ -737,10 +743,25 @@ Putting the video itself in `path` is the common slip, and `isdir` alone reporte
 not exist" — false, and it sends the user looking for a file that is plainly there. The targeted
 check runs first and nulls `:path`, so the existence check does not also fire.
 
-### The issues folder is wiped each run
+### The issues folder is only ever added to (#86)
 
-`results_dir/issues` reflects only the current verification run, so it is removed up front and
-recreated lazily the first time a frame fails to detect.
+`verifications!` used to open by recursively force-deleting `issues_dir` — a path the caller hands
+in, defaulting to a relative `results_dir/issues` resolved against whatever the process cwd happened
+to be. Naming the folder one level up (`results_dir` instead of `results_dir/issues`) wiped every
+track and diagnostic; anything the user kept beside the dumped frames went with it; and because the
+wipe ran first thing, a run that failed on the next line had already destroyed the previous run's
+evidence. The precompile workload calls `load_rectifications` with that default, so precompiling the
+package ran the `rm` too.
+
+Freshness comes from newness instead of deletion. Each run dumps into a folder named for the second
+it started (`issues/2026-08-20T14-22-05/`, counted apart when that second already has one), so a
+folder holds exactly what its run wrote and nothing has to be removed to keep it that way.
+`save_issue_frame` mkpaths on demand, so a run with nothing to report writes nothing at all —
+including during precompilation. The stamp carries no colons, so the folders are creatable on
+Windows.
+
+Fromage removes nothing from the issues folder, including anything of the user's that happens to
+live there. Cleaning it out is their call.
 
 ---
 


### PR DESCRIPTION
Closes #98. Documentation only — no code change, no behaviour change.

The README sends readers to `DESIGN-HISTORY.md` *before changing anything that looks gratuitously
complicated, because it is usually load-bearing*. Both of these entries were telling them something
false.

### 1. The issues-folder wipe that #86 removed

`85fc75f` removed the recursive force-delete of `issues_dir` and changed no documentation, so the
entry arguing **for** it has been standing ever since — right next to a `run_issues_dir` whose
time-stamped folders are precisely the kind of thing that looks unnecessary until you know what they
replaced. A reader following the README's advice would have been told the complicated part is
redundant and the `rm` is correct.

Rewritten to record what #86 actually decided: why the wipe was dangerous (a caller-supplied
relative path, resolved against the process cwd, deleted first thing — so a run that failed on the
next line had already destroyed the previous run's evidence, and precompilation ran it too), and why
freshness now comes from newness rather than deletion.

### 2. A bounds check that doesn't exist

The "Anamorphic video" entry ended:

> `start_location` and a rectification's `center`/`north` are likewise display-pixel conventions and
> are bounds-checked against the display width, `width × sar`.

Only `start_location` is. `VerifyRuns/verifications.jl` checks `sl[1] > dim[1] * sar`;
`VerifyRectifications/verifications.jl` checks `center`/`north` against `:dimension` — the stored
frame size straight from ffprobe, no `sar` applied.

Corrected, and while there, the paragraph now names the inconsistency underneath it: `fix_coordinate`
scales `center`/`north` by `aspect` where the tracker's `get_guess` divides by it, so the two halves
of the pipeline disagree about which direction `sar` goes for the same user-supplied value. All
invisible at `sar = 1`, which is why it has stood.

**Not fixing that here** — it is #36's territory. The point is only that the design history should
not assert a check exists when it doesn't, since that is exactly the sentence someone would trust
instead of reading the code.

### Verification

Prose only, in a file nothing builds or imports — it is not part of the docs site. Rebased onto main
after #96 merged. Both rewritten sections keep the file's ~100-column wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHn1sFycGkKrJko33MxBbQ