### PR TITLE
The rectification diagnostic image is reachable

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -55,10 +55,10 @@ lens["_first_critical"] = @benchmarkable R._first_critical($K)
 lens["forward, 640 px"] = @benchmarkable [R.lens_distortion(v, $K) for v in $PIXELS]
 lens["inverse, 640 px"] = @benchmarkable [R.inv_lens_distortion(v, $K, $RSTAR) for v in $PIXELS]
 
-# An only_scale rectification: no video is read when `diagnostic` is nothing, so this is a pure
-# pair of coordinate maps.
-const RECT = R.from_scale(; file = "unread.mp4", extrinsic = 0, scale = 0.05, aspect = 1.0,
-    center = missing, north = missing, width = 640, height = 480)
+# An only_scale rectification: no video is read unless `rectification_diagnostics` asks for one, so
+# this is a pure pair of coordinate maps.
+const RECT = R.from_scale(; file = "unread.mp4", extrinsic = 0, calibration_id = "bench",
+    scale = 0.05, aspect = 1.0, center = missing, north = missing, width = 640, height = 480)
 const IMAGE_PTS = vec([SVector(float(r), float(c)) for r in 1:16:480, c in 1:16:640])
 const REAL_PTS = map(RECT.image2real, IMAGE_PTS)
 

