### PR TITLE
Three small ones: a leaked task, a stale reason, a dropped frame

### DIFF
--- a/src/PawsomeTracker/diagnose.jl
+++ b/src/PawsomeTracker/diagnose.jl
@@ -56,9 +56,14 @@ function Diagnostic(file::AbstractString, darker_target, fps, scene; radius, fon
         darker_target ? Gray{N0f8}(1) : Gray{N0f8}(0), radius, font, FTFont(String(FONT)), scene)
 end
 
+# Written frames are 1, skip+1, 2*skip+1, … — the counter is tested BEFORE it is bumped. Bumping
+# first tested the opening frame as `rem(1, skip)`, so the one frame that shows where tracking
+# actually began was the one frame never written, unless the stride happened to be 1. That is the
+# frame a reader checking for a wrong `start_location` needs (see results.md).
 function (dia::Diagnostic)(frame, point, extra...)
+    write_now = rem(dia.state[], dia.skip) == 0
     dia.state[] += 1
-    rem(dia.state[], dia.skip) == 0 || return nothing
+    write_now || return nothing
     canvas, ij = dia.scene(frame, point, extra...)
     if !ismissing(ij)
         push!(dia.trace, ij)

--- a/src/Rectifications/from_video.jl
+++ b/src/Rectifications/from_video.jl
@@ -165,8 +165,14 @@ function from_video(; file, extrinsic, calibration_id, start, stop, temporal_ste
     vf = _vf(yadif, blur)
     intrinsic_task = Threads.@spawn extract_intrinsics(file, start, stop, temporal_step, vf, width, height, n_corners)
     extrinsic_corners = get_corners(file, extrinsic, vf, width, height, n_corners)
-    ismissing(extrinsic_corners) && error("no corners detected at extrinsic time stamp")
+    # Fetched before the extrinsic frame is judged, so the spawned scan is awaited on every path out
+    # of here. Throwing first left its `tmap` of ffmpeg reads running against the share after the
+    # call had already failed, and dropped its exception silently — an unfetched failed Task is
+    # never reported. There is nothing to cancel (Julia has no task cancellation) and nothing to
+    # gain from failing sooner: the scan is bounded by the calibs window, and in the pipeline this
+    # error is close to unreachable, `verify_extrinsics!` having already rejected such a row.
     imgpointss = fetch(intrinsic_task)
+    ismissing(extrinsic_corners) && error("no corners detected at extrinsic time stamp")
     push!(imgpointss, extrinsic_corners)
     return _rectification(file, extrinsic, calibration_id, imgpointss, width, height, n_corners, checker_size, aspect, radial_parameters, center, north, rectification_diagnostics)
 end

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -101,8 +101,11 @@ function verifications!(df::AbstractDataFrame, data_path)
     verify!(df, (a, o) -> a ≥ o, "start must come before stop", :start, :stop)
     verify!(df, (o, d) -> o > d, "stop can not come after video duration", :stop, :duration)
     verify!(df, (a, d) -> a > d, "start can not come after video duration", :start, :duration)
-    # PawsomeTracker reads round(Int, fps × (stop − start)) frames, so a window shorter than half a
-    # frame period reads none at all, and a zero-frame segment crashes the multi-segment track.
+    # A window shorter than half a frame period is not what anyone asking for a window meant. It
+    # does not crash: `Video` floors its sample count at one (`max(1, floor(Int, …))`), so such a
+    # segment yields a single-sample track instead — silently, which is why this is checked here.
+    # (This used to claim a zero-frame segment crashed the multi-segment track. That `max` has made
+    # it impossible, and a wrong reason invites someone to delete the check once they find out.)
     verify!(df, (o, a, f) -> round(Int, f * (o - a)) < 1, "temporal window is too short to contain a single frame at this fps", :stop, :start, :fps)
 
     # Cross-row: segments of one run (shared :run_id) must agree on the run-level parameters.

--- a/test/pawsometracker.jl
+++ b/test/pawsometracker.jl
@@ -153,6 +153,16 @@ const DATADIR = mktempdir()
         @test s.nframes / s.fps * 2 ≈ 2 rtol = 0.01
     end
 
+    @testset "the diagnostic opens on the first tracked frame" begin
+        # `stop` trims the window to 49 samples, an ODD count — which is what makes the two
+        # behaviours distinguishable. The opening frame plus every 2nd after it is cld(49, 2) = 25;
+        # starting at the stride instead, as it used to, gives fld(49, 2) = 24 and drops the one
+        # frame that shows where tracking began. The 50-sample case above cannot tell them apart.
+        df = joinpath(DATADIR, "diag_first.mp4")
+        track(base_file; stop = 1.96, diagnostic_file = df)
+        @test probe_stream(df).nframes == 25
+    end
+
     @testset "diagnostic playback speed holds for a non-divisor fps (#55)" begin
         # The check above only covers a divisor rate, where requested == effective and the bug is
         # invisible. The diagnostic declares its framerate from the fps it is handed, so handing it


### PR DESCRIPTION
Closes #102, closes #103, closes #104. Three small, independent fixes on one branch — they touch
different files and none needs a suite run of its own.

### #102 — `from_video` leaked the spawned intrinsic scan

```julia
intrinsic_task = Threads.@spawn extract_intrinsics(...)
extrinsic_corners = get_corners(...)
ismissing(extrinsic_corners) && error("no corners detected at extrinsic time stamp")   # <- left here
imgpointss = fetch(intrinsic_task)
```

On that error the task kept running — a `tmap` of ffmpeg processes against the share, still going
after the call had already failed — and if it had raised, nobody would ever have seen it: an
unfetched failed `Task` is dropped silently.

It is fetched before the extrinsic frame is judged now, so it is awaited on every path out. Nothing
is lost by failing a moment later: the scan is bounded by the calibs window, there is nothing to
cancel (Julia has no task cancellation), and in the pipeline this error is close to unreachable —
`verify_extrinsics!` has already rejected a row whose extrinsic frame yields no corners.

**No new test, deliberately.** The leak is not observable without exposing the task handle, and the
only externally visible side effect is *which* exception surfaces when both the scan and the
extrinsic fail — pinning that would over-constrain future refactoring for no real benefit. Both
touched lines are already exercised by the existing `from_video` tests (10x and 5x in the `.cov`
output), so patch coverage is unaffected.

### #103 — a stale reason on a check worth keeping

The comment claimed a zero-frame segment crashes the multi-segment track. It cannot: `Video` floors
its sample count at one (`max(1, floor(Int, ...))`), so such a window yields a **single-sample
track** instead — silently, which is the real reason to check for it. A wrong reason is worse than
none: it invites deleting the check once someone discovers the crash it cites is impossible.

Comment only.

### #104 — the first tracked frame never reached the diagnostic video

```julia
dia.state[] += 1
rem(dia.state[], dia.skip) == 0 || return nothing
```

`state` starts at 0, so the opening frame was tested as `rem(1, skip)` — true only when the stride
is 1. Frames came out at `skip, 2*skip, ...` and the one frame showing where tracking actually began
was the one frame never written. That is the frame a reader checking for a wrong `start_location`
needs, and `results.md` names a wrong start location as a leading cause of a bad track.

Testing before the bump gives `1, skip+1, 2*skip+1, ...`. The written count goes from
`fld(n, skip)` to `cld(n, skip)` — the same, or one more frame.

The new test trims the window to an **odd** 49 samples, which is what makes the two behaviours
distinguishable: `cld(49, 2) = 25` against `fld(49, 2) = 24`. The existing 50-sample assertion
(`fld` and `cld` both 25) cannot tell them apart, which is exactly why this went unnoticed — and it
still passes unchanged.

### Verification

Rebased onto main after #101 merged, and verified on the **merged** tree rather than on the branch
in isolation — #101's first CI run failed precisely because a clean textual merge is not a clean
semantic one, so a conflict-marker check is not enough:

- `from_video` reads correctly with #101's new signature (`calibration_id`,
  `rectification_diagnostics::Bool`) and this PR's reordering both intact, and its 13-argument
  `_rectification` call is right.
- Swept every call site of the six functions #101 changed signatures on — all 18 accounted for.
- Loaded `benchmark/benchmarks.jl`, which no test suite or CI job touches, confirming it still runs.

Local suite on the rebased branch: **1214 passed, 0 failed** (8m00s, `JULIA_NUM_THREADS=16`,
`coverage = true`).

Patch coverage from the `.cov` files: **3/3 executable added lines hit (100%)**. Most of the diff is
comments; `#103` adds no executable lines at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHn1sFycGkKrJko33MxBbQ
