### PR TITLE
Stop copying every frame written to a diagnostic video (#119)

### DIFF
--- a/src/PawsomeTracker/apriltag.jl
+++ b/src/PawsomeTracker/apriltag.jl
@@ -449,7 +449,9 @@ function (s::ApriltagScene)(frame, beetle, H)
         c = _canvas_to_cm(s, idx[1], idx[2]); v = Hinv * SVector(c[1], c[2], 1.0)
         SVector(v[2]/v[3], v[1]/v[3])                           # (row, col) = (img_y, img_x)
     end
-    wimg = warp(Gray{N0f8}.(frame), tf, (1:s.m, 1:s.m); fillvalue = zero(Gray{N0f8}))
+    # `convert` rather than a broadcast, for the reason given at RectifiedScene: `frame` is a stack
+    # slice in the prefill loop and `vid.img` in the rolling one, both `Gray{N0f8}` already.
+    wimg = warp(convert(AbstractArray{Gray{N0f8}}, frame), tf, (1:s.m, 1:s.m); fillvalue = zero(Gray{N0f8}))
     return wimg, ismissing(beetle) ? missing : _cm_to_canvas(s, beetle)
 end
 

--- a/src/PawsomeTracker/diagnose.jl
+++ b/src/PawsomeTracker/diagnose.jl
@@ -140,8 +140,12 @@ end
 canvas_prototype(s::RectifiedScene) = Matrix{Gray{N0f8}}(undef, length.(s.indices)...)
 update_ratio!(::RectifiedScene, _) = nothing
 
+# `convert`, not `Gray{N0f8}.(img)`: the frame handed here is a slice of the stack, which stores
+# `Gray{N0f8}` already (#27), so the broadcast was an identity copy of the whole frame on every
+# written frame. `convert(AbstractArray{T}, A)` returns `A` itself when the eltype matches and
+# converts otherwise, so the fallback for anything else is unchanged.
 function (s::RectifiedScene)(img, point)
-    wimg = warp(Gray{N0f8}.(img), s.real2image, s.indices; fillvalue = zero(Gray{N0f8}))
+    wimg = warp(convert(AbstractArray{Gray{N0f8}}, img), s.real2image, s.indices; fillvalue = zero(Gray{N0f8}))
     return wimg, CartesianIndex(Tuple(round.(Int, s.image2real(point))))
 end
 


### PR DESCRIPTION
Closes #119.

Both warping scenes ran the frame through `Gray{N0f8}.(…)` before warping it, but the frame is already `Gray{N0f8}` in every case:

* `RectifiedScene` is handed `selectdim(parent(parent(stack)), 3, i)` — a `SubArray{Gray{N0f8}, 2}` of the raw stack, which stores frames unwidened (#27).
* `ApriltagScene` gets that same slice in the prefill loop, and `vid.img` — a `PermutedDimsArray{Gray{N0f8}}` — in the rolling one.

So the broadcast was an identity copy of the whole frame, once per frame written to a diagnostic video, on both paths.

| | allocated |
|---|---|
| a 1080p frame | 1.98 MB |
| `Gray{N0f8}.(slice)` | 1.98 MB |
| `convert(AbstractArray{Gray{N0f8}}, slice)` | 0 bytes |

`convert(AbstractArray{T}, A)` returns `A` itself when the eltype already matches and converts otherwise, so any other eltype behaves exactly as it did.

### Checking

Equivalence was checked for both shapes that actually reach the scenes — the stack `SubArray` and `vid.img`'s `PermutedDimsArray` — on more than pixel equality, because the writer consumes `parent(canvas)`:

* same values
* same axes
* same container type (`OffsetMatrix{Gray{N0f8}, Matrix{Gray{N0f8}}}`)
* same type of `parent(...)`

Full suite, Julia 1.12.7: **1286 / 1286 pass**, no warnings. (That run was on the pre-rebase tree; the rebase onto current `main` left both files untouched, and this branch is disjoint from #118 — it touches only the two `PawsomeTracker` files, sharing no function with the gateway work.)