### PR TITLE
Give each gateway suite its own CSV writer (#115)

### DIFF
--- a/test/VerifyRectifications/helpers.jl
+++ b/test/VerifyRectifications/helpers.jl
@@ -5,7 +5,7 @@ using Test
 using Fromage: VerifyRectifications
 using CSV, DataFrames
 using FFMPEG, MAT
-import ..Harness: write_csv
+import ..Harness
 
 const VRect = VerifyRectifications
 
@@ -105,7 +105,9 @@ const HEADER = ["calibration_id", "path", "file", "matlab_file", "type", "extrin
                 "yadif", "aspect", "apriltags", "family", "comment"]
 
 row(; kw...) = buildrow(HEADER; kw...)
-write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)
+# Module-local, and deliberately not a method on `Harness.write_csv`: both suites would add
+# the same two-argument signature to it, and the second would silently replace the first (#115).
+write_rows(path, rows; header = HEADER) = Harness.write_csv(path, rows, header)
 _merge(base; kw...) = row(; merge(base, values(kw))...)
 
 # Clean baseline rows per rectification type; override any field via keyword to isolate one issue.
@@ -137,7 +139,7 @@ column `verifications!` references — no column-completing filler rows are need
 # extrinsic frame) don't write into the test's working directory; a test that inspects the dumped
 # frames passes an explicit path.
 function check(name, rows; strict = false, header = HEADER, defaults = (;), issues_dir = mktempdir())
-    csv = write_csv(joinpath(DATADIR, name), rows; header)
+    csv = write_rows(joinpath(DATADIR, name), rows; header)
     VRect.load_rectifications(DATADIR, csv; strict, defaults, issues_dir)
 end
 

--- a/test/VerifyRectifications/test_input.jl
+++ b/test/VerifyRectifications/test_input.jl
@@ -6,12 +6,12 @@
     end
 
     @testset "empty csv file" begin
-        csv = write_csv(joinpath(DATADIR, "empty.csv"), [])   # header only, no data rows
+        csv = write_rows(joinpath(DATADIR, "empty.csv"), [])   # header only, no data rows
         @test_throws "csv file is empty" VRect.load_rectifications(DATADIR, csv)
     end
 
     @testset "unrecognized column" begin
-        csv = write_csv(joinpath(DATADIR, "badcol.csv"), [["x", "y"]]; header = ["calibration_id", "foo"])
+        csv = write_rows(joinpath(DATADIR, "badcol.csv"), [["x", "y"]]; header = ["calibration_id", "foo"])
         @test_throws "unrecognized column" VRect.load_rectifications(DATADIR, csv)
     end
 end

--- a/test/VerifyRectifications/test_reading.jl
+++ b/test/VerifyRectifications/test_reading.jl
@@ -145,7 +145,7 @@
     @testset "single-type CSV (no per-type fillers) loads" begin
         # parse_row back-fills every COLUMNS entry with missing, so a video-only CSV (which never
         # creates the :scale column) must not make verifications! throw `column :scale not found`.
-        csv = write_csv(joinpath(DATADIR, "videoonly.csv"), [videorow()])   # no fillers
+        csv = write_rows(joinpath(DATADIR, "videoonly.csv"), [videorow()])   # no fillers
         @test (VRect.load_rectifications(DATADIR, csv; strict = false); true)
     end
 

--- a/test/VerifyRuns/helpers.jl
+++ b/test/VerifyRuns/helpers.jl
@@ -5,7 +5,7 @@ using Test
 using Fromage: VerifyRuns
 using CSV, DataFrames
 import ..Fixtures: make_target_video
-import ..Harness: write_csv
+import ..Harness
 
 const VR = VerifyRuns
 
@@ -38,7 +38,9 @@ const HEADER = ["run_id", "calibration_id", "path", "file", "start", "stop", "ta
                 "initial_search_factor", "scale", "background_length"]
 
 row(; kw...) = buildrow(HEADER; kw...)
