### PR TITLE
Four comments describe code that is no longer there (#113)

### DIFF
--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -312,12 +312,13 @@ canvas2raw(Hinv, scale) = rc -> (p = apply_h(Hinv, SVector(rc[2], rc[1]) ./ scal
 const PROTECT_PAD = 5
 
 # ============================================================================================
-# PHASE 2 — detection and the single-pass tracking loop.
+# Detection and the single-pass tracking loop.
 # ============================================================================================
 
 # The AprilTag detector needs a plain Gray{N0f8}/UInt8 matrix (not the Gray{Float32} background
-# stack), so detection always runs on the raw frame. Whole-frame detection for now — the ROI /
-# local-search fast path is PHASE 4.
+# stack), so detection always runs on the raw frame. Whole-frame detection is used only to establish
+# the reference and to relocate the (stationary) tags in a run's first frame; every frame after that
+# goes through the per-tag local search below.
 function set_detector!(det; nthreads = 1)
     det.nThreads = nthreads
     det.quad_decimate = 1.0
@@ -358,7 +359,7 @@ function apriltag_guess(start_xy::NTuple{2, Int}, _, vid, _, _, _, _, seedR)
     return round.(Int, vid.scale .* (p[2], p[1]))
 end
 
-# ---- PHASE 4: local ROI search ----------------------------------------------------------------
+# ---- local ROI search --------------------------------------------------------------------------
 # AprilTag detection cost scales with pixels, so after the reference frame each tag is searched in a
 # small box around where it was last seen rather than over the whole frame. Detecting on a crop
 # reproduces the full-frame corners to better than 0.1 px, so this is a pure speedup. The box grows

--- a/src/VerifyRectifications/precompile.jl
+++ b/src/VerifyRectifications/precompile.jl
@@ -10,7 +10,7 @@
     dir = mktempdir()
     csv = joinpath(dir, "precompile.csv")
     open(csv, "w") do io
-        # Minimal header (other columns are back-filled by parse_row); one row per type so all three
+        # Minimal header (other columns are back-filled by parse_row); one row per type so all four
         # parse branches and the type-specific verifications compile. All point at a nonexistent file.
         println(io, "calibration_id,file,matlab_file,type,extrinsic,extrinsic_index,scale")
         println(io, "v,nope.mp4,,video,1,,")

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -294,9 +294,10 @@ end
 # The camera-model fit needs at least 3 frames with detectable corners sampled from the
 # [start, stop] window — the "temporal_step too short" check only guarantees 3 *sampled* frames, not
 # 3 *detectable* ones. Detection stops as soon as 3 succeed, so a good window costs ~3 frame reads
-# and only a genuinely bad one scans to the end. Frames are read in small parallel batches, with the
-# global read semaphore in Rectifications bounding the concurrent opens as in the real
-# rectification.
+# and only a genuinely bad one scans to the end. Frames are read in parallel batches of 4, which is
+# the only thing bounding the concurrent opens: the global read limiter this used to name
+# (`READ_SEM`) was measured against the real share, found to prevent nothing, and deleted — see
+# WHY-FRAMES-FAIL.md.
 function intrinsic_issue(file, start, stop, temporal_step, yadif, blur, width, height, n_corners)
     vf = _vf(yadif, blur)
     found = 0

--- a/src/VerifyRuns/precompile.jl
+++ b/src/VerifyRuns/precompile.jl
@@ -3,8 +3,9 @@
 
 # Precompile the parse → verify → report pipeline. The bulk of first-call latency is the
 # DataFrames machinery (column-typed `subset`/`groupby`/`verify!` specializations) a single
-# points at a nonexistent file, so the run exercises the full parse + verification path but bails
-# before any ffprobe — no bundled media, fast and deterministic.
+# `load_runs` run compiles. The workload CSV points at a nonexistent file, so the run exercises the
+# full parse + verification path but bails before any ffprobe — no bundled media, fast and
+# deterministic.
 @setup_workload begin
     dir = mktempdir()
     csv = joinpath(dir, "precompile.csv")

--- a/test/apriltag.jl
+++ b/test/apriltag.jl
@@ -32,7 +32,7 @@ const ANGLES  = [0.10, -0.20, 0.15, -0.05]
 const TAGS_CM = [[CENTERS[i] + rot(ANGLES[i]) * c for c in CANON] for i in 1:4]
 project(H) = [[apply_h(H, c) for c in tc] for tc in TAGS_CM]
 
-@testset "AprilTag geometry (phase 1)" begin
+@testset "AprilTag geometry" begin
 
     @testset "homography_dlt recovers a known homography" begin
         pts = SVector{2,Float64}[SVector(1400, 880), SVector(1500, 890), SVector(1490, 970), SVector(1395, 965), SVector(1445, 925)]


### PR DESCRIPTION
Closes #113.

Five comments and one testset name that describe code which is no longer there. No behaviour changes.

| | |
|---|---|
| `VerifyRectifications/verifications.jl` | `intrinsic_issue` credited the concurrent-open bound to "the global read semaphore in Rectifications". `READ_SEM` was measured against the real share, found to prevent nothing, and deleted (WHY-FRAMES-FAIL.md, DESIGN-HISTORY.md); the `partition(…, 4)` batching is now the only thing bounding those opens. |
| `PawsomeTracker/apriltag.jl` | `set_detector!` said whole-frame detection was all there was and the ROI fast path was "PHASE 4" — but that path is implemented in the same file and is what the tracking loop calls after the seed frame. Whole-frame detection now survives only to establish the reference and to relocate the tags in a run's first frame. The `PHASE 2` / `PHASE 4` section labels went with it: phases 1 and 3 appear nowhere in the file. |
| `VerifyRuns/precompile.jl` | The header sentence had lost its middle ("…specializations) a single / points at a nonexistent file"). Restored from the sibling file's intact wording. |
| `VerifyRectifications/precompile.jl` | The workload writes `video`, `matlab`, `only_scale` and `apriltag` rows — four parse branches, not three. The count was not updated when the AprilTag type landed. |
| `test/apriltag.jl` | `@testset "AprilTag geometry (phase 1)"` was the last survivor of the same abandoned numbering. `"rolling phase"` elsewhere in the suite is the tracking loop's own term and stays. |

### Checking

Every changed line in `src/` starts with `#`, verified mechanically, and all four files parse. The testset rename is the one non-comment line in the diff, so rather than assert it was safe I ran that testset — pure synthetic geometry, no video or fixtures — and it reports **16 passes, 0 failures** across all seven subsets under its new name.

The full suite was not run locally for a comment pass; CI covers it.
