### PR TITLE
Carry the probed frame rate instead of reopening the video for it

### DIFF
--- a/src/PawsomeTracker/PawsomeTracker.jl
+++ b/src/PawsomeTracker/PawsomeTracker.jl
@@ -383,7 +383,8 @@ end
 Use a Difference of Gaussian (DoG) filter to track a target in the video `file` between `start`
 and `stop` seconds, sampling `fps` frames per second (capped at the video's own rate, and rounded
 to the nearest rate reachable by skipping whole frames — `vid_fps / skip`; `ts` always describes the
-rate actually used). Returns
+rate actually used; `video_fps` is that own rate, read from the file unless a caller who already
+knows it — the runs gateway probes it — passes it in, sparing an open). Returns
 `(ts, coords)`: timestamps and the target's per-frame position. With a `rectification`, `coords`
 are **real-world** coordinates (the rectification's `image2real` applied); without one, they are
 raw `(row, col)` pixels in the original frame (`scale` trades precision for speed — see `scale` in
@@ -442,7 +443,13 @@ function track(
         start_location::AbstractVector = similar(files, Missing),
         window_size::Union{Missing, Int, NTuple{2, Int}} = round(Int, 2target_width),
         darker_target::Bool = true,
-        fps::Real = get_framerate(files[1]),
+        # The video's own frame rate. Declared before `fps` so that one defaults to the other: the
+        # rate is then read at most once, where the two used to call `get_framerate` separately. A
+        # caller who already knows it (`track(::Run)`, from the gateway's probe) passes it and the
+        # video is never opened for it at all — one fewer open of the share per run, which is worth
+        # having in a package where an open is the thing that fails (see WHY-FRAMES-FAIL.md).
+        video_fps::Real = get_framerate(files[1]),
+        fps::Real = video_fps,
         diagnostic_file::Union{Nothing, AbstractString} = nothing,
         initial_search_factor::Real = 4,
         scale::Real = 1,
@@ -456,8 +463,9 @@ function track(
     window_size = ismissing(window_size) ? round(Int, 2target_width) : window_size
 
     # As in the single-file method (#55). Segments are assumed to share one native frame rate (see
-    # runs.md), so the first one's is representative — as it is for the `fps` default above.
-    dia_fps = effective_fps(get_framerate(files[1]), fps)
+    # runs.md), so the first one's is representative — as it is for the `fps` default above, and as
+    # it is for the value `track(::Run)` hands in.
+    dia_fps = effective_fps(video_fps, fps)
 
     nfiles = length(files)
     tss = Vector{StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}(undef, nfiles)

--- a/src/VerifyRuns/types.jl
+++ b/src/VerifyRuns/types.jl
@@ -20,6 +20,7 @@ struct Source
     window_size::Union{Missing, Int, NTuple{2, Int}}
     darker_target::Bool
     fps::Float64
+    video_fps::Float64
     initial_search_factor::Float64
     scale::Float64
     background_length::Int
@@ -41,10 +42,15 @@ end
 # The run-level values are read off the group's first row (verify_run_consistency! guaranteed the
 # segments agree on them — :dimension/:sar included). :dimension is the ffprobe-filled
 # (width, height) in stored pixels; :sar the sample aspect ratio (display width = width × sar).
+#
+# :video_fps is the exception: it is NOT in SHARED_PARAMS, so segments are not required to agree on
+# it (see runs.md, #95). The first row's is what `track` used anyway — it read the rate from
+# `files[1]` — so carrying it here changes nothing except that the video is no longer reopened for
+# it.
 function Source(g::AbstractDataFrame)
     width, height = g.dimension[1]
     Source(g.target_width[1], g.window_size[1], g.darker_target[1],
-        g.fps[1], g.initial_search_factor[1], g.scale[1],
+        g.fps[1], g.video_fps[1], g.initial_search_factor[1], g.scale[1],
         g.background_length[1], width, height, g.sar[1])
 end
 
@@ -65,7 +71,8 @@ end
 # impute_window_size).
 function shared_kw(r::Run)
     s = r.source
-    (; s.target_width, s.darker_target, s.fps, s.initial_search_factor, s.scale, s.background_length)
+    (; s.target_width, s.darker_target, s.fps, s.video_fps, s.initial_search_factor, s.scale,
+        s.background_length)
 end
 
 # Drive `PawsomeTracker.track` from a verified run. The returned coordinates are (row, col) in

--- a/test/VerifyRuns/test_video_metadata.jl
+++ b/test/VerifyRuns/test_video_metadata.jl
@@ -12,6 +12,17 @@
         @test r.source.sar    == 1                      # square pixels; anamorphic: test_tracking.jl
     end
 
+    @testset "the video's own frame rate is carried onto the run's Source" begin
+        # The gateway already probes it (it imputes a blank `fps` from it and bounds-checks an
+        # explicit one against it). Carrying it means `track` no longer reopens the video to read it
+        # back — one fewer open of the share per run.
+        r = only(check([runrow()]))
+        @test r.source.video_fps == 30.0
+        # an explicit tracking fps does not disturb it: the two are different numbers
+        r2 = only(check([runrow(fps = "15")]))
+        @test r2.source.fps == 15.0 && r2.source.video_fps == 30.0
+    end
+
     @testset "CSV values win over imputation" begin
         r = only(check([runrow(stop = "3", fps = "15")]))
         @test only(r.stops) == 3.0

--- a/test/pawsometracker.jl
+++ b/test/pawsometracker.jl
@@ -163,6 +163,23 @@ const DATADIR = mktempdir()
         @test probe_stream(df).nframes == 25
     end
 
+    @testset "a supplied video_fps is used instead of reopening the video" begin
+        # `track(::Run)` hands in the rate the gateway probed. Supplying the true rate must be
+        # indistinguishable from letting it be read; supplying a wrong one must visibly change the
+        # diagnostic's declared playback rate, which is what proves the value is actually used
+        # rather than quietly re-read from the file.
+        df_read = joinpath(DATADIR, "vfps_read.mp4")
+        df_told = joinpath(DATADIR, "vfps_told.mp4")
+        df_lied = joinpath(DATADIR, "vfps_lied.mp4")
+        track(base_file; diagnostic_file = df_read)
+        track(base_file; video_fps = 25, diagnostic_file = df_told)
+        # 30, not 50: at 50 the sampler picks skip = 2 and the effective rate lands back on 25, so
+        # the declared rate would match by coincidence and the test would prove nothing
+        track(base_file; video_fps = 30, fps = 25, diagnostic_file = df_lied)
+        @test probe_stream(df_told).fps ≈ probe_stream(df_read).fps
+        @test probe_stream(df_lied).fps ≉ probe_stream(df_read).fps
+    end
+
     @testset "diagnostic playback speed holds for a non-divisor fps (#55)" begin
         # The check above only covers a divisor rate, where requested == effective and the bug is
         # invisible. The diagnostic declares its framerate from the fps it is handed, so handing it


### PR DESCRIPTION
Closes #108.

The runs gateway already probes each video's own frame rate into `:video_fps` and uses it — a blank
`fps` is imputed from it, an explicit one bounds-checked against it — but it never reached `Source`,
so `track` opened the video again to read it back:

```julia
fps::Real = get_framerate(files[1]),
...
dia_fps = effective_fps(get_framerate(files[1]), fps)
```

**Twice**, when `fps` was left blank: once for the keyword default, once for `dia_fps`.

`get_framerate` opens through VideoIO (retried via `ShareIO`, falling back to a separate ffprobe
spawn when the container reports an infinite rate). Worth removing in a package where an open is the
thing that fails — `WHY-FRAMES-FAIL.md` counts these paths precisely because the share drops
connections on its own schedule. An open that does not happen cannot fail.

### Shape

- `Source` carries `video_fps`, alongside the `:dimension` and `:sar` it already took from the probe.
- `track(files; …)` gains a `video_fps` keyword **declared before `fps`**, so `fps` defaults to it.
  A direct caller sees no change except that the rate is read once instead of twice.
- `track(::Run)` passes the probed value through `shared_kw`, and the video is not opened for it at
  all.

### No change for mismatched segments

`:video_fps` is not in `SHARED_PARAMS`, so a run's segments are not required to agree on it (see
`runs.md`, #95). The group's first row is what `track` used anyway — it read the rate from
`files[1]` — so mismatched segments behave exactly as before, and as documented.

### Tests

- **The probed rate reaches `Source`**: `r.source.video_fps == 30.0`, and an explicit tracking
  `fps = 15` leaves it alone — the two are distinct numbers now, so a test can tell them apart.
- **The supplied value is actually used**: supplying the true rate is indistinguishable from letting
  it be read, while supplying a *wrong* one visibly changes the diagnostic's declared playback rate.
  Without the second half the first proves nothing, since a re-read would also pass.

That second test nearly proved nothing. I first wrote the wrong value as `50`, but at 50 the sampler
picks `skip = 2` and the effective rate lands back on 25 — the same declared rate as the truth. `30`
actually discriminates (30.0 against 25.0). The comment in the test records why, so nobody
"simplifies" it back.

### Verification

Local suite: **1218 passed, 0 failed** (8m03s, `JULIA_NUM_THREADS=16`, `coverage = true`).

Patch coverage from the `.cov` files: **2/2 executable added lines hit (100%)** — most of the diff is
comments and keyword-signature lines.

No file overlap with the open #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHn1sFycGkKrJko33MxBbQ