-write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)
+# Module-local, and deliberately not a method on `Harness.write_csv`: both suites would add
+# the same two-argument signature to it, and the second would silently replace the first (#115).
+write_rows(path, rows; header = HEADER) = Harness.write_csv(path, rows, header)
 _merge(base; kw...) = row(; merge(base, values(kw))...)
 
 # Clean baseline run row (run_id + calibration_id + a 5 s video; every other field defaults).
@@ -51,7 +53,7 @@ runrow(; kw...) = _merge((run_id = "r", calibration_id = "c", file = ART.a); kw.
 # ---------------------------------------------------------------------------
 
 function check(name, rows; strict = false, header = HEADER, defaults = (;))
-    csv = write_csv(joinpath(DATADIR, name), rows; header)
+    csv = write_rows(joinpath(DATADIR, name), rows; header)
     VR.load_runs(DATADIR, csv; strict, defaults)
 end
 

--- a/test/VerifyRuns/test_input.jl
+++ b/test/VerifyRuns/test_input.jl
@@ -6,12 +6,12 @@
     end
 
     @testset "empty csv file" begin
-        csv = write_csv(joinpath(DATADIR, "empty.csv"), [])   # header only, no data rows
+        csv = write_rows(joinpath(DATADIR, "empty.csv"), [])   # header only, no data rows
         @test_throws "csv file is empty" VR.load_runs(DATADIR, csv)
     end
 
     @testset "unrecognized column" begin
-        csv = write_csv(joinpath(DATADIR, "badcol.csv"), [["x", "y"]]; header = ["run_id", "foo"])
+        csv = write_rows(joinpath(DATADIR, "badcol.csv"), [["x", "y"]]; header = ["run_id", "foo"])
         @test_throws "unrecognized column" VR.load_runs(DATADIR, csv)
     end
 
@@ -19,8 +19,8 @@
         # It was accepted and validated but never read, so it was removed rather than implemented.
         # A csv that still carries it is rejected up front, naming the column — the migration is
         # deleting it, and nothing about tracking changes, since the value never reached the tracker.
-        csv = write_csv(joinpath(DATADIR, "wp_removed.csv"), [["c1", "a.mp4", "1.0"]];
-                        header = ["calibration_id", "file", "white_point"])
+        csv = write_rows(joinpath(DATADIR, "wp_removed.csv"), [["c1", "a.mp4", "1.0"]];
+                         header = ["calibration_id", "file", "white_point"])
         @test_throws "unrecognized column" VR.load_runs(DATADIR, csv)
         @test_throws "white_point" VR.load_runs(DATADIR, csv)
     end


### PR DESCRIPTION
Closes #115.

Both `helpers.jl` files did this, with a different `HEADER` each:

```julia
import ..Harness: write_csv
write_csv(path, rows; header = HEADER) = write_csv(path, rows, header)
```

The `import` is what makes extending `Harness.write_csv` legal, and both modules added the *same* two-positional-argument method to it, so only one survived — the runs suite's. It worked purely by include order: the rectification suite runs its tests before the runs suite's helpers load. Reorder the includes, or add a case that reruns a rectification scenario later, and those calls would have written their CSVs under the runs header, which has no `type`, `extrinsic` or `center` column. The rows would not have failed to parse; they would have parsed as something else.

Each suite now delegates under a module-local name instead of extending the shared function:

```julia
import ..Harness
write_rows(path, rows; header = HEADER) = Harness.write_csv(path, rows, header)
```

Six call sites updated plus the two definitions; no bare `write_csv` remains outside `test/harness.jl`.

### Why the name had to change

Keeping `write_csv` was not available. `Harness` exports it and both parent modules do `using ..Harness`, so a local definition of that name must be either an extension or an error — which is how the collision arose in the first place. `write_rows` cannot collide, and fits the existing `row` / `buildrow` vocabulary.

### Checking

Full suite on the committed tree, Julia 1.12.7: **1286 / 1286 pass**, 8m42s — the same count as `main`, so the rename moved no test. The two `Method definition write_csv ... overwritten` warnings that every previous run printed are gone; the log now contains no `WARNING` lines at all.

Independent of #114: the two branches touch disjoint file sets, and #114 introduces no `write_csv` / `write_rows` call site.