--- a/docs/src/help.md
+++ b/docs/src/help.md
@@ -49,6 +49,8 @@ Fromage.only_track("path/to/data"; runs_file = "runs.csv", run_ids = ["run1", "l
 
 `main` itself also accepts `run_ids` to process only a subset of the runs (only the calibrations those runs reference are built). Every id you list must exist: if even one does not, the run stops with an error naming it and listing the ids that do exist, rather than quietly processing the ones that matched.
 
+`main` and `only_rectify` also accept `rectification_diagnostics = true`, which saves each calibration's warped extrinsic frame to `results_dir/rectifications/` so you can check a calibration before tracking against it — see [the rectification images](results.md#The-rectification-images).
+
 ## Changing a default for all rows at once
 
 The default of every *tuning* column can be overridden globally from `main`, so you don't have to fill in the same value on every row. The hierarchy is: a csv cell always wins over a global default, which wins over the built-in default (including the value probed from the video, for `yadif` and `fps`):

--- a/docs/src/results.md
+++ b/docs/src/results.md
@@ -39,6 +39,21 @@ Things to look for:
 - The arena should look right in the top-down view: straight edges straight, circles circular. A warped arena means a bad calibration.
 - The trace should look like a plausible path for your animal.
 
+## The rectification images
+
+Off by default. Ask for them and `main` saves, for every calibration, that calibration's `extrinsic` frame warped through the rectification fit to it:
+
+```julia
+main("path/to/data"; rectification_diagnostics = true)
+```
+
+One JPEG per calibration lands in `results_dir/rectifications/`, named by its `calibration_id` — so `c1.jpg` is the calibration the csv calls `c1`. `only_rectify` takes the same keyword.
+
+This is the same "is the arena square?" check the diagnostic video gives you, except you get it as soon as the calibrations are built, before a single run has been tracked. Straight arena edges should come out straight and circles circular. A bowed, sheared or wildly stretched image means the calibration is wrong, and there is no point tracking anything against it — fix the calibration first.
+
+!!! note "AprilTag calibrations produce no image here"
+    An `apriltag` calibration has no single fixed image-to-real map to warp through, because the drone moves and every frame is registered separately. Its top-down view is the per-run [diagnostic video](#The-diagnostic-video) instead.
+
 ## The issues folder
 
 If a calibration fails detection — the checkerboard or the AprilTags can't be found in its extrinsic frame — Fromage saves that exact frame so you can see what it saw. The message in the report tells you where it went, e.g.:

--- a/src/Rectifications/Rectifications.jl
+++ b/src/Rectifications/Rectifications.jl
@@ -2,6 +2,7 @@ module Rectifications
 
 using ColorTypes: Gray
 using CoordinateTransformations: AffineMap, IdentityTransformation, LinearMap, PerspectiveMap, Translation
+using ..Paths: rectifications_dir
 using ..ShareIO: ShareIO
 using FFMPEG: FFMPEG
 using FileIO: FileIO
@@ -32,7 +33,7 @@ include("from_matlab.jl")
 include("plotting.jl")
 
 """
-    Rectification(c; diagnostic = nothing)
+    Rectification(c; rectification_diagnostics = false)
 
 The image ↔ real map pair for one verified calibration `c`, chosen by `c`'s type. The methods live
 in `VerifyRectifications`, which owns those types; each reads `c`'s fields and calls one of the

--- a/src/Rectifications/from_matlab.jl
+++ b/src/Rectifications/from_matlab.jl
@@ -4,7 +4,8 @@
 # angle conventions) is ported untouched from CameraCalibrations.jl's `loadMAT`. Real-world
 # coordinates come out in the `.mat`'s own world units (whatever square size the MATLAB
 # calibration was given), so the unit scale is 1.
-function from_matlab(; file, extrinsic, matlab_file, extrinsic_index, aspect, center, north, width, height, diagnostic = nothing)
+function from_matlab(; file, extrinsic, calibration_id, matlab_file, extrinsic_index, aspect, center, north,
+        width, height, rectification_diagnostics::Bool = false)
     dict = matread(matlab_file)
     # the Camera Calibrator wraps everything in a single top-level struct (e.g. "cameraParams");
     # unwrap until the calibration fields are at hand (VerifyRectifications already verified they
@@ -29,6 +30,6 @@ function from_matlab(; file, extrinsic, matlab_file, extrinsic_index, aspect, ce
     # checker_size/checker_size_pixel (there are no detected corners to measure it from): one
     # real-world unit step at the origin spans 1/ratio pixels
     ratio = 1 / norm(real2image(SVector(1.0, 0.0)) - real2image(SVector(0.0, 0.0)))
-    _diagnostic(diagnostic, file, extrinsic, width, height, ratio, real2image)
+    _diagnostic(rectification_diagnostics, file, extrinsic, calibration_id, width, height, ratio, real2image)
     return (; image2real, real2image, ratio, width, height)
 end

--- a/src/Rectifications/from_scale.jl
+++ b/src/Rectifications/from_scale.jl
@@ -2,16 +2,16 @@
 # ratio, with no camera model at all. `file`/`extrinsic` are used only to render the diagnostic
 # frame. Keyword-only, like every builder here — see the note above the dispatchers in
 # VerifyRectifications/types.jl.
-function from_scale(; file, extrinsic, scale, aspect, center, north, width, height, diagnostic = nothing)
+function from_scale(; file, extrinsic, calibration_id, scale, aspect, center, north, width, height,
+        rectification_diagnostics::Bool = false)
     image2real = LinearMap(scale * SDiagonal(SVector{2, Float64}(1, aspect)))
     real2image = inv(image2real)
     center = default_center(center, width, height)
     image2real, real2image = add_center_north(image2real, real2image, center, north, aspect)
-    warp_trans = get_warp(scale, real2image)
-    if !isnothing(diagnostic)
-        imgw = warp_extrinsic(file, extrinsic, width, height, warp_trans)
-        FileIO.save(joinpath(diagnostic, string(first(splitext(basename(file))), "_$extrinsic.jpg")), parent(imgw))
-    end
+    # `scale` is this method's units-per-pixel, i.e. its `ratio` — the same argument the other
+    # builders hand `_diagnostic`. This used to repeat that function's body inline, and computed the
+    # warp transform on every call whether or not a diagnostic was wanted.
+    _diagnostic(rectification_diagnostics, file, extrinsic, calibration_id, width, height, scale, real2image)
     return (; image2real, real2image, ratio = scale, width, height)
 end
 

--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -159,15 +159,16 @@ end
 # however, are read off a GUI (Gimp, Photoshop) by hand, so they are:
 # 1. pixel coordinates with width first and height second, (w, h)
 # 2. at an aspect ratio of 1, whatever `aspect` says
-function from_video(; file, extrinsic, start, stop, temporal_step, yadif, blur, width, height,
-        n_corners, checker_size, aspect, radial_parameters, center, north, diagnostic = nothing)
+function from_video(; file, extrinsic, calibration_id, start, stop, temporal_step, yadif, blur,
+        width, height, n_corners, checker_size, aspect, radial_parameters, center, north,
+        rectification_diagnostics::Bool = false)
     vf = _vf(yadif, blur)
     intrinsic_task = Threads.@spawn extract_intrinsics(file, start, stop, temporal_step, vf, width, height, n_corners)
     extrinsic_corners = get_corners(file, extrinsic, vf, width, height, n_corners)
     ismissing(extrinsic_corners) && error("no corners detected at extrinsic time stamp")
     imgpointss = fetch(intrinsic_task)
     push!(imgpointss, extrinsic_corners)
-    return _rectification(file, extrinsic, imgpointss, width, height, n_corners, checker_size, aspect, radial_parameters, center, north, diagnostic)
+    return _rectification(file, extrinsic, calibration_id, imgpointss, width, height, n_corners, checker_size, aspect, radial_parameters, center, north, rectification_diagnostics)
 end
 
 """
@@ -183,16 +184,16 @@ than flagged; everything else (`yadif`, `blur`, `n_corners`, `checker_size`, `as
 DESIGN-HISTORY.md for why this asymmetry is deliberate.
 """
 function from_extrinsic(; file, extrinsic, yadif, blur, width, height, n_corners, checker_size,
-        aspect, center, north, diagnostic = nothing)
+        aspect, center, north, calibration_id, rectification_diagnostics::Bool = false)
     vf = _vf(yadif, blur)
     extrinsic_corners = get_corners(file, extrinsic, vf, width, height, n_corners)
     ismissing(extrinsic_corners) && error("no corners detected at extrinsic time stamp")
-    return _rectification(file, extrinsic, [extrinsic_corners], width, height, n_corners, checker_size, aspect, 0, center, north, diagnostic)
+    return _rectification(file, extrinsic, calibration_id, [extrinsic_corners], width, height, n_corners, checker_size, aspect, 0, center, north, rectification_diagnostics)
 end
 
 # Shared tail of both constructors above: fit the camera model to the collected views (the
 # extrinsic frame is always the LAST view) and compose the transform pipeline off its pose.
-function _rectification(file, extrinsic, imgpointss, width, height, n_corners, checker_size, aspect, radial_parameters, center, north, diagnostic)
+function _rectification(file, extrinsic, calibration_id, imgpointss, width, height, n_corners, checker_size, aspect, radial_parameters, center, north, rectification_diagnostics)
     objpoints = XYZ.(Tuple.(CartesianIndices((0:(n_corners[1] - 1), 0:(n_corners[2] - 1), 0:0))))
     # (height, width), not (width, height): every point handed to OpenCV lives in the TRANSPOSED
     # view (see `get_corners` — the frame goes in as `reshape(img, 1, h, w)` and OpenCV.jl's `Mat`
@@ -205,7 +206,7 @@ function _rectification(file, extrinsic, imgpointss, width, height, n_corners, c
     t = ts[extrinsic_index]
     image2real, real2image = _maps(R, t, frow, fcol, crow, ccol, k, checker_size, width, height, aspect, center, north)
     ratio = checker_size/checker_size_pixel(extrinsic_corners, n_corners)
-    _diagnostic(diagnostic, file, extrinsic, width, height, ratio, real2image)
+    _diagnostic(rectification_diagnostics, file, extrinsic, calibration_id, width, height, ratio, real2image)
     return (; image2real, real2image, ratio, width, height)
 end
 
@@ -223,12 +224,22 @@ function _maps(R, t, frow, fcol, crow, ccol, k, checker_size, width, height, asp
     return add_center_north(image2real, real2image, center, north, aspect)
 end
 
-# Save the warped extrinsic frame as a JPEG into the `diagnostic` directory (a no-op when none
-# was requested) — a quick visual check that the rectification looks right.
-function _diagnostic(diagnostic, file, extrinsic, width, height, ratio, real2image)
-    isnothing(diagnostic) && return
-    warp_trans = get_warp(ratio, real2image)
-    imgw = warp_extrinsic(file, extrinsic, width, height, warp_trans)
-    FileIO.save(joinpath(diagnostic, string(first(splitext(basename(file))), "_$extrinsic.jpg")), parent(imgw))
+# Save the warped extrinsic frame (a no-op unless asked) — a quick visual check that the
+# rectification looks right, available as soon as the rectification is built rather than after every
+# run has been tracked. `rectification_diagnostics` is the same flag `main` takes, passed straight
+# down, so there is one name and one type for it the whole way.
+#
+# The file is named by `calibration_id`, which is what lets a reader match an image back to its csv
+# row — and is unique, where the video/extrinsic pair this used to be named after is not: two video
+# rows differing only in `center` are not duplicates by `verify_unique_calibrations!` and warp
+# differently, so one would have silently overwritten the other.
+#
+# `mkpath` here rather than in the caller keeps the function correct when called on its own, and is
+# safe under the builders' `tmap`: it tolerates the directory already existing.
+function _diagnostic(rectification_diagnostics, file, extrinsic, calibration_id, width, height, ratio, real2image)
+    rectification_diagnostics || return
+    imgw = warp_extrinsic(file, extrinsic, width, height, get_warp(ratio, real2image))
+    mkpath(rectifications_dir)
+    FileIO.save(joinpath(rectifications_dir, string(calibration_id, ".jpg")), parent(imgw))
     return
 end

--- a/src/VerifyRectifications/types.jl
+++ b/src/VerifyRectifications/types.jl
@@ -74,14 +74,15 @@ end
 # `width`/`height`, `start`/`stop` and `center`/`north` are same-typed neighbours, so a
 # transposition would produce a silently wrong map rather than an error.
 
-# The six facts every builder needs. `aspect` is not among them: the AprilTag path recovers metric
+# The six facts every builder needs from the shared `Source` (`calibration_id`, which names the
+# diagnostic image, lives on the method itself and is passed alongside). `aspect` is not among them: the AprilTag path recovers metric
 # scale from the tags themselves and has no pixel-aspect correction to make, so the three builders
 # that do need it ask for it by name.
 _source(s::Source) = (; s.file, s.extrinsic, s.center, s.north, s.width, s.height)
 
 Rectification(c::Video; kwargs...) =
-    from_video(; _source(c.source)..., c.source.aspect, c.start, c.stop, c.temporal_step, c.yadif,
-        c.blur, c.n_corners, c.checker_size, c.radial_parameters, kwargs...)
+    from_video(; _source(c.source)..., c.calibration_id, c.source.aspect, c.start, c.stop,
+        c.temporal_step, c.yadif, c.blur, c.n_corners, c.checker_size, c.radial_parameters, kwargs...)
 
 # A Video without a calibs window (both bounds blank ⇒ Video{Missing}) is an extrinsics-only
 # rectification: the pose and focal length come from the single extrinsic frame and lens aberrations
@@ -89,17 +90,18 @@ Rectification(c::Video; kwargs...) =
 # when filled anyway (see the `from_extrinsic` docstring); only one bound filled is still an error
 # (verify_pair).
 Rectification(c::Video{Missing}; kwargs...) =
-    from_extrinsic(; _source(c.source)..., c.source.aspect, c.yadif, c.blur, c.n_corners,
-        c.checker_size, kwargs...)
+    from_extrinsic(; _source(c.source)..., c.calibration_id, c.source.aspect, c.yadif, c.blur,
+        c.n_corners, c.checker_size, kwargs...)
 
 # A MATLAB rectification reads the camera model (intrinsics, distortion, and the pose picked by
 # extrinsic_index) from the .mat file; the source video supplies the frame size (already
 # cross-checked against the .mat's ImageSize) and the extrinsic timestamp for the diagnostics.
 Rectification(c::MATLAB; kwargs...) =
-    from_matlab(; _source(c.source)..., c.source.aspect, c.matlab_file, c.extrinsic_index, kwargs...)
+    from_matlab(; _source(c.source)..., c.calibration_id, c.source.aspect, c.matlab_file,
+        c.extrinsic_index, kwargs...)
 
 Rectification(c::Scale; kwargs...) =
-    from_scale(; _source(c.source)..., c.source.aspect, c.scale, kwargs...)
+    from_scale(; _source(c.source)..., c.calibration_id, c.source.aspect, c.scale, kwargs...)
 
 # An AprilTag rectification builds its shared reference from the extrinsic frame (detecting the tags
 # and fitting the metric map) and carries the centre/north gauge. There is no diagnostic image to

--- a/src/main.jl
+++ b/src/main.jl
@@ -65,7 +65,12 @@ function gather_runs(data_path, runs_file, defaults, run_ids = nothing)
     return filter_ids!(rs, run_ids, :run_id, "run_ids")
 end
 
-build_rectifications(cs) = @showprogress desc = "Building rectifications" tmap(Rectification, cs)
+# `rectification_diagnostics` travels from here to `_diagnostic` unchanged — same name, same `Bool`
+# — so there is no path assembly in between and nothing to keep in step. An `apriltag` calibration
+# has no fixed image->real map to warp through and quietly produces no image; its top-down
+# diagnostic is the per-run video instead.
+build_rectifications(cs, rectification_diagnostics::Bool = false) =
+    @showprogress desc = "Building rectifications" tmap(c -> Rectification(c; rectification_diagnostics), cs)
 
 # `rectification_defaults`/`tracking_defaults` globally replace the hardcoded defaults of the
 # tuning parameters (e.g. `rectification_defaults = (n_corners = (5, 8), blur = 0)`,
@@ -73,8 +78,14 @@ build_rectifications(cs) = @showprogress desc = "Building rectifications" tmap(R
 # hardcoded/probed defaults. Each gateway whitelists what may be set (see DEFAULTS in the
 # respective parsers.jl) and rejects anything else up front. `run_ids` restricts processing to
 # the named runs (only the rectifications those runs reference are built).
+#
+# `rectification_diagnostics` saves each calibration's extrinsic frame, warped through the
+# rectification that was fit to it, to `results_dir/rectifications/<calibration_id>.jpg` — the same
+# "are the straight edges straight" check the diagnostic video offers, but available as soon as the
+# rectifications are built rather than after every run has been tracked.
 function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.csv",
-        rectification_defaults = (;), tracking_defaults = (;), run_ids = nothing)
+        rectification_defaults = (;), tracking_defaults = (;), run_ids = nothing,
+        rectification_diagnostics::Bool = false)
     cs = gather_rectifications(data_path, calibs_file, rectification_defaults)
     rs = gather_runs(data_path, runs_file, tracking_defaults, run_ids)
 
@@ -88,7 +99,7 @@ function main(data_path::String; calibs_file = "calibs.csv", runs_file = "runs.c
 
     calibs = DataFrame(calibration_id = calib_ids, c = cs)
 
-    calibs.rectification .= build_rectifications(calibs.c)
+    calibs.rectification .= build_rectifications(calibs.c, rectification_diagnostics)
 
     runs = DataFrame(calibration_id = [r.calibration_id for r in rs], run_id = [r.run_id for r in rs], r = rs)
     leftjoin!(runs, calibs, on = :calibration_id)
@@ -114,7 +125,8 @@ function only_track(data_path::String; runs_file = "runs.csv", tracking_defaults
         r -> track(r; diagnostic_file = joinpath(results_dir, string(r.run_id, ".mp4"))), rs)
 end
 
-function only_rectify(data_path::String; calibs_file = "calibs.csv", rectification_defaults = (;), calibration_ids = nothing)
+function only_rectify(data_path::String; calibs_file = "calibs.csv", rectification_defaults = (;),
+        calibration_ids = nothing, rectification_diagnostics::Bool = false)
     cs = gather_rectifications(data_path, calibs_file, rectification_defaults, calibration_ids)
-    return build_rectifications(cs)
+    return build_rectifications(cs, rectification_diagnostics)
 end

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -9,6 +9,11 @@ using Dates: format, now, @dateformat_str
 # docs/src/results.md): the tracks, the diagnostic videos, and the issue frames below.
 const results_dir = "results_dir"
 
+# One warped extrinsic frame per calibration, written only when a caller asks for them (`main`'s
+# `rectification_diagnostics`). Derived here like every other output location, so there is still one
+# string to change.
+const rectifications_dir = joinpath(results_dir, "rectifications")
+
 # The parent of the per-run issue folders (see `run_issues_dir`), and the default a caller who names
 # no folder of their own gets.
 const DEFAULT_ISSUES_DIR = joinpath(results_dir, "issues")

--- a/test/Rectifications/test_calibration.jl
+++ b/test/Rectifications/test_calibration.jl
@@ -159,8 +159,8 @@
         corners = reshape(map(oblique, objs), ncr)
 
         checker = 1.0
-        rect = R._rectification("unused.mp4", 0.0, [corners], Wf, Hf, ncr, checker, 1.0, 0,
-                                missing, missing, nothing)
+        rect = R._rectification("unused.mp4", 0.0, "regression", [corners], Wf, Hf, ncr, checker,
+                                1.0, 0, missing, missing, false)
         metric = map(rect.image2real, corners)
         down   = vec([hypot((metric[i + 1, j] - metric[i, j])...) for i in 1:ncr[1] - 1, j in 1:ncr[2]])
         across = vec([hypot((metric[i, j + 1] - metric[i, j])...) for i in 1:ncr[1], j in 1:ncr[2] - 1])

--- a/test/Rectifications/test_from_matlab.jl
+++ b/test/Rectifications/test_from_matlab.jl
@@ -18,7 +18,7 @@
     mat = writemat(joinpath(matdir, "consistent.mat"))
     # Every case below is this call with one field varied. Naming them is what the keyword-only
     # builder buys: the test now says which `missing` is the centre and which is the north.
-    rectify(; kw...) = R.from_matlab(; file = "unused.mp4", extrinsic = 0.0, matlab_file = mat,
+    rectify(; kw...) = R.from_matlab(; file = "unused.mp4", extrinsic = 0.0, calibration_id = "m", matlab_file = mat,
         extrinsic_index = 1, aspect = 1.0, center = missing, north = missing,
         width = W, height = H, kw...)
 

--- a/test/Rectifications/test_from_scale.jl
+++ b/test/Rectifications/test_from_scale.jl
@@ -6,7 +6,7 @@
 
     @testset "scales pixel steps into real units" begin
         for (scale, aspect) in ((0.5, 1.0), (2.0, 1.0), (0.5, 1.4))
-            rect = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, scale, aspect,
+            rect = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, calibration_id = "s", scale, aspect,
                 center = missing, north = missing, width = 640, height = 480)
             image2real = rect.image2real
             p0 = SVector(100.0, 120.0)
@@ -23,7 +23,7 @@
 
     @testset "center defaults to frame centre" begin
         # center = missing must reproduce the explicit frame-centre pixel exactly
-        scaled(; kw...) = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, scale = 0.5, aspect = 1.0,
+        scaled(; kw...) = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, calibration_id = "s", scale = 0.5, aspect = 1.0,
             center = missing, north = missing, width = 640, height = 480, kw...)
         i2r_def = scaled().image2real
         i2r_exp = scaled(center = SVector(320.0, 240.0)).image2real
@@ -34,7 +34,7 @@
 
     @testset "northing preserves scale (rigid rotation)" begin
         # supplying a north point rotates the world frame; distances must be preserved
-        i2r = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, scale = 0.5, aspect = 1.0,
+        i2r = R.from_scale(; file = "unused.mp4", extrinsic = 0.0, calibration_id = "s", scale = 0.5, aspect = 1.0,
             center = SVector(320.0, 240.0), north = SVector(320.0, 100.0), width = 640, height = 480).image2real
         p0 = SVector(100.0, 120.0)
         @test hypot((i2r(p0 + SVector(1.0, 0.0)) - i2r(p0))...) ≈ 0.5

--- a/test/Rectifications/test_rectification.jl
+++ b/test/Rectifications/test_rectification.jl
@@ -65,13 +65,16 @@
         extrinsic_t, start, stop, step = 1.15, 0.05, 1.05, 0.1
         # The two `missing`s used to be positional here, and nothing said which was `yadif` and
         # which was `blur`.
-        common = (; file = vid, extrinsic = extrinsic_t, start, stop, temporal_step = step,
+        common = (; file = vid, extrinsic = extrinsic_t, calibration_id = "c1", start, stop, temporal_step = step,
                   yadif = missing, blur = missing, width = Wimg, height = Himg, n_corners,
                   checker_size, aspect = 1.0, radial_parameters = 1)
 
-        diag = mktempdir()
+        # `rectification_diagnostics` is the same flag `main` takes: the image lands under
+        # results_dir, which is relative to the working directory, hence the `cd`.
+        outdir = mktempdir()
         # center = missing ⇒ defaults to the frame centre (the intended behaviour)
-        rect = R.from_video(; common..., center = missing, north = missing, diagnostic = diag)
+        rect = cd(() -> R.from_video(; common..., center = missing, north = missing,
+                                     rectification_diagnostics = true), outdir)
         image2real = rect.image2real
         ext_corners = R.get_corners(vid, extrinsic_t, missing, Wimg, Himg, n_corners)
 
@@ -93,7 +96,7 @@
             # no calibs window: pose + focal fit from the extrinsic frame alone, distortion pinned
             # at zero. The rendered clip is a pure pinhole with the principal point at the frame
             # centre, so the single-view fit (which fixes the principal point there) is well-posed.
-            rect0 = R.from_extrinsic(; file = vid, extrinsic = extrinsic_t, yadif = missing,
+            rect0 = R.from_extrinsic(; file = vid, extrinsic = extrinsic_t, calibration_id = "c0", yadif = missing,
                                      blur = missing, width = Wimg, height = Himg, n_corners,
                                      checker_size, aspect = 1.0, center = missing, north = missing)
             real_pts = map(rect0.image2real, ext_corners)
@@ -111,9 +114,9 @@
         end
 
         @testset "diagnostic frame written" begin
-            jpgs = filter(f -> endswith(f, ".jpg"), readdir(diag))
-            @test length(jpgs) == 1
-            @test filesize(joinpath(diag, only(jpgs))) > 0
+            jpg = joinpath(outdir, "results_dir", "rectifications", "c1.jpg")   # named by calibration_id
+            @test isfile(jpg)
+            @test filesize(jpg) > 0
         end
     end
 end

--- a/test/fromage.jl
+++ b/test/fromage.jl
@@ -77,7 +77,8 @@ end
     # main writes results_dir/diagnostic.mp4 relative to the current directory
     outdir = mktempdir()
     runs = cd(() -> main(dir; rectification_defaults = (n_corners = (5, 8),),
-                              tracking_defaults = (target_width = 10,)), outdir)
+                              tracking_defaults = (target_width = 10,),
+                              rectification_diagnostics = true), outdir)
 
     @test runs isa DataFrame
     @test nrow(runs) == 1
@@ -90,6 +91,11 @@ end
     diag = joinpath(outdir, "results_dir", "diagnostic.mp4")
     @test isfile(diag)
     @test filesize(diag) > 0
+    # rectification_diagnostics: one warped extrinsic frame per calibration, named by its id — so a
+    # bad calibration is visible without watching the run through
+    rectjpg = joinpath(outdir, "results_dir", "rectifications", "c1.jpg")
+    @test isfile(rectjpg)
+    @test filesize(rectjpg) > 0
     # the diagnostic contract: fixed square canvas, 2× real time — 50 tracked frames at 25 fps
     # write every 2nd frame, declared at 25 fps ⇒ 25 frames spanning 1 s of playback
     s = probe_stream(diag)
@@ -135,6 +141,15 @@ end
     @test (rect.width, rect.height) == (320, 240)
     p = SVector(7.0, 11.0)
     @test rect.real2image(rect.image2real(p)) ≈ p   # the two maps are inverses
+    # off by default, and off means no trace at all — not even the folder
+    @test !ispath(joinpath(outdir, "results_dir", "rectifications"))
+
+    # on request, one image per calibration here too — this time through the only_scale builder
+    diagdir = mktempdir()
+    cd(() -> Fromage.only_rectify(dir; rectification_diagnostics = true), diagdir)
+    scalejpg = joinpath(diagdir, "results_dir", "rectifications", "c1.jpg")
+    @test isfile(scalejpg)
+    @test filesize(scalejpg) > 0
 
     # no rectification involved: raw pixel coordinates, one raw-view diagnostic per run, named by
     # run_id — which this csv does not set, so it is the imputed row number


### PR DESCRIPTION
Closes #100.

Every rectification builder took a `diagnostic` keyword that saves the extrinsic frame warped
through the rectification fit to it — and nothing in `src/` ever passed it. `main`, `only_rectify`
and `build_rectifications` all called `tmap(Rectification, cs)` bare, `main` exposed no keyword, and
the docs never mentioned it. The only caller anywhere was one test.

So `_diagnostic`, all of `plotting.jl`, and the `ImageIO` dependency loaded solely for FileIO's JPEG
backend — plus the `ignore = (:ImageIO,)` exemption in `quality.jl`'s stale-import check — were
being maintained for something no user could ask for.

### Now reachable

```julia
main("path/to/data"; rectification_diagnostics = true)
Fromage.only_rectify("path/to/data"; rectification_diagnostics = true)
```

One image per calibration, at `results_dir/rectifications/<calibration_id>.jpg`. Off means **no
trace at all** — the folder isn't created, matching how the issues folder behaves.

### One name, one type, all the way down

`rectification_diagnostics` is the same `Bool` at every level:

```
main / only_rectify  ->  build_rectifications  ->  Rectification  ->  from_video / from_extrinsic
                                                                      from_matlab / from_scale
                                                                  ->  _diagnostic
```

No path assembly in between, so there is nothing to keep in step. `_diagnostic` owns where the
image goes and what it is called, which is why the builders now take `calibration_id` as well. The
output location lives in `Paths` beside `results_dir` and the issues folder, which is what that
module is for.

`results.md` already tells people the top-down view is how a bad calibration is caught ("straight
edges straight, circles circular — a warped arena means a bad calibration"), but the only place to
see that was the diagnostic *video*, produced after every run has been tracked. This is the same
check the moment the rectifications are built: the cheap step before the expensive one.

An `apriltag` calibration produces no image — no single fixed image-to-real map to warp through,
since the drone moves — documented rather than warned about, its top-down view being the per-run
video.

### Two things dead code could afford and live code cannot

**The filename would have collided.** It was `<video>_<extrinsic>.jpg`, but
`verify_unique_calibrations!` keys a video row on `[:file, :start, :stop, :extrinsic, :center,
:north]` — so two rows differing only in `center` are *not* duplicates, produce genuinely different
warps, and would have written the same filename with one silently overwriting the other. Same for
two `only_scale` rows differing only in `scale`. Named by `calibration_id` now: unique, and what
lets a reader match an image back to its csv row.

**`from_scale` duplicated `_diagnostic`'s body** inline, and computed its `warp_trans` on every call
whether or not a diagnostic was wanted. It calls the shared function now.

### Tests

- The existing unit test asserted only that *a* `.jpg` appeared in a directory of its own choosing;
  it now `cd`s into a temp dir and asserts the real production filename.
- End-to-end through `main` (the `from_video` builder) and through `only_rectify` (`from_scale`,
  whose body changed).
- Off by default writes nothing: `@test !ispath(.../rectifications)`.

Five other builder call sites in the suite gained `calibration_id`; they don't request diagnostics,
but the argument is now required.

Docs: a new "The rectification images" section in `results.md`, and a pointer from `help.md`
alongside the other `main` keywords.

### Rebased onto main, and two call sites fixed

The first CI run failed, and it is worth recording why. #97 added a regression test calling
`_rectification` positionally; this PR changes that function's signature. Neither branch was broken
on its own — only their merge was, and a `git merge-tree` check found no conflict because the two
edits are textually far apart. **A clean textual merge is not a clean semantic merge.** Rebased onto
main and the call updated.

Sweeping the whole tree for stale call sites afterwards turned up a second one no test run touches:
`benchmark/benchmarks.jl` called `from_scale` without the now-required `calibration_id`. Neither the
local suite nor CI would ever have caught it — only someone running PkgBenchmark, much later. Fixed.

### Verification

Local suite on the rebased branch: **1213 passed, 0 failed** (7m54s, `JULIA_NUM_THREADS=16`,
`coverage = true`).

Patch coverage from the `.cov` files: **19/19 executable added lines hit (100%)**. The added lines
marked non-executable are the `const rectifications_dir = joinpath(...)` (identical in shape to the
`DEFAULT_ISSUES_DIR` const two lines below it, which codecov already accepts), the keyword-signature
lines, and `using` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHn1sFycGkKrJko33MxBbQ
