### PR TITLE
Let a caller silence the gateway progress meters (#117)

### DIFF
--- a/src/VerifyRectifications/VerifyRectifications.jl
+++ b/src/VerifyRectifications/VerifyRectifications.jl
@@ -31,24 +31,26 @@ include("verifications.jl")
 # detection is dumped for inspection (see `verifications!`). Every run writes into a new time-stamped
 # folder of its own inside it, so what a run dumped is exactly what its folder holds; nothing here is
 # ever deleted, including anything the user keeps in the folder they name.
-function load_rectifications(file; strict = true, defaults = (;), issues_dir = DEFAULT_ISSUES_DIR)
+function load_rectifications(file; strict = true, defaults = (;), issues_dir = DEFAULT_ISSUES_DIR,
+        progress = true)
     data_path = dirname(file)
-    load_rectifications(data_path, file; strict, defaults, issues_dir)
+    load_rectifications(data_path, file; strict, defaults, issues_dir, progress)
 end
 
 # `defaults` globally replaces the hardcoded fallbacks of the whitelisted rectification parameters
 # (see DEFAULTS in parsers.jl); the hierarchy is csv cell → `defaults` → hardcoded/probed value.
-function load_rectifications(data_path, file; strict = true, defaults = (;), issues_dir = DEFAULT_ISSUES_DIR)
+function load_rectifications(data_path, file; strict = true, defaults = (;), issues_dir = DEFAULT_ISSUES_DIR,
+        progress = true)
     defaults = resolve_defaults(defaults)   # fail fast on unknown keys / unconvertible values
     csvrows = read_rows(file, COLUMNS, "calibration")
 
     # parse rows to RectificationMethods or error messages
-    cs = @showprogress desc = "Parsing calibs.csv" tmap(r -> parse_row(r, defaults), collect(csvrows))
+    cs = @showprogress desc = "Parsing calibs.csv" enabled = progress tmap(r -> parse_row(r, defaults), collect(csvrows))
 
     df = DataFrame(Tables.dictrowtable(cs))
     allowmissing!(df)
 
-    verifications!(df, data_path, issues_dir)
+    verifications!(df, data_path, issues_dir; progress)
 
     # a blank calibration_id cell is itself flagged as an issue, so it can be missing here
     if report_issues(df, :calibration_id, "calibs.csv", "calibration", strict;

--- a/src/VerifyRectifications/precompile.jl
+++ b/src/VerifyRectifications/precompile.jl
@@ -19,9 +19,11 @@
         println(io, "a,nope.mp4,,apriltag,1,,")
     end
     @compile_workload begin
+        # `progress = false` silences the meters, which draw on stderr; the redirect silences the
+        # issues report, which is a genuine println to stdout. Neither belongs in precompile output.
         redirect_stdout(devnull) do
             try
-                load_rectifications(dir, csv; strict = false)
+                load_rectifications(dir, csv; strict = false, progress = false)
             catch e
                 # Deliberately broad: precompilation must not fail because the workload did. Ctrl-C
                 # during precompile should still stop it.

--- a/src/VerifyRectifications/verifications.jl
+++ b/src/VerifyRectifications/verifications.jl
@@ -9,13 +9,13 @@ end
 # the video :width/:height (always taken from the file — they are the frame size used to decode it)
 # and impute :aspect/:yadif. Grouping on the canonical resolved :file reads one physical file once,
 # not once per spelling.
-function read_video_metadata!(df::AbstractDataFrame)
+function read_video_metadata!(df::AbstractDataFrame; progress = true)
     # :width/:height have no CSV column (they are not user-supplied); create them here so the probe
     # can fill them, alongside the intermediate :duration/:dimension columns.
     blank!(df, :duration, :dimension, :width, :height)
     # Every type carries a source video (:file), so every group is probed once: the read fills
     # :duration/:dimension/:width/:height for all, plus imputes :aspect (and :yadif for video).
-    read_per_file!(df, :file, [:file, :type], "Reading calibration videos...", probe_video, apply_video_metadata!)
+    read_per_file!(df, :file, [:file, :type], "Reading calibration videos...", probe_video, apply_video_metadata!; progress)
 end
 
 function apply_video_metadata!(g, issue::String)
@@ -122,11 +122,11 @@ end
 # (:n_extrinsics) and the ImageSize cross-check against the source video. Grouping on the canonical
 # resolved :matlab_file reads each physical file once. The source-video :dimension was already filled
 # by read_video_metadata!, so the cross-check runs here against it.
-function read_matlab_metadata!(df::AbstractDataFrame)
+function read_matlab_metadata!(df::AbstractDataFrame; progress = true)
     blank!(df, :n_extrinsics)
     # matlab_file is set for matlab rows only, so non-matlab rows form no group and are untouched.
     read_per_file!(df, :matlab_file, [:matlab_file], "Reading matlab calibration files...",
-                   matlab_metadata, apply_matlab_metadata!)
+                   matlab_metadata, apply_matlab_metadata!; progress)
 end
 
 # Pure read+derive: one matread, then structure/extrinsic-count/dimension off the same dict. A bad
@@ -262,7 +262,7 @@ function note_saved_frame(issue, saved)
     return string(issue, " — saved the extrinsic frame to ", saved, " for inspection")
 end
 
-function verify_extrinsics!(df::AbstractDataFrame, run_dir)
+function verify_extrinsics!(df::AbstractDataFrame, run_dir; progress = true)
     # :file is the canonical resolved path, so grouping on it corner-detects a file reached via different
     # spellings once per (extrinsic, blur, n_corners).
     videos = subset(df, :type => ByRow(passmissing(==("video"))); view = true, skipmissing = true)
@@ -281,7 +281,7 @@ function verify_extrinsics!(df::AbstractDataFrame, run_dir)
     usable = dropmissing(clean, [:file, :extrinsic, :blur, :n_corners, :width, :height]; view = true)
     gs = groupby(usable, [:file, :extrinsic, :yadif, :blur, :width, :height, :n_corners])
     ks = collect(keys(gs))
-    issues = @showprogress desc = "Validating extrinsics..." tmap(k -> extrinsic_issue(k.file, k.extrinsic, k.yadif, k.blur, k.width, k.height, k.n_corners), ks)
+    issues = @showprogress desc = "Validating extrinsics..." enabled = progress tmap(k -> extrinsic_issue(k.file, k.extrinsic, k.yadif, k.blur, k.width, k.height, k.n_corners), ks)
     for (g, k, issue) in zip(gs, ks, issues)
         isnothing(issue) && continue
         # dump the frame the detector saw (deinterlaced/blurred) so the user can see what went wrong
@@ -317,7 +317,7 @@ function intrinsic_issue(file, start, stop, temporal_step, yadif, blur, width, h
     end
 end
 
-function verify_intrinsics!(df::AbstractDataFrame)
+function verify_intrinsics!(df::AbstractDataFrame; progress = true)
     # Rows already flagged are skipped: a failed probe, extrinsic or window check implies this
     # (expensive) scan would fail too — re-running it wastes frame reads and re-reports noise.
     # A missing calibs window (both bounds blank) is skipped like everywhere else.
@@ -325,7 +325,7 @@ function verify_intrinsics!(df::AbstractDataFrame)
     clean = subset(videos, :issues => ByRow(isempty); view = true)
     usable = dropmissing(clean, [:file, :start, :stop, :temporal_step, :width, :height, :n_corners]; view = true)
     gs = groupby(usable, [:file, :start, :stop, :temporal_step, :yadif, :blur, :width, :height, :n_corners])
-    issues = @showprogress desc = "Validating intrinsics..." tmap(k -> intrinsic_issue(k.file, k.start, k.stop, k.temporal_step, k.yadif, k.blur, k.width, k.height, k.n_corners), keys(gs))
+    issues = @showprogress desc = "Validating intrinsics..." enabled = progress tmap(k -> intrinsic_issue(k.file, k.start, k.stop, k.temporal_step, k.yadif, k.blur, k.width, k.height, k.n_corners), keys(gs))
     for (g, issue) in zip(gs, issues)
         if !isnothing(issue)
             blank!(g, :start, :stop)
@@ -338,13 +338,13 @@ end
 # `family` must be detectable and their metric fit must converge (coplanar, not mis-detected). Reads
 # real frames, so it runs only on otherwise-clean apriltag rows, grouped so one physical file is
 # checked once per (extrinsic, apriltags, family, checker_size).
-function verify_apriltag_extrinsics!(df::AbstractDataFrame, run_dir)
+function verify_apriltag_extrinsics!(df::AbstractDataFrame, run_dir; progress = true)
     tags = subset(df, :type => ByRow(passmissing(==("apriltag"))); view = true, skipmissing = true)
     clean = subset(tags, :issues => ByRow(isempty); view = true)
     usable = dropmissing(clean, [:file, :extrinsic, :apriltags, :family, :checker_size]; view = true)
     gs = groupby(usable, [:file, :extrinsic, :apriltags, :family, :checker_size])
     ks = collect(keys(gs))
-    issues = @showprogress desc = "Validating AprilTag extrinsics..." tmap(k -> PawsomeTracker.apriltag_extrinsic_issue(k.file, k.extrinsic, k.apriltags, k.family, k.checker_size), ks)
+    issues = @showprogress desc = "Validating AprilTag extrinsics..." enabled = progress tmap(k -> PawsomeTracker.apriltag_extrinsic_issue(k.file, k.extrinsic, k.apriltags, k.family, k.checker_size), ks)
     for (g, k, issue) in zip(gs, ks, issues)
         isnothing(issue) && continue
         # dump the extrinsic frame the tag detector saw so the user can see what went wrong
@@ -399,7 +399,8 @@ function verify_unique_calibrations!(df::AbstractDataFrame)
     end
 end
 
-function verifications!(df::AbstractDataFrame, data_path, issues_dir = DEFAULT_ISSUES_DIR)
+function verifications!(df::AbstractDataFrame, data_path, issues_dir = DEFAULT_ISSUES_DIR;
+        progress = true)
 
     # This run's frames go in a folder of their own, named for the moment the run started, so the
     # folder reflects only this run without anything being deleted to make that true — `issues_dir`
@@ -420,9 +421,9 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = DEFAULT_I
     # One read per physical file: ffprobe on the source video (every type) and matread on the .mat
     # (matlab). read_video_metadata! must run first: it sets the frame size that bounds-checks
     # center/north and cross-checks the matlab ImageSize.
-    read_video_metadata!(df)
+    read_video_metadata!(df; progress)
 
-    read_matlab_metadata!(df)
+    read_matlab_metadata!(df; progress)
 
     # center/north are optional and left missing when omitted (no imputation). verify! skips missing
     # rows, so a missing center or north is simply not bounds-checked.
@@ -462,14 +463,14 @@ function verifications!(df::AbstractDataFrame, data_path, issues_dir = DEFAULT_I
 
     # the extrinsic time stamp must actually yield a detectable frame; only meaningful once the
     # time stamp itself has been range-checked above
-    verify_extrinsics!(df, run_dir)
+    verify_extrinsics!(df, run_dir; progress)
 
     # the calibs window must actually contain ≥ 3 detectable-corner frames; runs after
     # verify_extrinsics! so rows whose extrinsic already failed are skipped, not re-scanned
-    verify_intrinsics!(df)
+    verify_intrinsics!(df; progress)
 
     # apriltag rows: the extrinsic frame must yield a valid shared reference (tags detectable + coplanar)
-    verify_apriltag_extrinsics!(df, run_dir)
+    verify_apriltag_extrinsics!(df, run_dir; progress)
 
     verify_unique_calibrations!(df)
 

--- a/src/VerifyRuns/VerifyRuns.jl
+++ b/src/VerifyRuns/VerifyRuns.jl
@@ -24,18 +24,18 @@ include("types.jl")
 include("parsers.jl")
 include("verifications.jl")
 
-function load_runs(file; strict = true, defaults = (;))
-    load_runs(dirname(file), file; strict, defaults)
+function load_runs(file; strict = true, defaults = (;), progress = true)
+    load_runs(dirname(file), file; strict, defaults, progress)
 end
 
 # `defaults` globally replaces the hardcoded fallbacks of the whitelisted tracking parameters
 # (see DEFAULTS in parsers.jl); the hierarchy is csv cell → `defaults` → hardcoded/probed value.
-function load_runs(data_path, file; strict = true, defaults = (;))
+function load_runs(data_path, file; strict = true, defaults = (;), progress = true)
     defaults = resolve_defaults(defaults)   # fail fast on unknown keys / unconvertible values
     csvrows = read_rows(file, COLUMNS, "runs")
 
     # parse each row to a Dict of parsed values + an :issues accumulator
-    cs = @showprogress desc = "Parsing runs.csv..." tmap(r -> parse_row(r, defaults), collect(csvrows))
+    cs = @showprogress desc = "Parsing runs.csv..." enabled = progress tmap(r -> parse_row(r, defaults), collect(csvrows))
 
     df = DataFrame(Tables.dictrowtable(cs))
     allowmissing!(df)
@@ -44,7 +44,7 @@ function load_runs(data_path, file; strict = true, defaults = (;))
     # :run_id is concrete on the clean path.
     resolve_run_ids!(df)
 
-    verifications!(df, data_path)
+    verifications!(df, data_path; progress)
 
     # a run_id that is missing (mixed numbering) or equal to the row number (auto-assigned) adds
     # nothing over "row $i", so it is only mentioned when the csv named the run itself

--- a/src/VerifyRuns/precompile.jl
+++ b/src/VerifyRuns/precompile.jl
@@ -14,9 +14,11 @@
         println(io, "r,c,nope.mp4,0,5")
     end
     @compile_workload begin
+        # `progress = false` silences the meters, which draw on stderr; the redirect silences the
+        # issues report, which is a genuine println to stdout. Neither belongs in precompile output.
         redirect_stdout(devnull) do
             try
-                load_runs(dir, csv; strict = false)
+                load_runs(dir, csv; strict = false, progress = false)
             catch e
                 # Deliberately broad: precompilation must not fail because the workload did. Ctrl-C
                 # during precompile should still stop it.

--- a/src/VerifyRuns/verifications.jl
+++ b/src/VerifyRuns/verifications.jl
@@ -18,9 +18,9 @@ end
 
 # One ffprobe per physical video file fills the intermediate :dimension/:duration/:video_fps columns
 # and imputes the two blank-able run parameters: :stop (← duration) and :fps (← video frame rate).
-function read_video_metadata!(df::AbstractDataFrame)
+function read_video_metadata!(df::AbstractDataFrame; progress = true)
     blank!(df, :dimension, :duration, :video_fps, :sar)
-    read_per_file!(df, :file, [:file], "Reading runs videos...", probe_video, apply_video_metadata!)
+    read_per_file!(df, :file, [:file], "Reading runs videos...", probe_video, apply_video_metadata!; progress)
 end
 
 apply_video_metadata!(g, issue::String) = push!.(g.issues, issue)
@@ -59,7 +59,7 @@ function verify_run_consistency!(df::AbstractDataFrame)
     end
 end
 
-function verifications!(df::AbstractDataFrame, data_path)
+function verifications!(df::AbstractDataFrame, data_path; progress = true)
     # run_id names the track file and the diagnostic segments, so it must be a usable file name.
     verify_id_filename!(df, :run_id)
 
@@ -68,7 +68,7 @@ function verifications!(df::AbstractDataFrame, data_path)
     resolve_paths!(df, data_path, :file)
 
     # One ffprobe per file: fills :dimension/:duration/:video_fps and imputes :stop/:fps.
-    read_video_metadata!(df)
+    read_video_metadata!(df; progress)
 
     # start_location is optional (missing rows skipped). It is (x, y) = (horizontal, vertical) in
     # *display* pixels, like a rectification's center/north, while ffprobe's width is in stored

--- a/src/gateway.jl
+++ b/src/gateway.jl
@@ -83,9 +83,9 @@ end
 # once, then fold the result back into its rows with `apply!`. Grouping on the canonical resolved
 # path (see `resolve_paths!`) reads a file reached through several spellings once, not once per
 # spelling. `read` returns either the metadata or an issue string, and `apply!` dispatches on which.
-function read_per_file!(df::AbstractDataFrame, filecol, groupcols, desc, read, apply!)
+function read_per_file!(df::AbstractDataFrame, filecol, groupcols, desc, read, apply!; progress = true)
     groups = collect(groupby(dropmissing(df, groupcols; view = true), groupcols))
-    metas = @showprogress desc = desc tmap(g -> read(g[1, filecol]), groups)
+    metas = @showprogress desc = desc enabled = progress tmap(g -> read(g[1, filecol]), groups)
     for (g, meta) in zip(groups, metas)
         apply!(g, meta)
     end


### PR DESCRIPTION
Closes #117.

Precompiling Fromage printed a progress bar for a CSV that points at a file which does not exist. Both workloads wrapped their loader in `redirect_stdout(devnull)`, which catches the issues report but not the meters: **ProgressMeter draws on stderr**.

Rather than redirect stderr too, this uses ProgressMeter's own API. `Progress` takes `enabled::Bool`, and `@showprogress` forwards its keywords to that constructor, so the flag propagates from the two gateway entry points as a `progress` keyword:

| entry point | meters reached |
|---|---|
| `load_runs` | the parse meter; `verifications!` → `read_video_metadata!` → `Gateway.read_per_file!` |
| `load_rectifications` | the parse meter; `verifications!` → `read_video_metadata!` / `read_matlab_metadata!` (both via `read_per_file!`), `verify_extrinsics!`, `verify_intrinsics!`, `verify_apriltag_extrinsics!` |

Eight meters in all. Both workloads now pass `progress = false`; every other caller keeps the default `true`, so nothing a user sees changes. `main`'s three meters are not reachable from precompilation and are left alone.

`redirect_stdout(devnull)` stays in both workloads, and now says why: it silences the issues report, which is a genuine `println` to stdout rather than a meter.

### Checking

Precompilation is quiet. Before:

```
1 dependency had output during precompilation:
┌ Fromage
│  Parsing calibs.csv  50%|█████████████▌  | ETA: 0:00:02
└
```

After:

```
Precompiling packages...
  49423.5 ms  ✓ Fromage
  1 dependency successfully precompiled in 50 seconds. 313 already precompiled.
```

Full suite, Julia 1.12.7: **1286 / 1286 pass**. All nine changed signatures gained a defaulted keyword only, and every call site was swept — tests, `benchmark/benchmarks.jl` and `main` all omit it and are unaffected.

### No regression test, deliberately

The obvious one — assert `load_*(…; progress = false)` writes nothing to stderr — would be **vacuous**. ProgressMeter has a ~0.1 s `dt` threshold, so on a small test CSV it draws nothing whether enabled or not (measured: a 3-item map emits 0 bytes with `enabled = true`). The precompile bar only appeared because compilation made that parse take 2 seconds. A version with teeth needs a workload slow enough to draw, which makes it timing-dependent and eventually flaky on CI. The behaviour is verified by precompiling instead, as above.